### PR TITLE
Feat: Skills loading within tacklr

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,15 @@ agent := tacklr.NewAgent(
 ```
 
 Each immediate child of a configured directory must contain a `SKILL.md` file
-with `name`, `description`, and an instruction body.
+with YAML front matter containing `name` and `description`, followed by an
+instruction body:
+
+```markdown
+---
+name: testing
+description: Write and validate automated tests for this project.
+---
+
+Follow the project's test conventions and run the relevant tests before
+reporting completion.
+```

--- a/README.md
+++ b/README.md
@@ -36,3 +36,24 @@ make vet       # runs go vet
 ## Server
 
 The `cmd/server` directory contains an HTTP/WebSocket/SSE server that uses the tacklr harness. See `.env.example` for configuration.
+
+## Skills
+
+Applications can load local `SKILL.md` directories into an agent with the
+existing `NewAgent` constructor. The first `Run` adds a compact skill catalog
+to the system prompt and registers `read_skill`, allowing the model to load
+full instructions only when needed:
+
+```go
+agent := tacklr.NewAgent(
+    tacklr.Config{
+        MaxWindowSize:    8192,
+        SystemPrompt:     "You are a helpful assistant.",
+        SkillDirectories: []string{"./skills"},
+    },
+    model, store, watchdog,
+)
+```
+
+Each immediate child of a configured directory must contain a `SKILL.md` file
+with `name`, `description`, and an instruction body.

--- a/skills/loader.go
+++ b/skills/loader.go
@@ -15,7 +15,6 @@ type Skill struct {
 	Name         string
 	Description  string
 	Instructions string
-	Path         string
 }
 
 // LoadDirectories loads one skill per immediate child directory. Directories
@@ -48,7 +47,6 @@ func LoadDirectories(roots []string) ([]Skill, error) {
 			if err != nil {
 				return nil, fmt.Errorf("skill %q: %w", entry.Name(), err)
 			}
-			skill.Path = path
 			if seen[skill.Name] {
 				return nil, fmt.Errorf("duplicate skill name %q", skill.Name)
 			}

--- a/skills/loader.go
+++ b/skills/loader.go
@@ -1,0 +1,98 @@
+// Package skills discovers and parses application-owned SKILL.md files.
+package skills
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const maxSkillFileSize = 1024 * 1024
+
+type Skill struct {
+	Name         string
+	Description  string
+	Instructions string
+	Path         string
+}
+
+// LoadDirectories loads one skill per immediate child directory. Directories
+// are processed in lexical order and duplicate skill names are rejected.
+func LoadDirectories(roots []string) ([]Skill, error) {
+	var loaded []Skill
+	seen := map[string]bool{}
+	for _, root := range roots {
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			return nil, fmt.Errorf("read skills directory %q: %w", root, err)
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
+				continue
+			}
+			path := filepath.Join(root, entry.Name(), "SKILL.md")
+			info, err := os.Stat(path)
+			if err != nil {
+				return nil, fmt.Errorf("skill %q: read SKILL.md: %w", entry.Name(), err)
+			}
+			if info.Size() > maxSkillFileSize {
+				return nil, fmt.Errorf("skill %q: SKILL.md exceeds %d bytes", entry.Name(), maxSkillFileSize)
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return nil, fmt.Errorf("skill %q: read SKILL.md: %w", entry.Name(), err)
+			}
+			skill, err := parse(string(data))
+			if err != nil {
+				return nil, fmt.Errorf("skill %q: %w", entry.Name(), err)
+			}
+			skill.Path = path
+			if seen[skill.Name] {
+				return nil, fmt.Errorf("duplicate skill name %q", skill.Name)
+			}
+			seen[skill.Name] = true
+			loaded = append(loaded, skill)
+		}
+	}
+	sort.Slice(loaded, func(i, j int) bool { return loaded[i].Name < loaded[j].Name })
+	return loaded, nil
+}
+
+func parse(document string) (Skill, error) {
+	if !strings.HasPrefix(document, "---\n") {
+		return Skill{}, fmt.Errorf("SKILL.md must start with front matter")
+	}
+	parts := strings.SplitN(document[4:], "\n---\n", 2)
+	if len(parts) != 2 {
+		return Skill{}, fmt.Errorf("SKILL.md has unterminated front matter")
+	}
+	metadata := map[string]string{}
+	for _, line := range strings.Split(parts[0], "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if ok {
+			metadata[strings.TrimSpace(key)] = strings.TrimSpace(value)
+		}
+	}
+	skill := Skill{
+		Name:         metadata["name"],
+		Description:  metadata["description"],
+		Instructions: strings.TrimSpace(parts[1]),
+	}
+	if skill.Name == "" || skill.Description == "" || skill.Instructions == "" {
+		return Skill{}, fmt.Errorf("name, description, and instructions are required")
+	}
+	return skill, nil
+}
+
+// Catalog creates the small prompt section shown before a skill is selected.
+// Full instructions are intentionally omitted to preserve context window.
+func Catalog(loaded []Skill) string {
+	var b strings.Builder
+	b.WriteString("Available skills (use read_skill to load instructions):\n")
+	for _, skill := range loaded {
+		fmt.Fprintf(&b, "- %s: %s\n", skill.Name, skill.Description)
+	}
+	return b.String()
+}

--- a/skills/loader_test.go
+++ b/skills/loader_test.go
@@ -1,0 +1,34 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	skill, err := parse("---\nname: weather\ndescription: Current conditions\n---\n\nUse the weather tool.")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if skill.Name != "weather" || skill.Description != "Current conditions" || skill.Instructions != "Use the weather tool." {
+		t.Fatalf("unexpected skill: %#v", skill)
+	}
+}
+
+func TestLoadDirectories(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "weather"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "weather", "SKILL.md"), []byte("---\nname: weather\ndescription: Conditions\n---\nUse get_weather."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadDirectories([]string{root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded) != 1 || loaded[0].Name != "weather" {
+		t.Fatalf("unexpected skills: %#v", loaded)
+	}
+}

--- a/tacklr.go
+++ b/tacklr.go
@@ -452,10 +452,6 @@ func (a *AgentHarness) initSkills() error {
 	if a.skillsInitialized {
 		return nil
 	}
-	if len(a.skillDirectories) == 0 {
-		a.skillsInitialized = true
-		return nil
-	}
 	loaded, err := skills.LoadDirectories(a.skillDirectories)
 	if err != nil {
 		return err
@@ -464,13 +460,11 @@ func (a *AgentHarness) initSkills() error {
 	for _, skill := range loaded {
 		a.skillByName[skill.Name] = skill
 	}
-	if len(loaded) == 0 {
-		a.skillsInitialized = true
-		return nil
+	if len(loaded) > 0 {
+		a.SystemPrompt = strings.TrimSpace(a.SystemPrompt + "\n\n" + skills.Catalog(loaded))
+		a.Model.SetSystemPrompt(a.SystemPrompt)
+		a.Tools = append(a.Tools, a.skillTool())
 	}
-	a.SystemPrompt = strings.TrimSpace(a.SystemPrompt + "\n\n" + skills.Catalog(loaded))
-	a.Model.SetSystemPrompt(a.SystemPrompt)
-	a.Tools = append(a.Tools, a.skillTool())
 	a.skillsInitialized = true
 	return nil
 }

--- a/tacklr.go
+++ b/tacklr.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/google/uuid"
 	"github.com/ryanaldo34/tacklr/control"
 	"github.com/ryanaldo34/tacklr/mcp"
+	"github.com/ryanaldo34/tacklr/skills"
 	"github.com/ryanaldo34/tacklr/stores"
 )
 
@@ -79,6 +81,9 @@ type AgentHarness struct {
 	streamingStrategy    StreamingStrategy
 	interruptToRequester map[string]string
 	pendingToolCalls     map[string]pendingToolCall
+	skillByName          map[string]skills.Skill
+	skillDirectories     []string
+	skillsInitialized    bool
 	mcpClients           []*mcp.Client
 	mcpInitialized       bool
 }
@@ -252,6 +257,9 @@ func (a *AgentHarness) Close() {
 }
 
 func (a *AgentHarness) Run(ctx context.Context, prompt string) (<-chan StreamEvent, error) {
+	if err := a.initSkills(); err != nil {
+		return nil, fmt.Errorf("load skills: %w", err)
+	}
 	a.initMCP(ctx)
 	out := make(chan StreamEvent)
 	err := a.fitContextWindowBeforeNextTurn(ctx, &Message{Role: RoleUser, Content: prompt}, out)
@@ -416,8 +424,9 @@ func (a *AgentHarness) ReturnFromInterrupt(ctx context.Context, finishedInterrup
 }
 
 type Config struct {
-	MaxWindowSize int
-	SystemPrompt  string
+	MaxWindowSize    int
+	SystemPrompt     string
+	SkillDirectories []string
 }
 
 func NewAgent(cfg Config, model InferenceStrategy, store stores.BaseStore, watchdog AgentWatchDog) *AgentHarness {
@@ -431,11 +440,51 @@ func NewAgent(cfg Config, model InferenceStrategy, store stores.BaseStore, watch
 		Store:                store,
 		Runtime:              runtime,
 		WatchDog:             watchdog,
+		skillDirectories:     cfg.SkillDirectories,
 		ContextWindow:        nil,
 		SessionId:            "",
 		interruptToRequester: make(map[string]string),
 		pendingToolCalls:     make(map[string]pendingToolCall),
 	}
+}
+
+func (a *AgentHarness) initSkills() error {
+	if a.skillsInitialized {
+		return nil
+	}
+	if len(a.skillDirectories) == 0 {
+		a.skillsInitialized = true
+		return nil
+	}
+	loaded, err := skills.LoadDirectories(a.skillDirectories)
+	if err != nil {
+		return err
+	}
+	a.skillByName = make(map[string]skills.Skill, len(loaded))
+	for _, skill := range loaded {
+		a.skillByName[skill.Name] = skill
+	}
+	if len(loaded) == 0 {
+		a.skillsInitialized = true
+		return nil
+	}
+	a.SystemPrompt = strings.TrimSpace(a.SystemPrompt + "\n\n" + skills.Catalog(loaded))
+	a.Model.SetSystemPrompt(a.SystemPrompt)
+	a.Tools = append(a.Tools, a.skillTool())
+	a.skillsInitialized = true
+	return nil
+}
+
+func (a *AgentHarness) skillTool() *Tool {
+	return &Tool{Name: "read_skill", Description: "Load the full instructions for an available skill.", Handler: func(args struct {
+		Name string `json:"name" desc:"Skill name from the available skills catalog"`
+	}) (string, error) {
+		skill, ok := a.skillByName[args.Name]
+		if !ok {
+			return "", fmt.Errorf("unknown skill %q", args.Name)
+		}
+		return skill.Instructions, nil
+	}}
 }
 
 func NewAgentHarnessFromSession(ctx context.Context, sessionId string, cfg Config, model InferenceStrategy, store stores.BaseStore, watchdog AgentWatchDog) (*AgentHarness, error) {
@@ -453,7 +502,7 @@ func NewAgentHarnessFromSession(ctx context.Context, sessionId string, cfg Confi
 	}
 	state.Runtime.Store = store
 	state.Runtime.EnsureInitialized()
-	return &AgentHarness{
+	h := &AgentHarness{
 		Model:                model,
 		Store:                store,
 		SessionId:            sessionId,
@@ -461,9 +510,12 @@ func NewAgentHarnessFromSession(ctx context.Context, sessionId string, cfg Confi
 		Runtime:              state.Runtime,
 		WatchDog:             watchdog,
 		MaxWindowSize:        cfg.MaxWindowSize,
+		SystemPrompt:         cfg.SystemPrompt,
 		compressionPrompt:    "",
 		streamingStrategy:    nil,
 		interruptToRequester: state.InterruptToRequester,
 		pendingToolCalls:     state.PendingToolCalls,
-	}, nil
+		skillDirectories:     cfg.SkillDirectories,
+	}
+	return h, nil
 }


### PR DESCRIPTION
Add support for loading application-owned skills from per-directory SKILL.md files. The harness validates skill metadata, builds a lightweight catalog for the model, and exposes a read_skill tool for lazy loading of full instructions. Skill directories are configured through Config.SkillDirectories, with support for session restoration and duplicate/invalid skill detection.