### PR TITLE
refactor: lock the public harness SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,19 @@ jobs:
         run: |
           docker version
           docker pull pgvector/pgvector:pg17
-          docker build \
+          attempt=0
+          until docker build \
             -f brain/testdata/Dockerfile.postgres \
             -t tacklr-pg-brain:test \
-            brain/testdata
+            brain/testdata; do
+            attempt=$((attempt + 1))
+            if [ "$attempt" -ge 3 ]; then
+              echo "docker build of tacklr-pg-brain:test failed after ${attempt} attempts" >&2
+              exit 1
+            fi
+            echo "docker build failed (attempt ${attempt}), retrying..." >&2
+            sleep $((attempt * 5))
+          done
           docker pull ghcr.io/helixdb/enterprise-dev:latest
 
       # Race detector and coverage profiles are separate: -race can flake under

--- a/agent.go
+++ b/agent.go
@@ -44,18 +44,15 @@ type AgentHarness struct {
 	interruptPayloads map[string][]byte
 	// parkedWorkersLive maps spawn_worker tool call id → live child harness.
 	// Durable park metadata is in SessionManager state; this map is not checkpointed.
-	parkedWorkersLive map[string]*AgentHarness
-	parkMu            sync.Mutex
-	skillByName       map[string]skills.Skill
-	skillDirectories  []string
-	skillsLoader      skills.SkillLoader
-	skillsInitialized bool
-	exaAPIKey         string
-	brain             *brain.Engine
-	brainWriteKinds   brain.WriteKinds
-	// searchCtx owns the current knowledge ResultSet for this agent thread.
-	// Checkpointed via checkpointSession / NewAgentFromSession; not SessionManager.
-	searchCtx            *brain.SearchContext
+	parkedWorkersLive    map[string]*AgentHarness
+	parkMu               sync.Mutex
+	skillByName          map[string]skills.Skill
+	skillDirectories     []string
+	skillsLoader         skills.SkillLoader
+	skillsInitialized    bool
+	exaAPIKey            string
+	brain                *brain.Engine
+	brainWriteKinds      brain.WriteKinds
 	runCommandUnattended bool
 	// vfsBridge is the mount→brain index lifecycle (not the agent turn loop).
 	// Workers receive the parent pointer at construct; ownsVFSBridge is set
@@ -66,7 +63,7 @@ type AgentHarness struct {
 	mcpInitialized   bool
 	builtinsInjected bool
 	context          ContextManager
-	tasks            ModelTasks
+	tasks            modelTasks
 	contextPolicy    ContextPolicy
 	toolRunner       *toolRunner
 	toolResultHooks  *toolResultHookRegistry
@@ -78,7 +75,7 @@ type AgentHarness struct {
 // VFS is the session mount table, or nil. Hosts call FuseMount on this.
 // The harness does not start or own the kernel mount.
 func (a *AgentHarness) VFS() *vfs.MountSession {
-	return a.session.VFS
+	return a.session.VFS()
 }
 
 // SessionID returns the durable session id, or empty if unbound.
@@ -173,18 +170,10 @@ func (a *AgentHarness) checkpointSession(ctx context.Context) error {
 	}
 	a.pendingMu.Unlock()
 
-	cp, err := session.NewCheckpointer().Capture(a.context.Snapshot(), a.session, ptc, itr)
+	cp, err := session.NewCheckpointer().Capture(a.context.Messages(), a.session, ptc, itr)
 	if err != nil {
 		telemetry.InstrumentsFromContext(ctx).RecordCheckpointSave(ctx, telemetry.OutcomeError)
 		return err
-	}
-	if a.searchCtx != nil {
-		raw, err := a.searchCtx.Export()
-		if err != nil {
-			telemetry.InstrumentsFromContext(ctx).RecordCheckpointSave(ctx, telemetry.OutcomeError)
-			return err
-		}
-		cp.State.SearchContext = raw
 	}
 	if err := a.store.SaveSession(ctx, a.sessionId, *cp); err != nil {
 		telemetry.InstrumentsFromContext(ctx).RecordCheckpointSave(ctx, telemetry.OutcomeError)

--- a/agent_cancel_test.go
+++ b/agent_cancel_test.go
@@ -12,7 +12,7 @@ import (
 // FinalizeCancelledWork pairs cancelled results and clears park state.
 func TestAgent_HasOpenToolWorkAndFinalizeCancelled(t *testing.T) {
 	ctx := context.Background()
-	h := mustNewAgent(t, ctx, AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		SessionID: "cancel-open-tools",
 		Store:     stores.NewInMemoryStore(),
 		Model:     &mockStrategy{},

--- a/agent_cancel_test.go
+++ b/agent_cancel_test.go
@@ -12,7 +12,7 @@ import (
 // FinalizeCancelledWork pairs cancelled results and clears park state.
 func TestAgent_HasOpenToolWorkAndFinalizeCancelled(t *testing.T) {
 	ctx := context.Background()
-	h := NewAgent(ctx, AgentOptions{
+	h := mustNewAgent(t, ctx, AgentOptions{
 		SessionID: "cancel-open-tools",
 		Store:     stores.NewInMemoryStore(),
 		Model:     &mockStrategy{},

--- a/agent_construct.go
+++ b/agent_construct.go
@@ -2,9 +2,7 @@ package tacklr
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"github.com/google/uuid"
@@ -32,8 +30,12 @@ type Config struct {
 // AgentOptions configures NewAgent and NewAgentFromSession.
 //
 // Usual fields: Config, Model, Store, Tools, MCPConfigs, SubAgents, SessionID.
-// ContextManager, ModelTasks, and ContextPolicy override the built-in ACM path;
-// leave them nil unless you replace that path.
+// ContextPolicy knobs (ratios, stream-summary) stay host-settable. Adaptive
+// Case Management itself is harness-owned and cannot be replaced.
+//
+// Store is the harness thread checkpoint (stores.BaseStore). Wire session
+// envelopes (server.ProtocolWireStore) are a separate protocol contract and
+// are not merged with this store.
 type AgentOptions struct {
 	Config Config
 	// SessionID is the durable thread id. Set at construction; do not change mid-turn.
@@ -44,16 +46,14 @@ type AgentOptions struct {
 	Tools      []*Tool
 	MCPConfigs []mcp.MCPConfig
 	SubAgents  []*SubAgent
-	// ContextManager is the conversation window. Nil uses NewModelContextManager.
-	ContextManager ContextManager
-	// ModelTasks runs Turn, Absorb, and Handoff. Nil uses DefaultModelTasks.
-	ModelTasks ModelTasks
 	// ContextPolicy sets pressure/compress ratios when non-zero fields are set.
 	ContextPolicy ContextPolicy
-	// ToolInterceptors wrap each tool call (outermost first).
-	// Nil: built-in planning lock and permission gate.
-	// Non-nil: replaces that chain (empty slice disables interceptors).
+	// ToolInterceptors wrap each tool call (outermost first). Built-in
+	// planning lock and permission gate are always installed after these.
 	ToolInterceptors []ToolInterceptor
+	// DisablePlanningLock omits planningWriteLock (workers and tests).
+	// The permission gate is still always installed.
+	DisablePlanningLock bool
 	// ToolResultHooks map tool name → post-success window effects for host tools.
 	// Plan builtins use BuiltinResult instead.
 	ToolResultHooks map[string]ToolResultHook
@@ -83,8 +83,6 @@ type AgentOptions struct {
 	RunCommandUnattended bool
 	// shareIndexBridge is the parent index bridge. Nil means Start a new bridge.
 	shareIndexBridge *vfsindex.Bridge
-	// skipPlanningLock false keeps planningWriteLock on the built-in interceptor chain.
-	skipPlanningLock bool
 }
 
 // streamEventBuffer is the harness event channel size so EmitUpdate is not dropped
@@ -92,21 +90,25 @@ type AgentOptions struct {
 const streamEventBuffer = 64
 
 // NewAgent builds a session-scoped harness. Turn-scoped Runtime is created in Run.
-func NewAgent(ctx context.Context, opts AgentOptions) *AgentHarness {
-	sm := session.NewSessionManager()
-	h := newHarnessBase(opts, sm)
+func NewAgent(ctx context.Context, opts AgentOptions) (*AgentHarness, error) {
+	h, err := newHarnessBase(opts, session.NewSessionManager())
+	if err != nil {
+		return nil, err
+	}
 	if opts.SessionID != "" {
 		h.sessionId = opts.SessionID
 	}
-	h.finishInit(ctx, opts.SubAgents)
-	return h
+	if err := h.finishInit(ctx, opts.SubAgents); err != nil {
+		return nil, err
+	}
+	return h, nil
 }
 
 // newHarnessBase fills shared fields. Session state lives on sm across turns.
 // sm must be non-nil.
-func newHarnessBase(opts AgentOptions, sm *session.SessionManager) *AgentHarness {
+func newHarnessBase(opts AgentOptions, sm *session.SessionManager) (*AgentHarness, error) {
 	if opts.Model == nil {
-		panic("tacklr: AgentOptions.Model is required")
+		return nil, fmt.Errorf("tacklr: AgentOptions.Model is required")
 	}
 	h := &AgentHarness{
 		model:                opts.Model,
@@ -129,23 +131,16 @@ func newHarnessBase(opts AgentOptions, sm *session.SessionManager) *AgentHarness
 		pendingToolCalls:     make(map[string]stores.PendingToolCall),
 		interruptPayloads:    make(map[string][]byte),
 		parkedWorkersLive:    make(map[string]*AgentHarness),
-		context:              opts.ContextManager,
-		tasks:                opts.ModelTasks,
+		context:              NewModelContextManager(),
 		contextPolicy:        opts.ContextPolicy,
 		runCommandUnattended: opts.RunCommandUnattended,
 		vfsBridge:            opts.shareIndexBridge,
 	}
 	if opts.MountSession != nil {
-		sm.VFS = opts.MountSession
+		sm.SetVFS(opts.MountSession)
 	}
-	if opts.Brain != nil {
-		h.searchCtx = brain.NewSearchContext()
-		if opts.SearchNamespace != nil {
-			h.searchCtx.SetNamespace(*opts.SearchNamespace)
-		}
-	}
-	if h.context == nil {
-		h.context = NewModelContextManager()
+	if opts.SearchNamespace != nil {
+		sm.Search().SetNamespace(*opts.SearchNamespace)
 	}
 	def := DefaultContextPolicy()
 	if h.contextPolicy.PressureRatio <= 0 {
@@ -154,30 +149,32 @@ func newHarnessBase(opts AgentOptions, sm *session.SessionManager) *AgentHarness
 	if h.contextPolicy.CompressFraction <= 0 {
 		h.contextPolicy.CompressFraction = def.CompressFraction
 	}
-	if h.tasks == nil {
-		h.tasks = NewDefaultModelTasks(h.model, h.context, h.contextPolicy, h.maxWindowSize)
+	h.tasks = newDefaultModelTasks(h.model, h.context, h.contextPolicy, h.maxWindowSize)
+	chain := append([]ToolInterceptor{}, opts.ToolInterceptors...)
+	if !opts.DisablePlanningLock {
+		chain = append(chain, h.planningWriteLock)
 	}
-	if opts.ToolInterceptors != nil {
-		h.toolRunner = newToolRunner(opts.ToolInterceptors...)
-	} else if opts.skipPlanningLock {
-		h.toolRunner = newToolRunner(toolPermissionGate)
-	} else {
-		h.toolRunner = newToolRunner(h.planningWriteLock, toolPermissionGate)
-	}
+	chain = append(chain, toolPermissionGate)
+	h.toolRunner = newToolRunner(chain...)
 	h.toolResultHooks = newToolResultHookRegistry(opts.ToolResultHooks)
-	return h
+	return h, nil
 }
 
-func (h *AgentHarness) finishInit(ctx context.Context, subAgents []*SubAgent) {
+func (h *AgentHarness) finishInit(ctx context.Context, subAgents []*SubAgent) error {
 	h.initMCP(ctx)
 	if err := h.initSkills(ctx); err != nil {
-		slog.Error("failed to initialize skills", "error", err)
+		return fmt.Errorf("initialize skills: %w", err)
 	}
-	h.initSubAgentWorkers(subAgents)
+	if err := h.initSubAgentWorkers(subAgents); err != nil {
+		return err
+	}
 	if h.vfsBridge == nil {
-		h.initVFSIndexBridge()
+		if err := h.initVFSIndexBridge(); err != nil {
+			return err
+		}
 	}
 	h.injectBuiltinTools()
+	return nil
 }
 
 // injectBuiltinTools registers plan tools, optional web/brain/VFS/index tools, and spawn_worker once.
@@ -197,21 +194,17 @@ func (a *AgentHarness) injectBuiltinTools() {
 		a.tools = append(a.tools, newWebSearchTool(client), newWebFetchTool(client))
 	}
 	br := a.vfsBridge
-	if a.session != nil && a.session.VFS != nil {
-		a.tools = append(a.tools, newVFSTools(a.session.VFS)...)
-		a.tools = append(a.tools, newRunCommand(a.session.VFS, !a.runCommandUnattended))
+	if ms := a.VFS(); ms != nil {
+		a.tools = append(a.tools, newVFSTools(ms)...)
+		a.tools = append(a.tools, newRunCommand(ms, !a.runCommandUnattended))
 	}
-	if a.brain != nil && a.searchCtx != nil {
-		var ms *vfs.MountSession
+	if a.brain != nil {
 		var idx *vfsindex.MountIndexer
-		if a.session != nil {
-			ms = a.session.VFS
-		}
 		if br != nil {
 			idx = br.Indexer
 		}
-		a.tools = append(a.tools, newBrainTools(a.brain, a.searchCtx, a.brainWriteKinds, brainToolDeps{
-			VFS:     ms,
+		a.tools = append(a.tools, newBrainTools(a.brain, a.session.Search(), a.brainWriteKinds, brainToolDeps{
+			VFS:     a.VFS(),
 			Indexer: idx,
 		})...)
 	}
@@ -227,53 +220,44 @@ func (a *AgentHarness) injectBuiltinTools() {
 // initVFSIndexBridge starts a new vfsindex.Bridge when Brain + VFS + namespace
 // are set. Call only when vfsBridge is nil (this harness owns the lifecycle).
 // Hosts with a non-empty kind catalog should register vfsindex.MountIndexKinds().
-func (a *AgentHarness) initVFSIndexBridge() {
-	if a.brain == nil || a.searchCtx == nil || a.session == nil || a.session.VFS == nil {
-		return
+func (a *AgentHarness) initVFSIndexBridge() error {
+	if a.brain == nil || a.VFS() == nil {
+		return nil
 	}
-	ns, ok := a.searchCtx.Namespace()
+	ns, ok := a.session.Search().Namespace()
 	if !ok {
-		return
+		return nil
 	}
 	nsCopy := ns
 	attachMemory := true
-	for _, s := range a.session.VFS.Specs() {
+	for _, s := range a.VFS().Specs() {
 		if s.Profile == brain.DefaultProfile {
 			attachMemory = false
 			break
 		}
 	}
-	br, err := vfsindex.Start(a.session.VFS, a.brain, brain.Scope{Namespace: &nsCopy}, attachMemory)
+	br, err := vfsindex.Start(a.VFS(), a.brain, brain.Scope{Namespace: &nsCopy}, attachMemory)
 	if err != nil {
-		slog.Error("vfsindex: failed to start bridge", "error", err)
-		return
+		return fmt.Errorf("vfsindex: start bridge: %w", err)
 	}
 	a.vfsBridge = br
 	a.ownsVFSBridge = true
+	return nil
 }
 
 // SetSearchNamespace sets retrieval isolation for knowledge tools.
 func (a *AgentHarness) SetSearchNamespace(id uuid.UUID) {
-	if a.searchCtx == nil {
-		a.searchCtx = brain.NewSearchContext()
-	}
-	a.searchCtx.SetNamespace(id)
+	a.session.Search().SetNamespace(id)
 }
 
 // ClearSearchNamespace clears retrieval isolation for knowledge tools.
 func (a *AgentHarness) ClearSearchNamespace() {
-	if a.searchCtx == nil {
-		return
-	}
-	a.searchCtx.ClearNamespace()
+	a.session.Search().ClearNamespace()
 }
 
 // SearchNamespace returns the host-set search namespace, if any.
 func (a *AgentHarness) SearchNamespace() (uuid.UUID, bool) {
-	if a.searchCtx == nil {
-		return uuid.UUID{}, false
-	}
-	return a.searchCtx.Namespace()
+	return a.session.Search().Namespace()
 }
 
 // planningWriteLock blocks write tools until create_plan has set a plan.
@@ -339,72 +323,16 @@ func NewAgentFromSession(ctx context.Context, sessionId string, opts AgentOption
 	if err != nil {
 		return nil, err
 	}
-	rehydrateHarnessState(sm)
-	h := newHarnessBase(opts, sm)
+	h, err := newHarnessBase(opts, sm)
+	if err != nil {
+		return nil, err
+	}
 	h.sessionId = sessionId
 	h.context.Restore(applied.Window)
 	h.interruptToRequester = applied.InterruptToRequester
 	h.pendingToolCalls = applied.PendingToolCalls
-	if h.searchCtx != nil {
-		if len(checkpoint.State.SearchContext) > 0 {
-			if err := h.searchCtx.Restore(checkpoint.State.SearchContext); err != nil {
-				return nil, fmt.Errorf("agent harness: restore search context: %w", err)
-			}
-		}
-		// Legacy checkpoints stored namespace only under runtime _search_namespace.
-		if _, ok := h.searchCtx.Namespace(); !ok {
-			if raw, ok := checkpoint.State.RuntimeState["_search_namespace"]; ok {
-				if s, ok := raw.(string); ok {
-					if id, err := uuid.Parse(s); err == nil {
-						h.searchCtx.SetNamespace(id)
-					}
-				}
-			}
-		}
+	if err := h.finishInit(ctx, opts.SubAgents); err != nil {
+		return nil, err
 	}
-	h.finishInit(ctx, opts.SubAgents)
 	return h, nil
-}
-
-// rehydrateHarnessState turns JSON-round-tripped RuntimeState values back into
-// the typed bags StateSet writes. Call at the checkpoint boundary only.
-func rehydrateHarnessState(sm *session.SessionManager) {
-	if raw, ok := sm.StateGet(parkedWorkersStateKey); ok {
-		sm.StateSet(parkedWorkersStateKey, decodeParkedWorkers(raw))
-	}
-	for _, key := range []string{permissionAlwaysAllowKey, permissionAlwaysDenyKey} {
-		if raw, ok := sm.StateGet(key); ok {
-			sm.StateSet(key, decodeBoolSet(raw))
-		}
-	}
-}
-
-func decodeBoolSet(raw any) map[string]bool {
-	if m, ok := raw.(map[string]bool); ok {
-		return m
-	}
-	b, err := json.Marshal(raw)
-	if err != nil {
-		return map[string]bool{}
-	}
-	var m map[string]bool
-	if err := json.Unmarshal(b, &m); err != nil || m == nil {
-		return map[string]bool{}
-	}
-	return m
-}
-
-func decodeParkedWorkers(raw any) map[string]parkedWorkerMeta {
-	if m, ok := raw.(map[string]parkedWorkerMeta); ok {
-		return m
-	}
-	b, err := json.Marshal(raw)
-	if err != nil {
-		return map[string]parkedWorkerMeta{}
-	}
-	var m map[string]parkedWorkerMeta
-	if json.Unmarshal(b, &m) != nil || m == nil {
-		return map[string]parkedWorkerMeta{}
-	}
-	return m
 }

--- a/agent_construct_test.go
+++ b/agent_construct_test.go
@@ -1,0 +1,67 @@
+package tacklr
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ryanaldo34/tacklr/stores"
+	"github.com/ryanaldo34/tacklr/vfs"
+)
+
+// TestNewAgent_missingSkillDirectory_constructError is the fail-closed
+// construct outcome: a missing SkillDirectories path surfaces from NewAgent.
+func TestNewAgent_missingSkillDirectory_constructError(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	_, err := NewAgent(context.Background(), AgentOptions{
+		Config: Config{MaxWindowSize: 8192, SkillDirectories: []string{missing}},
+		Model:  &mockStrategy{},
+	})
+	if err == nil || !strings.Contains(err.Error(), "initialize skills") {
+		t.Fatalf("want skills construct error, got %v", err)
+	}
+}
+
+// TestNewAgent_sessionIDAndMount_visibleOnHarness is the host-wiring outcome:
+// SessionID and a borrowed MountSession are visible on the public harness.
+func TestNewAgent_sessionIDAndMount_visibleOnHarness(t *testing.T) {
+	ms := vfs.MustNewMountSession("sess-host", vfs.NewBackendRegistry())
+	h := mustNewAgent(t, context.Background(), AgentOptions{
+		Config:       Config{MaxWindowSize: 8192},
+		SessionID:    "sess-host",
+		Model:        &mockStrategy{},
+		MountSession: ms,
+	})
+	if h.SessionID() != "sess-host" {
+		t.Fatalf("SessionID = %q", h.SessionID())
+	}
+	if h.VFS() != ms {
+		t.Fatal("VFS must be the host mount table")
+	}
+}
+
+// TestNewAgentFromSession_missingSession_error is the resume outcome when the
+// store has no checkpoint for the thread id.
+func TestNewAgentFromSession_missingSession_error(t *testing.T) {
+	_, err := NewAgentFromSession(context.Background(), "no-such-session", AgentOptions{
+		Model: &mockStrategy{},
+		Store: testStore(t),
+	})
+	if err == nil || !strings.Contains(err.Error(), "no-such-session") {
+		t.Fatalf("want missing session error, got %v", err)
+	}
+}
+
+// TestNewAgentFromSession_nilModel_error is the resume fail-closed outcome:
+// a stored checkpoint still requires AgentOptions.Model.
+func TestNewAgentFromSession_nilModel_error(t *testing.T) {
+	store := testStore(t)
+	if err := store.SaveSession(context.Background(), "sess-nomodel", stores.SessionCheckpoint{}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := NewAgentFromSession(context.Background(), "sess-nomodel", AgentOptions{Store: store})
+	if err == nil || !strings.Contains(err.Error(), "Model is required") {
+		t.Fatalf("want model required, got %v", err)
+	}
+}

--- a/agent_construct_test.go
+++ b/agent_construct_test.go
@@ -7,12 +7,11 @@ import (
 	"testing"
 
 	"github.com/ryanaldo34/tacklr/stores"
-	"github.com/ryanaldo34/tacklr/vfs"
 )
 
-// TestNewAgent_missingSkillDirectory_constructError is the fail-closed
-// construct outcome: a missing SkillDirectories path surfaces from NewAgent.
-func TestNewAgent_missingSkillDirectory_constructError(t *testing.T) {
+// TestNewAgent_constructFailClosed is the fail-closed construct surface:
+// missing skill dir, missing session, and resume without a model.
+func TestNewAgent_constructFailClosed(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "does-not-exist")
 	_, err := NewAgent(context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192, SkillDirectories: []string{missing}},
@@ -21,46 +20,20 @@ func TestNewAgent_missingSkillDirectory_constructError(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "initialize skills") {
 		t.Fatalf("want skills construct error, got %v", err)
 	}
-}
 
-// TestNewAgent_sessionIDAndMount_visibleOnHarness is the host-wiring outcome:
-// SessionID and a borrowed MountSession are visible on the public harness.
-func TestNewAgent_sessionIDAndMount_visibleOnHarness(t *testing.T) {
-	ms := vfs.MustNewMountSession("sess-host", vfs.NewBackendRegistry())
-	h := mustNewAgent(t, context.Background(), AgentOptions{
-		Config:       Config{MaxWindowSize: 8192},
-		SessionID:    "sess-host",
-		Model:        &mockStrategy{},
-		MountSession: ms,
-	})
-	if h.SessionID() != "sess-host" {
-		t.Fatalf("SessionID = %q", h.SessionID())
-	}
-	if h.VFS() != ms {
-		t.Fatal("VFS must be the host mount table")
-	}
-}
-
-// TestNewAgentFromSession_missingSession_error is the resume outcome when the
-// store has no checkpoint for the thread id.
-func TestNewAgentFromSession_missingSession_error(t *testing.T) {
-	_, err := NewAgentFromSession(context.Background(), "no-such-session", AgentOptions{
+	_, err = NewAgentFromSession(context.Background(), "no-such-session", AgentOptions{
 		Model: &mockStrategy{},
 		Store: testStore(t),
 	})
 	if err == nil || !strings.Contains(err.Error(), "no-such-session") {
 		t.Fatalf("want missing session error, got %v", err)
 	}
-}
 
-// TestNewAgentFromSession_nilModel_error is the resume fail-closed outcome:
-// a stored checkpoint still requires AgentOptions.Model.
-func TestNewAgentFromSession_nilModel_error(t *testing.T) {
 	store := testStore(t)
 	if err := store.SaveSession(context.Background(), "sess-nomodel", stores.SessionCheckpoint{}); err != nil {
 		t.Fatal(err)
 	}
-	_, err := NewAgentFromSession(context.Background(), "sess-nomodel", AgentOptions{Store: store})
+	_, err = NewAgentFromSession(context.Background(), "sess-nomodel", AgentOptions{Store: store})
 	if err == nil || !strings.Contains(err.Error(), "Model is required") {
 		t.Fatalf("want model required, got %v", err)
 	}

--- a/agent_run.go
+++ b/agent_run.go
@@ -42,7 +42,7 @@ func (a *AgentHarness) RunMessage(ctx context.Context, user *Message) (<-chan St
 	out := make(chan StreamEvent, streamEventBuffer)
 	// Turn-scoped Runtime: event bus for this Run only; durable state is on a.session.
 	// Tools receive a value copy via invoke; plan tools emit plan_update through it.
-	turnRT := session.NewRuntime(out, a.store, a.session)
+	turnRT := session.NewRuntime(out, a.session)
 
 	emitCancelled := func() {
 		// Pair open tools into the window before the cancel error event so the
@@ -261,8 +261,7 @@ func (a *AgentHarness) RunMessage(ctx context.Context, user *Message) (<-chan St
 						toolResults[i] = a.emitToolResult(out, tc, toolErr.Error(), "error")
 						return
 					}
-					runtimeCopy := turnRT
-					runtimeCopy.CurrentToolCallID = tcKey
+					runtimeCopy := turnRT.WithToolCallID(tcKey)
 					output, toolDisp, err := a.toolRunner.Run(toolCtx, ToolInvocation{
 						Tool:     tool,
 						ArgsJSON: tc.Arguments,

--- a/agent_run_test.go
+++ b/agent_run_test.go
@@ -78,7 +78,7 @@ func runPrompt(t *testing.T, model *mockStrategy, opts AgentOptions) (*AgentHarn
 	if opts.Config.MaxWindowSize == 0 {
 		opts.Config.MaxWindowSize = 8192
 	}
-	h := NewAgent(context.Background(), opts)
+	h := mustNewAgent(t, context.Background(), opts)
 	t.Cleanup(h.Close)
 	_ = h.SessionID() // exercise getter (empty when no store/session id set)
 	events, err := h.Run(context.Background(), "hi")
@@ -89,7 +89,7 @@ func runPrompt(t *testing.T, model *mockStrategy, opts AgentOptions) (*AgentHarn
 }
 
 func TestRunMessage_imageAcceptedOnlyWhenModelAllows(t *testing.T) {
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  &mockStrategy{},
 	})
@@ -110,7 +110,7 @@ func TestRunMessage_imageAcceptedOnlyWhenModelAllows(t *testing.T) {
 		t.Fatalf("text-only model: %v", err)
 	}
 
-	vision := NewAgent(context.Background(), AgentOptions{
+	vision := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model: &mockStrategy{
 			supportsMIMEFn: func(string) bool { return true },
@@ -165,7 +165,7 @@ func TestRun_maxTurnRequests_emitsStopReason(t *testing.T) {
 			}
 		},
 	}
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192, MaxTurnRequests: 1},
 		Model:  strategy,
 		Tools:  []*Tool{tool},
@@ -182,7 +182,7 @@ func TestRun_maxTurnRequests_emitsStopReason(t *testing.T) {
 
 // TestRun_invokeError_emitsErrorEvent: model Invoke failures end the turn with an error event.
 func TestRun_invokeError_emitsErrorEvent(t *testing.T) {
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  &mockStrategy{invokeErr: errors.New("provider down")},
 	})
@@ -223,7 +223,7 @@ func TestRun_modelStreamError_afterToolAnnounce_emitsFailedToolResults(t *testin
 			}
 		},
 	}
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 	})
@@ -253,7 +253,7 @@ func TestRun_incompleteToolCall_emitsFailedToolResult(t *testing.T) {
 			// Stream ends without a complete executable function_call.
 		},
 	}
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 	})
@@ -291,7 +291,7 @@ func TestRun_unknownTool_surfacesToolResultError(t *testing.T) {
 			}
 		},
 	}
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 	})
@@ -334,7 +334,7 @@ func TestRun_functionCallRecordedBeforeToolResult(t *testing.T) {
 			ch <- LLMResponseChunk{Type: StreamEventMessage, Content: "done", IsComplete: true}
 		},
 	}
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Tools:  []*Tool{tool},
@@ -394,7 +394,7 @@ func TestRun_modelErrorAfterTools_tagsAndCheckpointsPairs(t *testing.T) {
 			}
 		},
 	}
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Tools:  []*Tool{tool},
@@ -467,7 +467,7 @@ func TestRun_modelError_stripsUnpairedFromCheckpoint(t *testing.T) {
 			}
 		},
 	}
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Store:  store,
@@ -536,7 +536,7 @@ func TestRun_customInstructionsInSystemPrompt(t *testing.T) {
 			ch <- LLMResponseChunk{Type: StreamEventMessage, Content: "ok", IsComplete: true}
 		},
 	}
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192, SystemPrompt: "Always greet formally."},
 		Model:  strategy,
 	})
@@ -589,7 +589,7 @@ func TestRun_mcpToolsDiscoveredAndInvokable(t *testing.T) {
 			ch <- LLMResponseChunk{Type: StreamEventMessage, Content: "done", IsComplete: true}
 		},
 	}
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		MCPConfigs: []mcp.MCPConfig{
@@ -637,7 +637,7 @@ func TestRun_watchdogRecordsToolResults(t *testing.T) {
 		},
 	}
 	wd := &recordingWatchdog{}
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Config:   Config{MaxWindowSize: 8192},
 		Model:    strategy,
 		Tools:    []*Tool{tool},
@@ -678,7 +678,7 @@ func TestRun_cancelMidTool_pairsCancelledResultsInWindow(t *testing.T) {
 		},
 	}
 	store := stores.NewInMemoryStore()
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Config:    Config{MaxWindowSize: 8192},
 		Model:     strategy,
 		Tools:     []*Tool{slow},
@@ -745,7 +745,7 @@ func TestRun_cancelAfterToolAnnounce_closesAnnouncedTools(t *testing.T) {
 			<-ctx.Done()
 		},
 	}
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 	})

--- a/agent_run_test.go
+++ b/agent_run_test.go
@@ -78,7 +78,7 @@ func runPrompt(t *testing.T, model *mockStrategy, opts AgentOptions) (*AgentHarn
 	if opts.Config.MaxWindowSize == 0 {
 		opts.Config.MaxWindowSize = 8192
 	}
-	h := mustNewAgent(t, context.Background(), opts)
+	h := mustNewAgent(t, opts)
 	t.Cleanup(h.Close)
 	_ = h.SessionID() // exercise getter (empty when no store/session id set)
 	events, err := h.Run(context.Background(), "hi")
@@ -89,7 +89,7 @@ func runPrompt(t *testing.T, model *mockStrategy, opts AgentOptions) (*AgentHarn
 }
 
 func TestRunMessage_imageAcceptedOnlyWhenModelAllows(t *testing.T) {
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  &mockStrategy{},
 	})
@@ -110,7 +110,7 @@ func TestRunMessage_imageAcceptedOnlyWhenModelAllows(t *testing.T) {
 		t.Fatalf("text-only model: %v", err)
 	}
 
-	vision := mustNewAgent(t, context.Background(), AgentOptions{
+	vision := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model: &mockStrategy{
 			supportsMIMEFn: func(string) bool { return true },
@@ -165,7 +165,7 @@ func TestRun_maxTurnRequests_emitsStopReason(t *testing.T) {
 			}
 		},
 	}
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192, MaxTurnRequests: 1},
 		Model:  strategy,
 		Tools:  []*Tool{tool},
@@ -182,7 +182,7 @@ func TestRun_maxTurnRequests_emitsStopReason(t *testing.T) {
 
 // TestRun_invokeError_emitsErrorEvent: model Invoke failures end the turn with an error event.
 func TestRun_invokeError_emitsErrorEvent(t *testing.T) {
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  &mockStrategy{invokeErr: errors.New("provider down")},
 	})
@@ -223,7 +223,7 @@ func TestRun_modelStreamError_afterToolAnnounce_emitsFailedToolResults(t *testin
 			}
 		},
 	}
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 	})
@@ -253,7 +253,7 @@ func TestRun_incompleteToolCall_emitsFailedToolResult(t *testing.T) {
 			// Stream ends without a complete executable function_call.
 		},
 	}
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 	})
@@ -291,7 +291,7 @@ func TestRun_unknownTool_surfacesToolResultError(t *testing.T) {
 			}
 		},
 	}
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 	})
@@ -334,7 +334,7 @@ func TestRun_functionCallRecordedBeforeToolResult(t *testing.T) {
 			ch <- LLMResponseChunk{Type: StreamEventMessage, Content: "done", IsComplete: true}
 		},
 	}
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Tools:  []*Tool{tool},
@@ -394,7 +394,7 @@ func TestRun_modelErrorAfterTools_tagsAndCheckpointsPairs(t *testing.T) {
 			}
 		},
 	}
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Tools:  []*Tool{tool},
@@ -467,7 +467,7 @@ func TestRun_modelError_stripsUnpairedFromCheckpoint(t *testing.T) {
 			}
 		},
 	}
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Store:  store,
@@ -536,7 +536,7 @@ func TestRun_customInstructionsInSystemPrompt(t *testing.T) {
 			ch <- LLMResponseChunk{Type: StreamEventMessage, Content: "ok", IsComplete: true}
 		},
 	}
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192, SystemPrompt: "Always greet formally."},
 		Model:  strategy,
 	})
@@ -589,7 +589,7 @@ func TestRun_mcpToolsDiscoveredAndInvokable(t *testing.T) {
 			ch <- LLMResponseChunk{Type: StreamEventMessage, Content: "done", IsComplete: true}
 		},
 	}
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		MCPConfigs: []mcp.MCPConfig{
@@ -637,7 +637,7 @@ func TestRun_watchdogRecordsToolResults(t *testing.T) {
 		},
 	}
 	wd := &recordingWatchdog{}
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config:   Config{MaxWindowSize: 8192},
 		Model:    strategy,
 		Tools:    []*Tool{tool},
@@ -678,7 +678,7 @@ func TestRun_cancelMidTool_pairsCancelledResultsInWindow(t *testing.T) {
 		},
 	}
 	store := stores.NewInMemoryStore()
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config:    Config{MaxWindowSize: 8192},
 		Model:     strategy,
 		Tools:     []*Tool{slow},
@@ -745,7 +745,7 @@ func TestRun_cancelAfterToolAnnounce_closesAnnouncedTools(t *testing.T) {
 			<-ctx.Done()
 		},
 	}
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 	})

--- a/brain/provider_test.go
+++ b/brain/provider_test.go
@@ -34,7 +34,7 @@ func TestBrainProvider_prefixWriteReadDirRemoveAndIR(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("engram", reg)
+	ms := vfs.MustNewMountSession("engram", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{
 		Point: "/engram", Profile: "brain",
 		Params: map[string]string{"mode": "prefix"},
@@ -261,7 +261,7 @@ func TestBrainProvider_rootsLayout(t *testing.T) {
 	if reg.HasProfile("brain") == false {
 		t.Fatal("default profile")
 	}
-	ms := vfs.NewMountSession("roots", reg)
+	ms := vfs.MustNewMountSession("roots", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{
 		Point: "/person", Profile: "brain",
 		Params: map[string]string{"mode": "roots", "kind": "Person"},
@@ -308,7 +308,7 @@ func TestBrainProvider_openCatalogListsKindsInUseAndMkdir(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("open", reg)
+	ms := vfs.MustNewMountSession("open", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/engram", Profile: "brain"}); err != nil {
 		t.Fatal(err)
 	}
@@ -392,7 +392,7 @@ func TestBrainFactory_openRejectsInvalidConfig(t *testing.T) {
 	if err := reg.Register(valid); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("factory", reg)
+	ms := vfs.MustNewMountSession("factory", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{
 		Point: "/person", Profile: "brain",
 		Params: map[string]string{"mode": "roots", "kinds": "Note"},
@@ -453,7 +453,7 @@ func TestBrainFactory_openRejectsInvalidConfig(t *testing.T) {
 	}
 
 	// prefix kinds= allow-list: ReadDir lists only the allowed kind after a write.
-	ms2 := vfs.NewMountSession("kinds-allow", reg)
+	ms2 := vfs.MustNewMountSession("kinds-allow", reg)
 	if err := ms2.Mount(ctx, vfs.MountSpec{
 		Point: "/engram", Profile: "brain",
 		Params: map[string]string{"mode": "prefix", "kinds": "Note"},

--- a/brain/testdata/Dockerfile.postgres
+++ b/brain/testdata/Dockerfile.postgres
@@ -23,8 +23,16 @@ RUN set -eux; \
 	esac; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends ca-certificates curl unzip; \
-	curl -fsSL -o /tmp/pgts.zip \
-		"https://github.com/timescale/pg_textsearch/releases/download/v${PG_TEXTSEARCH_VERSION}/pg-textsearch-v${PG_TEXTSEARCH_VERSION}-pg17-${deb_arch}.zip"; \
+	url="https://github.com/timescale/pg_textsearch/releases/download/v${PG_TEXTSEARCH_VERSION}/pg-textsearch-v${PG_TEXTSEARCH_VERSION}-pg17-${deb_arch}.zip"; \
+	i=0; \
+	until curl -fsSL --retry 8 --retry-delay 2 --retry-all-errors --retry-max-time 180 -o /tmp/pgts.zip "$url"; do \
+		i=$((i + 1)); \
+		if [ "$i" -ge 5 ]; then \
+			echo "failed to download pg_textsearch from ${url} after ${i} attempts" >&2; \
+			exit 1; \
+		fi; \
+		sleep $((i * 3)); \
+	done; \
 	mkdir -p /tmp/pgts; \
 	unzip -d /tmp/pgts /tmp/pgts.zip; \
 	dpkg -i /tmp/pgts/*.deb; \

--- a/builtins.go
+++ b/builtins.go
@@ -82,8 +82,8 @@ var askUserChoiceTool = NewTool(ToolConfig{
 		if err != nil {
 			return "", fmt.Errorf("marshal choices: %w", err)
 		}
-		if runtime.CurrentToolCallID != "" {
-			runtime.StateSet(askUserQuestionStateKey(runtime.CurrentToolCallID), args.Question)
+		if runtime.CurrentToolCallID() != "" {
+			_ = runtime.StateSet(askUserQuestionStateKey(runtime.CurrentToolCallID()), args.Question)
 		}
 
 		intr, err := runtime.RaiseInterrupt("user_selection_choice", optionsJSON)

--- a/builtins_test.go
+++ b/builtins_test.go
@@ -41,7 +41,7 @@ func drainEventCh() chan streaming.StreamEvent {
 
 // planRT is a turn Runtime for plan/ask tool unit tests (events drained).
 func planRT() HarnessRuntime {
-	return session.NewRuntime(drainEventCh(), nil, session.NewSessionManager())
+	return session.NewRuntime(drainEventCh(), session.NewSessionManager())
 }
 
 // TestCreatePlanTool covers create_plan success and rejection return paths.
@@ -314,8 +314,8 @@ func TestEditPlanTool(t *testing.T) {
 }
 
 func TestAskUserChoiceTool_raiseAndResume(t *testing.T) {
-	rt := session.NewRuntime(make(chan streaming.StreamEvent, 4), nil, session.NewSessionManager())
-	rt.CurrentToolCallID = "tc_ask"
+	rt := session.NewRuntime(make(chan streaming.StreamEvent, 4), session.NewSessionManager())
+	rt = rt.WithToolCallID("tc_ask")
 
 	args, _ := json.Marshal(map[string]any{
 		"question": "Which approach?",
@@ -422,7 +422,7 @@ func TestRun_planToolHappyAndErrorPaths(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			model := sequentialToolModel([]ToolCall{c.call})
 			opts := AgentOptions{Model: model, Config: Config{MaxWindowSize: 8192}}
-			h := NewAgent(context.Background(), opts)
+			h := mustNewAgent(t, context.Background(), opts)
 			t.Cleanup(h.Close)
 			if c.seed != nil {
 				c.seed(h)
@@ -442,7 +442,7 @@ func TestRun_planToolHappyAndErrorPaths(t *testing.T) {
 func TestRun_askUserChoice_withoutDescription_formatsSelection(t *testing.T) {
 	model := sequentialToolModel([]ToolCall{toolCall("ask1", "ask_user_choice",
 		`{"question":"Pick?","choices":[{"title":"A"},{"title":"B"}]}`)})
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Model: model, Config: Config{MaxWindowSize: 8192}, Store: testStore(t),
 	})
 	t.Cleanup(h.Close)
@@ -588,7 +588,7 @@ func TestRun_completeTodo_withPlanDocument_preservesFullPlan(t *testing.T) {
 			}
 		},
 	}
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Model: strategy, Config: Config{MaxWindowSize: 8192}, Store: testStore(t),
 	})
 	t.Cleanup(h.Close)
@@ -640,7 +640,7 @@ func TestRun_editPlan_planChange_triggersHandoff(t *testing.T) {
 			}
 		},
 	}
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Model: strategy, Config: Config{MaxWindowSize: 8192}, Store: testStore(t),
 	})
 	t.Cleanup(h.Close)
@@ -685,7 +685,7 @@ func TestRun_completeTodo_persistsPlanInStore(t *testing.T) {
 		},
 	}
 
-	ah := NewAgent(context.Background(), AgentOptions{
+	ah := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Store:  store,

--- a/builtins_test.go
+++ b/builtins_test.go
@@ -422,7 +422,7 @@ func TestRun_planToolHappyAndErrorPaths(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			model := sequentialToolModel([]ToolCall{c.call})
 			opts := AgentOptions{Model: model, Config: Config{MaxWindowSize: 8192}}
-			h := mustNewAgent(t, context.Background(), opts)
+			h := mustNewAgent(t, opts)
 			t.Cleanup(h.Close)
 			if c.seed != nil {
 				c.seed(h)
@@ -442,7 +442,7 @@ func TestRun_planToolHappyAndErrorPaths(t *testing.T) {
 func TestRun_askUserChoice_withoutDescription_formatsSelection(t *testing.T) {
 	model := sequentialToolModel([]ToolCall{toolCall("ask1", "ask_user_choice",
 		`{"question":"Pick?","choices":[{"title":"A"},{"title":"B"}]}`)})
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Model: model, Config: Config{MaxWindowSize: 8192}, Store: testStore(t),
 	})
 	t.Cleanup(h.Close)
@@ -588,7 +588,7 @@ func TestRun_completeTodo_withPlanDocument_preservesFullPlan(t *testing.T) {
 			}
 		},
 	}
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Model: strategy, Config: Config{MaxWindowSize: 8192}, Store: testStore(t),
 	})
 	t.Cleanup(h.Close)
@@ -640,7 +640,7 @@ func TestRun_editPlan_planChange_triggersHandoff(t *testing.T) {
 			}
 		},
 	}
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Model: strategy, Config: Config{MaxWindowSize: 8192}, Store: testStore(t),
 	})
 	t.Cleanup(h.Close)
@@ -685,7 +685,7 @@ func TestRun_completeTodo_persistsPlanInStore(t *testing.T) {
 		},
 	}
 
-	ah := mustNewAgent(t, context.Background(), AgentOptions{
+	ah := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Store:  store,

--- a/context_manager.go
+++ b/context_manager.go
@@ -29,13 +29,11 @@ func DefaultContextPolicy() ContextPolicy {
 }
 
 // ContextManager owns the conversation window structure only (no inference).
-// ModelTasks does model work and applies results with Replace or InstallPlanDocument.
-// Snapshot must be safe while another path Absorbs or Replaces after resume.
+// modelTasks does model work and applies results with Replace or InstallPlanDocument.
+// Messages must be safe while another path Absorbs or Replaces after resume.
 type ContextManager interface {
-	// Messages returns a retainable snapshot of the live window.
+	// Messages returns a retainable snapshot of the live window (also used for checkpoints).
 	Messages() []*Message
-	// Snapshot is for checkpointing (shallow copy of message pointers).
-	Snapshot() []*Message
 	// Restore copies window into storage (caller keeps its slice).
 	Restore(window []*Message)
 	// Replace takes ownership of window; do not reuse the slice after.
@@ -64,10 +62,6 @@ func (m *ModelContextManager) Messages() []*Message {
 		return nil
 	}
 	return slices.Clone(m.window)
-}
-
-func (m *ModelContextManager) Snapshot() []*Message {
-	return m.Messages()
 }
 
 func (m *ModelContextManager) Restore(window []*Message) {

--- a/docs/badges/coverage.json
+++ b/docs/badges/coverage.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "coverage",
-  "message": "90.1%",
+  "message": "90.3%",
   "color": "green"
 }

--- a/docs/badges/coverage.json
+++ b/docs/badges/coverage.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "coverage",
-  "message": "90.0%",
+  "message": "90.1%",
   "color": "green"
 }

--- a/docs/fuse-vfs-run-command.md
+++ b/docs/fuse-vfs-run-command.md
@@ -6,7 +6,7 @@
 | **Date** | 2026-08-15 |
 | **Product** | Tacklr — opinionated Go agent harness SDK |
 | **Repo** | `/Users/ryan/development/tacklr` |
-| **Status** | In progress — Phases 0–2 shipped; this file is the remaining train |
+| **Status** | Complete — Phases 0–5 shipped. Agent catalog is `read`, `write`, `run_command` (plus index tools when Brain is wired). |
 | **Depends on** | host-owned `vfs.MountSession`, `VFSProjection`, `run_command`, write-through IR |
 
 ---
@@ -15,7 +15,7 @@
 
 Phases 0–2 of this train are in the tree. A live Registry session with a VFS and a FUSE device gets a kernel projection. `run_command` runs `/bin/sh -c` with cwd at that root. Providers persist on write. The harness is turn-scoped; the host owns the mount table and the FUSE tree.
 
-What is still open is the **agent file catalog**. The model still sees `find_files`, `find_content`, `read_lines`, `replace_lines`, `replace_text`, and a full-body `write` next to `run_command`. Those extra tools were the stand-in while host `ls` / `rg` / `fd` could not see the tree. They can see it now. This document is the plan to finish that collapse, then stop. Writable FUSE, jail, broker, and a custom shell stay out.
+The **agent file catalog** is collapsed. Discovery (`find_files`, `find_content`), line editors (`read_lines`, `replace_lines`, `replace_text`), and directory tools (`list`, `stat`, `mkdir`, `remove`) are gone. The model sees `read`, `write`, and `run_command`. Live names and grep go through `run_command` → `ls` / `rg` / `fd` on the FUSE tree. Writable FUSE, jail, broker, and a custom shell stay out.
 
 ---
 
@@ -69,15 +69,15 @@ What is still open is the **agent file catalog**. The model still sees `find_fil
 
 ---
 
-## Remaining work
+## Remaining work (shipped)
 
 ```text
-Phase 3   Drop find_files and find_content. Keep list / stat / index_file / unindex.
+Phase 3   Drop find_files and find_content. (Also dropped list/stat/mkdir/remove; live names via run_command.)
 Phase 4a  Rename read_lines → read. Path-only read returns the first page.
 Phase 4b  Fold replace_lines + replace_text + write into one write (mode count).
 Phase 5   Docs pass (vfs.md, knowledge.md, README, vfs/doc.go).
 Next      Writable FUSE (separate plan) so run_command can mkdir / rm / echo >.
-Later     Jail / broker / eBPF; custom shell; drop list/stat.
+Later     Jail / broker / eBPF; custom shell.
 ```
 
 Do not start Phase 3 until a FUSE-capable host shows `run_command` → `ls` / `rg` matches `ReadDir` / `ReadText`. Kernel tests already skip without a device. Do not skip that gate by rewriting tests to avoid `run_command`.

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -63,7 +63,7 @@ Almost every design mistake in this area comes from treating these as the same t
 
 ```text
   Agent
-    ├─ file tools     list, stat, read, write, mkdir, remove, run_command
+    ├─ file tools     read, write, run_command
     └─ knowledge tools schema, search, find_exact, find_objects,
                        link, expand, find_links, save_*, continue
               │

--- a/docs/vfs.md
+++ b/docs/vfs.md
@@ -64,7 +64,10 @@ reg := vfs.NewBackendRegistry()
 _ = reg.Register(vfs.LocalFactory{ID: "scratch", Base: "/var/agent/scratch"})
 // S3: reg.Register(vfs.S3Factory{ID: "docs", Client: vfs.AWSS3{Client: s3c}, DefaultBucket: "my-bucket"})
 
-ms := vfs.NewMountSession("sess-1", reg)
+ms, err := vfs.NewMountSession("sess-1", reg)
+if err != nil {
+	return err
+}
 _ = ms.Mount(ctx, vfs.MountSpec{Point: "/work", Profile: "scratch"})
 ```
 
@@ -258,7 +261,7 @@ ctx := context.Background()
 // --- Mount ---
 reg := vfs.NewBackendRegistry()
 _ = reg.Register(vfs.LocalFactory{ID: "scratch", Base: "/var/agent/scratch"})
-ms := vfs.NewMountSession("sess-1", reg)
+ms, _ := vfs.NewMountSession("sess-1", reg)
 _ = ms.Mount(ctx, vfs.MountSpec{Point: "/work", Profile: "scratch"})
 
 // Optional seed via raw bytes

--- a/export_test.go
+++ b/export_test.go
@@ -39,6 +39,15 @@ func turnRuntime(h *AgentHarness) HarnessRuntime {
 	return session.NewRuntime(ch, h.session)
 }
 
+func nopRuntime() HarnessRuntime {
+	ch := make(chan StreamEvent, 8)
+	go func() {
+		for range ch {
+		}
+	}()
+	return session.NewRuntime(ch, session.NewSessionManager())
+}
+
 func mustNewAgent(t testing.TB, ctx context.Context, opts AgentOptions) *AgentHarness {
 	t.Helper()
 	h, err := NewAgent(ctx, opts)

--- a/export_test.go
+++ b/export_test.go
@@ -1,7 +1,6 @@
 package tacklr
 
 import (
-	"context"
 	"testing"
 
 	"github.com/ryanaldo34/tacklr/internal/session"
@@ -48,9 +47,9 @@ func nopRuntime() HarnessRuntime {
 	return session.NewRuntime(ch, session.NewSessionManager())
 }
 
-func mustNewAgent(t testing.TB, ctx context.Context, opts AgentOptions) *AgentHarness {
+func mustNewAgent(t testing.TB, opts AgentOptions) *AgentHarness {
 	t.Helper()
-	h, err := NewAgent(ctx, opts)
+	h, err := NewAgent(t.Context(), opts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/export_test.go
+++ b/export_test.go
@@ -1,6 +1,7 @@
 package tacklr
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ryanaldo34/tacklr/internal/session"
@@ -35,5 +36,14 @@ func turnRuntime(h *AgentHarness) HarnessRuntime {
 		for range ch {
 		}
 	}()
-	return session.NewRuntime(ch, h.store, h.session)
+	return session.NewRuntime(ch, h.session)
+}
+
+func mustNewAgent(t testing.TB, ctx context.Context, opts AgentOptions) *AgentHarness {
+	t.Helper()
+	h, err := NewAgent(ctx, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
 }

--- a/inference/capabilities_test.go
+++ b/inference/capabilities_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSupportsMIME_visionAndPDF(t *testing.T) {
-	s := NewOpenAIInferenceStrategy(nil).WithModel("gpt-4o").(*OpenAIInferenceStrategy)
+	s := NewOpenAIInferenceStrategy(nil).WithModel("gpt-4o")
 	if !s.SupportsMIME("text/plain") || !s.SupportsMIME("") {
 		t.Fatal("text always supported")
 	}
@@ -21,7 +21,7 @@ func TestSupportsMIME_visionAndPDF(t *testing.T) {
 	if s.SupportsMIME("application/zip") {
 		t.Fatal("unknown binary rejected")
 	}
-	s2 := NewOpenAIInferenceStrategy(nil).WithModel("unknown-local-llm").(*OpenAIInferenceStrategy)
+	s2 := NewOpenAIInferenceStrategy(nil).WithModel("unknown-local-llm")
 	if s2.SupportsMIME("image/png") || s2.SupportsMIME("application/pdf") {
 		t.Fatal("unknown model rejects binary")
 	}
@@ -72,7 +72,7 @@ func TestMarshalMessagesToInput_multimodal(t *testing.T) {
 }
 
 func TestUnsupportedMIMEs(t *testing.T) {
-	s := NewOpenAIInferenceStrategy(nil).WithModel("unknown").(*OpenAIInferenceStrategy)
+	s := NewOpenAIInferenceStrategy(nil).WithModel("unknown")
 	bad := tacklr.UnsupportedMIMEs(s, []string{"text/plain", "image/png", "image/png", "application/pdf"})
 	if len(bad) != 2 {
 		t.Fatalf("bad=%v", bad)

--- a/inference/coverage_extra_test.go
+++ b/inference/coverage_extra_test.go
@@ -52,7 +52,7 @@ func TestOpenAIStrategy_telemetryAndMaxTokens(t *testing.T) {
 	if id := nilS.ModelTelemetryIdentity(); id != (telemetry.ModelIdentity{}) {
 		t.Fatalf("%+v", id)
 	}
-	s := NewOpenAIInferenceStrategy(nil).WithApiKey("k").WithModel("gpt-test").(*OpenAIInferenceStrategy)
+	s := NewOpenAIInferenceStrategy(nil).WithApiKey("k").WithModel("gpt-test")
 	s.WithURL("https://api.openai.com/v1")
 	id := s.ModelTelemetryIdentity()
 	if id.Model != "gpt-test" || id.Provider != telemetry.GenAIProviderOpenAI {

--- a/inference/coverage_test.go
+++ b/inference/coverage_test.go
@@ -46,13 +46,6 @@ func TestMaxContextWindow_knownAndPrefixAndUnknown(t *testing.T) {
 	}
 }
 
-func TestCompressContextWindow_noop(t *testing.T) {
-	s := NewOpenAIInferenceStrategy(nil)
-	if err := s.CompressContextWindow(); err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestWithReasoningAndStructuredOutput_onInvokeRequest(t *testing.T) {
 	var saw map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -89,7 +82,7 @@ func TestWithReasoningAndStructuredOutput_onInvokeRequest(t *testing.T) {
 		{Role: tacklr.RoleDeveloper, Content: "dev handoff"},
 	}, []*tacklr.Tool{
 		tacklr.NewTool(tacklr.ToolConfig{Name: "lookup", Handler: func(ctx context.Context) (string, error) { return "", nil }}),
-	})
+	}, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -176,11 +169,11 @@ func TestCountTokens_withToolsAndInstructions(t *testing.T) {
 
 func TestInvoke_missingConfig(t *testing.T) {
 	s := NewOpenAIInferenceStrategy(http.DefaultClient)
-	if _, err := s.Invoke(context.Background(), nil, nil); !errors.Is(err, tacklr.ErrApiKeyNotSet) {
+	if _, err := s.Invoke(context.Background(), nil, nil, ""); !errors.Is(err, tacklr.ErrApiKeyNotSet) {
 		t.Fatalf("%v", err)
 	}
 	s.WithApiKey("k")
-	if _, err := s.Invoke(context.Background(), nil, nil); !errors.Is(err, tacklr.ErrModelNotSet) {
+	if _, err := s.Invoke(context.Background(), nil, nil, ""); !errors.Is(err, tacklr.ErrModelNotSet) {
 		t.Fatalf("%v", err)
 	}
 }
@@ -196,7 +189,7 @@ func TestInvoke_httpDoError_closesChannel(t *testing.T) {
 	s.WithModel("m")
 	s.WithURL("http://example.invalid")
 
-	ch, err := s.Invoke(context.Background(), []*tacklr.Message{{Role: tacklr.RoleUser, Content: "x"}}, nil)
+	ch, err := s.Invoke(context.Background(), []*tacklr.Message{{Role: tacklr.RoleUser, Content: "x"}}, nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -430,7 +423,7 @@ func TestCountTokens_structuredOutputAndDoError(t *testing.T) {
 func TestInvoke_createRequestErrorAndCancelledSend(t *testing.T) {
 	s := NewOpenAIInferenceStrategy(http.DefaultClient)
 	s.WithApiKey("k").WithModel("m").WithURL("http://\x00") // invalid URL
-	ch, err := s.Invoke(context.Background(), []*tacklr.Message{{Role: tacklr.RoleUser, Content: "x"}}, nil)
+	ch, err := s.Invoke(context.Background(), []*tacklr.Message{{Role: tacklr.RoleUser, Content: "x"}}, nil, "")
 	if err != nil {
 		// NewRequest may fail before goroutine
 		return
@@ -445,7 +438,7 @@ func TestInvoke_createRequestErrorAndCancelledSend(t *testing.T) {
 		return nil, errors.New("x")
 	})})
 	s2.WithApiKey("k").WithModel("m").WithURL("http://example.invalid")
-	ch2, err := s2.Invoke(ctx, []*tacklr.Message{{Role: tacklr.RoleUser, Content: "x"}}, nil)
+	ch2, err := s2.Invoke(ctx, []*tacklr.Message{{Role: tacklr.RoleUser, Content: "x"}}, nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/inference/inference.go
+++ b/inference/inference.go
@@ -51,12 +51,12 @@ func NewOpenAIInferenceStrategy(client *http.Client) *OpenAIInferenceStrategy {
 	}
 }
 
-func (s *OpenAIInferenceStrategy) WithApiKey(key string) tacklr.InferenceStrategy {
+func (s *OpenAIInferenceStrategy) WithApiKey(key string) *OpenAIInferenceStrategy {
 	s.apiKey = key
 	return s
 }
 
-func (s *OpenAIInferenceStrategy) WithModel(model string) tacklr.InferenceStrategy {
+func (s *OpenAIInferenceStrategy) WithModel(model string) *OpenAIInferenceStrategy {
 	s.model = model
 	return s
 }
@@ -70,12 +70,12 @@ func (s *OpenAIInferenceStrategy) ModelTelemetryIdentity() telemetry.ModelIdenti
 	return telemetry.NewModelIdentity(s.model, s.baseURL)
 }
 
-func (s *OpenAIInferenceStrategy) WithURL(url string) tacklr.InferenceStrategy {
+func (s *OpenAIInferenceStrategy) WithURL(url string) *OpenAIInferenceStrategy {
 	s.baseURL = url
 	return s
 }
 
-func (s *OpenAIInferenceStrategy) WithReasoningLevel(level string) tacklr.InferenceStrategy {
+func (s *OpenAIInferenceStrategy) WithReasoningLevel(level string) *OpenAIInferenceStrategy {
 	s.reasoning = level
 	// Default summary so Azure OpenAI / OpenAI stream thought deltas as
 	// response.reasoning_summary_text.delta (mapped to StreamEventReasoning).
@@ -103,7 +103,7 @@ func (s *OpenAIInferenceStrategy) WithMaxOutputTokens(n int) *OpenAIInferenceStr
 	return s
 }
 
-func (s *OpenAIInferenceStrategy) WithStructuredOutput(v any) tacklr.InferenceStrategy {
+func (s *OpenAIInferenceStrategy) WithStructuredOutput(v any) *OpenAIInferenceStrategy {
 	if v == nil {
 		s.structuredOutputSchema = nil
 		s.structuredOutputName = ""
@@ -128,10 +128,6 @@ func (s *OpenAIInferenceStrategy) SupportsMIME(mimeType string) bool {
 		return streaming.IsTextMIME(mimeType)
 	}
 	return modelSupportsMIME(s.model, mimeType)
-}
-
-func (s *OpenAIInferenceStrategy) CompressContextWindow() error {
-	return nil
 }
 
 func (s *OpenAIInferenceStrategy) MaxContextWindow() (int, error) {
@@ -245,7 +241,7 @@ func (s *OpenAIInferenceStrategy) CountTokens(ctx context.Context, messages []*t
 	return countResp.InputTokens, nil
 }
 
-func (s *OpenAIInferenceStrategy) Invoke(ctx context.Context, messages []*tacklr.Message, tools []*tacklr.Tool) (chan tacklr.LLMResponseChunk, error) {
+func (s *OpenAIInferenceStrategy) Invoke(ctx context.Context, messages []*tacklr.Message, tools []*tacklr.Tool, systemPrompt string) (chan tacklr.LLMResponseChunk, error) {
 	if s.apiKey == "" {
 		return nil, fmt.Errorf("invoke: %w", tacklr.ErrApiKeyNotSet)
 	}
@@ -276,8 +272,12 @@ func (s *OpenAIInferenceStrategy) Invoke(ctx context.Context, messages []*tacklr
 		reqBody.MaxOutputTokens = s.maxOutputTokens
 	}
 
-	if s.instructions != "" {
-		reqBody.Instructions = &s.instructions
+	prompt := systemPrompt
+	if prompt == "" {
+		prompt = s.instructions
+	}
+	if prompt != "" {
+		reqBody.Instructions = &prompt
 	}
 
 	if s.reasoning != "" || s.reasoningSummary != "" {

--- a/inference/invoke_test.go
+++ b/inference/invoke_test.go
@@ -59,7 +59,7 @@ func TestInvoke_streamsMessageAndMapsDeveloperToSystem(t *testing.T) {
 		}),
 	}
 
-	ch, err := s.Invoke(context.Background(), msgs, tools)
+	ch, err := s.Invoke(context.Background(), msgs, tools, "")
 	if err != nil {
 		t.Fatalf("Invoke: %v", err)
 	}
@@ -189,7 +189,7 @@ func TestInvoke_contextCancel_stopsStream(t *testing.T) {
 		WithURL(srv.URL)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	ch, err := s.Invoke(ctx, []*tacklr.Message{{Role: tacklr.RoleUser, Content: "hi"}}, nil)
+	ch, err := s.Invoke(ctx, []*tacklr.Message{{Role: tacklr.RoleUser, Content: "hi"}}, nil, "")
 	if err != nil {
 		t.Fatalf("Invoke: %v", err)
 	}
@@ -234,7 +234,7 @@ func TestInvoke_apiError_emitsErrorChunk(t *testing.T) {
 
 	ch, err := s.Invoke(context.Background(), []*tacklr.Message{
 		{Role: tacklr.RoleUser, Content: "hi"},
-	}, nil)
+	}, nil, "")
 	if err != nil {
 		t.Fatalf("Invoke sync err: %v", err)
 	}

--- a/internal/agentbench/runner.go
+++ b/internal/agentbench/runner.go
@@ -214,8 +214,11 @@ func runCase(ctx context.Context, cfg Config, c Case, exa string) CaseResult {
 		}
 	}
 
-	agent := tacklr.NewAgent(caseCtx, agentOpts())
 	var turns []TurnTrace
+	agent, err := tacklr.NewAgent(caseCtx, agentOpts())
+	if err != nil {
+		return failResult(c, turns, "construct agent: "+err.Error())
+	}
 	for i, prompt := range c.Turns {
 		if c.RestoreSession && i == len(c.Turns)-1 && i > 0 {
 			loaded, err := tacklr.NewAgentFromSession(caseCtx, sessionID, agentOpts())

--- a/internal/session/checkpointer.go
+++ b/internal/session/checkpointer.go
@@ -36,6 +36,13 @@ func (Checkpointer) Capture(
 	if err != nil {
 		return nil, err
 	}
+	if sm.Search() != nil {
+		raw, err := sm.Search().Export()
+		if err != nil {
+			return nil, fmt.Errorf("checkpointer: export search context: %w", err)
+		}
+		cp.State.SearchContext = raw
+	}
 	return cp, nil
 }
 
@@ -54,6 +61,11 @@ func (Checkpointer) Apply(cp stores.SessionCheckpoint, sm *SessionManager) (Appl
 		return AppliedCheckpoint{}, fmt.Errorf("checkpointer: session manager is nil")
 	}
 	sm.LoadUserAndPlanState(cp.State.RuntimeState)
+	if len(cp.State.SearchContext) > 0 {
+		if err := sm.Search().Restore(cp.State.SearchContext); err != nil {
+			return AppliedCheckpoint{}, fmt.Errorf("checkpointer: restore search context: %w", err)
+		}
+	}
 	if err := sm.LoadInterruptsJSON(cp.State.PendingInterrupts, cp.State.ResolvedInterrupts); err != nil {
 		return AppliedCheckpoint{}, err
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -5,24 +5,30 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/google/uuid"
+
+	"github.com/ryanaldo34/tacklr/brain"
 	"github.com/ryanaldo34/tacklr/interrupt"
 	"github.com/ryanaldo34/tacklr/vfs"
 )
 
 // SessionManager owns durable and live data for one agent harness thread
 // (checkpoint id), not an ACP client session id: plan, user tool state,
-// interrupts, and the optional virtual filesystem mount table.
-// Knowledge namespace + ResultSet live on brain.SearchContext.
-// Builtins close over it; user tools use Runtime.
+// permission memory, parked workers, search context, interrupts, and the
+// optional virtual filesystem mount table.
+//
+// VFS is host-owned and attached with SetVFS. Knowledge namespace + ResultSet
+// live on Search(). Builtins close over the manager; user tools use Runtime.
 type SessionManager struct {
 	mu        sync.RWMutex
 	plan      *PlanStore
 	userState map[string]any
 	pending   interruptMap
 	resolved  interruptMap
-	// VFS is a borrowed host-owned mount table (AgentOptions.MountSession).
-	// Nil when unused. The harness does not create, persist, or close it.
-	VFS *vfs.MountSession
+	perms     *permissionBag
+	parks     *parkBag
+	search    *brain.SearchContext
+	vfs       *vfs.MountSession
 }
 
 // NewSessionManager returns an empty manager ready for use.
@@ -32,31 +38,14 @@ func NewSessionManager() *SessionManager {
 		userState: map[string]any{},
 		pending:   interruptMap{},
 		resolved:  interruptMap{},
-	}
-}
-
-func (s *SessionManager) ensure() {
-	if s.plan == nil {
-		s.plan = NewPlanStore()
-	}
-	if s.userState == nil {
-		s.userState = map[string]any{}
-	}
-	if s.pending == nil {
-		s.pending = interruptMap{}
-	}
-	if s.resolved == nil {
-		s.resolved = interruptMap{}
+		perms:     newPermissionBag(),
+		parks:     newParkBag(),
+		search:    brain.NewSearchContext(),
 	}
 }
 
 // Plan returns the plan module. Never nil after NewSessionManager.
 func (s *SessionManager) Plan() *PlanStore {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.plan == nil {
-		s.plan = NewPlanStore()
-	}
 	return s.plan
 }
 
@@ -65,7 +54,35 @@ func (s *SessionManager) HasActivePlan() bool {
 	return s.Plan().HasActive()
 }
 
-// --- user State bag (facade target for Runtime.StateGet/Set) ---
+// Search returns the knowledge retrieval session (namespace + ResultSet).
+func (s *SessionManager) Search() *brain.SearchContext {
+	return s.search
+}
+
+// SetSearch replaces the search context. Nil resets to an empty context.
+func (s *SessionManager) SetSearch(sc *brain.SearchContext) {
+	if sc == nil {
+		sc = brain.NewSearchContext()
+	}
+	s.search = sc
+}
+
+// VFS returns the host-owned mount table, or nil.
+func (s *SessionManager) VFS() *vfs.MountSession {
+	if s == nil {
+		return nil
+	}
+	return s.vfs
+}
+
+// SetVFS attaches a host-owned mount table. The harness does not create,
+// persist, or close it.
+func (s *SessionManager) SetVFS(ms *vfs.MountSession) {
+	if s == nil {
+		return
+	}
+	s.vfs = ms
+}
 
 // StateGet returns a host/tool state value without a turn Runtime.
 func (s *SessionManager) StateGet(key string) (any, bool) {
@@ -73,8 +90,9 @@ func (s *SessionManager) StateGet(key string) (any, bool) {
 }
 
 // StateSet stores a host/tool state value without a turn Runtime.
-func (s *SessionManager) StateSet(key string, value any) {
-	s.stateSet(key, value)
+// Reserved module keys return an error.
+func (s *SessionManager) StateSet(key string, value any) error {
+	return s.stateSet(key, value)
 }
 
 // StateDelete removes a host/tool state value without a turn Runtime.
@@ -97,16 +115,14 @@ func (s *SessionManager) stateGet(key string) (any, bool) {
 	return v, ok
 }
 
-func (s *SessionManager) stateSet(key string, value any) {
+func (s *SessionManager) stateSet(key string, value any) error {
 	if IsReservedRuntimeStateKey(key) {
-		return
+		return fmt.Errorf("session: reserved state key %q cannot be set", key)
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.userState == nil {
-		s.userState = map[string]any{}
-	}
 	s.userState[key] = value
+	return nil
 }
 
 func (s *SessionManager) stateDelete(key string) {
@@ -117,8 +133,6 @@ func (s *SessionManager) stateDelete(key string) {
 	defer s.mu.Unlock()
 	delete(s.userState, key)
 }
-
-// --- interrupts (facade target for Runtime Raise/Return/…) ---
 
 // HasPendingInterrupt reports whether any interrupt is still awaiting a client payload.
 func (s *SessionManager) HasPendingInterrupt() bool {
@@ -143,7 +157,6 @@ func (s *SessionManager) ReturnInterrupt(id string, result []byte) (interrupt.In
 func (s *SessionManager) returnInterrupt(id string, result []byte) (interrupt.Interrupt, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.ensure()
 	intr, ok := s.pending[id]
 	if !ok {
 		return nil, fmt.Errorf("interrupt %q: %w", id, interrupt.ErrInterruptNotFound)
@@ -170,7 +183,6 @@ func (s *SessionManager) adoptInterrupt(toolCallID string, intr interrupt.Interr
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.ensure()
 	if resolved, ok := s.resolved[toolCallID]; ok {
 		delete(s.resolved, toolCallID)
 		return resolved, nil
@@ -200,7 +212,6 @@ func (s *SessionManager) pendingInterrupt(id string) (interrupt.Interrupt, bool)
 func (s *SessionManager) raiseInterrupt(toolCallID string, kind string, payload []byte) (interrupt.Interrupt, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.ensure()
 	if resolved, ok := s.resolved[toolCallID]; ok {
 		delete(s.resolved, toolCallID)
 		return resolved, nil
@@ -218,10 +229,10 @@ func (s *SessionManager) raiseInterrupt(toolCallID string, kind string, payload 
 	return nil, intr
 }
 
-// SnapshotDurable copies user state, plan modules, and interrupt maps for
+// SnapshotDurable copies user state, session modules, and interrupt maps for
 // checkpointing. Interrupts are deep-cloned so marshal does not race live maps.
-// Reserved plan keys in userState are never exported as user keys; plan is
-// written via PlanStore.ExportInto.
+// Reserved keys in userState are never exported as user keys; modules write
+// their own reserved keys via ExportInto.
 func (s *SessionManager) SnapshotDurable() (runtimeState map[string]any, pending, resolved interruptMap) {
 	s.mu.RLock()
 	runtimeState = make(map[string]any, len(s.userState))
@@ -244,24 +255,32 @@ func (s *SessionManager) SnapshotDurable() (runtimeState map[string]any, pending
 		}
 	}
 	plan := s.plan
+	perms := s.perms
+	parks := s.parks
 	s.mu.RUnlock()
 
-	if plan != nil {
-		plan.ExportInto(runtimeState)
-	}
+	plan.ExportInto(runtimeState)
+	perms.exportInto(runtimeState)
+	parks.exportInto(runtimeState)
 	return runtimeState, pending, resolved
 }
 
-// LoadUserAndPlanState hydrates user State and plan from checkpoint RuntimeState.
-// Reserved keys (including legacy _search_namespace) are not left as user keys.
+// LoadUserAndPlanState hydrates user State and session modules from checkpoint
+// RuntimeState. Reserved keys (including legacy _search_namespace) are not
+// left as user keys. A string _search_namespace restores Search().
 func (s *SessionManager) LoadUserAndPlanState(state map[string]any) {
-	s.ensure()
 	s.plan.LoadFromState(state)
+	s.perms.loadFromState(state)
+	s.parks.loadFromState(state)
+	if raw, ok := state[searchNamespaceStateKey]; ok {
+		if ns, ok := raw.(string); ok && ns != "" {
+			if id, err := uuid.Parse(ns); err == nil {
+				s.search.SetNamespace(id)
+			}
+		}
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.userState == nil {
-		s.userState = map[string]any{}
-	}
 	for k, v := range state {
 		if IsReservedRuntimeStateKey(k) {
 			continue
@@ -274,7 +293,6 @@ func (s *SessionManager) LoadUserAndPlanState(state map[string]any) {
 func (s *SessionManager) LoadInterruptsJSON(pendingJSON, resolvedJSON []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.ensure()
 	if len(pendingJSON) > 0 {
 		if err := json.Unmarshal(pendingJSON, &s.pending); err != nil {
 			return fmt.Errorf("unmarshal pending interrupts: %w", err)

--- a/internal/session/modules_test.go
+++ b/internal/session/modules_test.go
@@ -25,6 +25,17 @@ func drainRuntime(sm *session.SessionManager) session.Runtime {
 // Capture → JSON wire → Apply on a fresh manager.
 func TestSessionModules_surviveCheckpoint(t *testing.T) {
 	sm := session.NewSessionManager()
+	sm.LoadUserAndPlanState(map[string]any{
+		"_parked_workers":          "not-a-map",
+		"_permission_always_allow": 42,
+		"_permission_always_deny":  []any{"x"},
+		"_search_namespace":        "not-a-uuid",
+		"keep":                     "user",
+	})
+	if v, ok := sm.StateGet("keep"); !ok || v != "user" {
+		t.Fatalf("user key after malformed bags: %v ok=%v", v, ok)
+	}
+
 	rt := drainRuntime(sm).WithToolCallID("spawn_1")
 	if rt.CurrentToolCallID() != "spawn_1" {
 		t.Fatalf("CurrentToolCallID=%q", rt.CurrentToolCallID())
@@ -122,80 +133,6 @@ func TestSessionModules_surviveCheckpoint(t *testing.T) {
 	gotFresh, ok := sm2.Search().Namespace()
 	if !ok || gotFresh != fresh {
 		t.Fatalf("SetSearch(nil) must yield a usable empty context, got %v ok=%v", gotFresh, ok)
-	}
-}
-
-// TestSessionManager_interruptFacade_raiseReturnClear is the session-scoped
-// interrupt outcome without a turn Runtime: pending → return → clear.
-func TestSessionManager_interruptFacade_raiseReturnClear(t *testing.T) {
-	sm := session.NewSessionManager()
-	rt := drainRuntime(sm).WithToolCallID("choice")
-	_, err := rt.RaiseInterrupt("user_selection_choice", []byte(`[{"title":"Yes"}]`))
-	if err == nil {
-		t.Fatal("raise parks as error")
-	}
-	if _, ok := sm.PendingInterrupt("choice"); !ok {
-		t.Fatal("PendingInterrupt after raise")
-	}
-
-	got, err := sm.ReturnInterrupt("choice", []byte(`{"selectionIdx":0}`))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got == nil {
-		t.Fatal("ReturnInterrupt must yield the resolved interrupt")
-	}
-
-	sm.ClearInterrupts()
-	rt = rt.WithToolCallID("perm")
-	_, err = rt.RaiseInterrupt("tool_permission", []byte(`{"toolName":"rm"}`))
-	if err == nil {
-		t.Fatal("after ClearInterrupts a new raise must park")
-	}
-	if _, ok := sm.PendingInterrupt("perm"); !ok {
-		t.Fatal("new raise after clear must be pending")
-	}
-}
-
-// TestSessionModules_malformedBags_sessionStillUsable is the recover-from-wire
-// outcome: corrupt reserved bags load as empty, then new grants and parks persist.
-func TestSessionModules_malformedBags_sessionStillUsable(t *testing.T) {
-	sm := session.NewSessionManager()
-	sm.LoadUserAndPlanState(map[string]any{
-		"_parked_workers":          "not-a-map",
-		"_permission_always_allow": 42,
-		"_permission_always_deny":  []any{"x"},
-		"_search_namespace":        "not-a-uuid",
-		"keep":                     "user",
-	})
-	if v, ok := sm.StateGet("keep"); !ok || v != "user" {
-		t.Fatalf("user key after malformed bags: %v ok=%v", v, ok)
-	}
-
-	rt := drainRuntime(sm)
-	rt.RememberPermissionAllow("ok_tool")
-	sm.SetParkedWorker("w1", session.ParkedWorkerMeta{WorkerName: "analyst", Task: "review"})
-	ns := uuid.New()
-	sm.Search().SetNamespace(ns)
-
-	cp, err := session.NewCheckpointer().Capture(nil, sm, nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	sm2 := session.NewSessionManager()
-	if _, err := session.NewCheckpointer().Apply(*cp, sm2); err != nil {
-		t.Fatal(err)
-	}
-	if !sm2.PermissionAlwaysAllowed("ok_tool") {
-		t.Fatal("grant after malformed load must persist")
-	}
-	got, ok := sm2.ParkedWorker("w1")
-	if !ok || got.WorkerName != "analyst" {
-		t.Fatalf("park after malformed load = %+v ok=%v", got, ok)
-	}
-	gotNS, ok := sm2.Search().Namespace()
-	if !ok || gotNS != ns {
-		t.Fatalf("namespace after malformed load %v ok=%v", gotNS, ok)
 	}
 }
 

--- a/internal/session/modules_test.go
+++ b/internal/session/modules_test.go
@@ -1,0 +1,216 @@
+package session_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/ryanaldo34/tacklr/internal/session"
+	"github.com/ryanaldo34/tacklr/streaming"
+	"github.com/ryanaldo34/tacklr/vfs"
+)
+
+func drainRuntime(sm *session.SessionManager) session.Runtime {
+	ch := make(chan streaming.StreamEvent, 8)
+	go func() {
+		for range ch {
+		}
+	}()
+	return session.NewRuntime(ch, sm)
+}
+
+// TestSessionModules_surviveCheckpoint is the durable-module outcome: permission
+// memory, parked workers, search namespace, and a host VFS pointer survive
+// Capture → JSON wire → Apply on a fresh manager.
+func TestSessionModules_surviveCheckpoint(t *testing.T) {
+	sm := session.NewSessionManager()
+	rt := drainRuntime(sm).WithToolCallID("spawn_1")
+	if rt.CurrentToolCallID() != "spawn_1" {
+		t.Fatalf("CurrentToolCallID=%q", rt.CurrentToolCallID())
+	}
+
+	rt.RememberPermissionAllow("crm_write")
+	rt.RememberPermissionDeny("crm_delete")
+	if !rt.PermissionAlwaysAllowed("crm_write") || !sm.PermissionAlwaysAllowed("crm_write") {
+		t.Fatal("allow-always not visible on Runtime and SessionManager")
+	}
+	if !rt.PermissionAlwaysDenied("crm_delete") || !sm.PermissionAlwaysDenied("crm_delete") {
+		t.Fatal("deny-always not visible on Runtime and SessionManager")
+	}
+
+	sm.SetParkedWorker("spawn_1", session.ParkedWorkerMeta{
+		WorkerName:        "researcher",
+		WorkerSessionID:   "sess/w/researcher/spawn_1",
+		Task:              "summarize the deal",
+		ChildInterruptIDs: []string{"child-1"},
+	})
+	meta, ok := sm.ParkedWorker("spawn_1")
+	if !ok || meta.WorkerName != "researcher" || meta.Task != "summarize the deal" {
+		t.Fatalf("parked = %+v ok=%v", meta, ok)
+	}
+
+	ns := uuid.New()
+	sm.Search().SetNamespace(ns)
+
+	reg := vfs.NewBackendRegistry()
+	ms, err := vfs.NewMountSession("sess-modules", reg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sm.SetVFS(ms)
+	if sm.VFS() != ms {
+		t.Fatal("SetVFS/VFS must return the host mount table")
+	}
+
+	cp, err := session.NewCheckpointer().Capture(
+		[]*streaming.Message{{Role: streaming.RoleUser, Content: "go"}},
+		sm, nil, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cp.State.SearchContext) == 0 {
+		t.Fatal("checkpoint must include search context")
+	}
+
+	// In-process Apply: typed park/permission maps + SearchContext blob.
+	smTyped := session.NewSessionManager()
+	if _, err := session.NewCheckpointer().Apply(*cp, smTyped); err != nil {
+		t.Fatal(err)
+	}
+	assertModules(t, smTyped, ns, "spawn_1", "researcher")
+
+	// JSON wire: typed bags become map[string]any / []any.
+	rawState, err := json.Marshal(cp.State.RuntimeState)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(rawState, &wire); err != nil {
+		t.Fatal(err)
+	}
+	cp.State.RuntimeState = wire
+
+	sm2 := session.NewSessionManager()
+	if _, err := session.NewCheckpointer().Apply(*cp, sm2); err != nil {
+		t.Fatal(err)
+	}
+	assertModules(t, sm2, ns, "spawn_1", "researcher")
+
+	sm2.DeleteParkedWorker("spawn_1")
+	sm2.SetParkedWorker("spawn_2", session.ParkedWorkerMeta{WorkerName: "writer", Task: "draft"})
+	cp2, err := session.NewCheckpointer().Capture(nil, sm2, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sm3 := session.NewSessionManager()
+	if _, err := session.NewCheckpointer().Apply(*cp2, sm3); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := sm3.ParkedWorker("spawn_1"); ok {
+		t.Fatal("deleted park must not reload")
+	}
+	got2, ok := sm3.ParkedWorker("spawn_2")
+	if !ok || got2.WorkerName != "writer" {
+		t.Fatalf("replacement park = %+v ok=%v", got2, ok)
+	}
+
+	fresh := uuid.New()
+	sm2.SetSearch(nil)
+	sm2.Search().SetNamespace(fresh)
+	gotFresh, ok := sm2.Search().Namespace()
+	if !ok || gotFresh != fresh {
+		t.Fatalf("SetSearch(nil) must yield a usable empty context, got %v ok=%v", gotFresh, ok)
+	}
+}
+
+// TestSessionManager_interruptFacade_raiseReturnClear is the session-scoped
+// interrupt outcome without a turn Runtime: pending → return → clear.
+func TestSessionManager_interruptFacade_raiseReturnClear(t *testing.T) {
+	sm := session.NewSessionManager()
+	rt := drainRuntime(sm).WithToolCallID("choice")
+	_, err := rt.RaiseInterrupt("user_selection_choice", []byte(`[{"title":"Yes"}]`))
+	if err == nil {
+		t.Fatal("raise parks as error")
+	}
+	if _, ok := sm.PendingInterrupt("choice"); !ok {
+		t.Fatal("PendingInterrupt after raise")
+	}
+
+	got, err := sm.ReturnInterrupt("choice", []byte(`{"selectionIdx":0}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("ReturnInterrupt must yield the resolved interrupt")
+	}
+
+	sm.ClearInterrupts()
+	rt = rt.WithToolCallID("perm")
+	_, err = rt.RaiseInterrupt("tool_permission", []byte(`{"toolName":"rm"}`))
+	if err == nil {
+		t.Fatal("after ClearInterrupts a new raise must park")
+	}
+	if _, ok := sm.PendingInterrupt("perm"); !ok {
+		t.Fatal("new raise after clear must be pending")
+	}
+}
+
+// TestSessionModules_malformedBags_sessionStillUsable is the recover-from-wire
+// outcome: corrupt reserved bags load as empty, then new grants and parks persist.
+func TestSessionModules_malformedBags_sessionStillUsable(t *testing.T) {
+	sm := session.NewSessionManager()
+	sm.LoadUserAndPlanState(map[string]any{
+		"_parked_workers":          "not-a-map",
+		"_permission_always_allow": 42,
+		"_permission_always_deny":  []any{"x"},
+		"_search_namespace":        "not-a-uuid",
+		"keep":                     "user",
+	})
+	if v, ok := sm.StateGet("keep"); !ok || v != "user" {
+		t.Fatalf("user key after malformed bags: %v ok=%v", v, ok)
+	}
+
+	rt := drainRuntime(sm)
+	rt.RememberPermissionAllow("ok_tool")
+	sm.SetParkedWorker("w1", session.ParkedWorkerMeta{WorkerName: "analyst", Task: "review"})
+	ns := uuid.New()
+	sm.Search().SetNamespace(ns)
+
+	cp, err := session.NewCheckpointer().Capture(nil, sm, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sm2 := session.NewSessionManager()
+	if _, err := session.NewCheckpointer().Apply(*cp, sm2); err != nil {
+		t.Fatal(err)
+	}
+	if !sm2.PermissionAlwaysAllowed("ok_tool") {
+		t.Fatal("grant after malformed load must persist")
+	}
+	got, ok := sm2.ParkedWorker("w1")
+	if !ok || got.WorkerName != "analyst" {
+		t.Fatalf("park after malformed load = %+v ok=%v", got, ok)
+	}
+	gotNS, ok := sm2.Search().Namespace()
+	if !ok || gotNS != ns {
+		t.Fatalf("namespace after malformed load %v ok=%v", gotNS, ok)
+	}
+}
+
+func assertModules(t *testing.T, sm *session.SessionManager, ns uuid.UUID, parkID, worker string) {
+	t.Helper()
+	rt := drainRuntime(sm)
+	if !rt.PermissionAlwaysAllowed("crm_write") || !rt.PermissionAlwaysDenied("crm_delete") {
+		t.Fatal("permission memory must reload")
+	}
+	got, ok := sm.ParkedWorker(parkID)
+	if !ok || got.WorkerName != worker || got.WorkerSessionID != "sess/w/researcher/spawn_1" {
+		t.Fatalf("park reload = %+v ok=%v", got, ok)
+	}
+	gotNS, ok := sm.Search().Namespace()
+	if !ok || gotNS != ns {
+		t.Fatalf("search namespace %v ok=%v want %v", gotNS, ok, ns)
+	}
+}

--- a/internal/session/park.go
+++ b/internal/session/park.go
@@ -1,0 +1,111 @@
+package session
+
+import (
+	"encoding/json"
+	"sync"
+)
+
+const parkedWorkersStateKey = "_parked_workers"
+
+// ParkedWorkerMeta is durable park metadata for a spawn_worker tool call.
+// Live harness pointers are not stored here.
+type ParkedWorkerMeta struct {
+	WorkerName        string   `json:"workerName"`
+	WorkerSessionID   string   `json:"workerSessionId"`
+	Task              string   `json:"task"`
+	ChildInterruptIDs []string `json:"childInterruptIds"`
+}
+
+type parkBag struct {
+	mu   sync.RWMutex
+	byID map[string]ParkedWorkerMeta
+}
+
+func newParkBag() *parkBag {
+	return &parkBag{byID: map[string]ParkedWorkerMeta{}}
+}
+
+func (p *parkBag) get(id string) (ParkedWorkerMeta, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	m, ok := p.byID[id]
+	return m, ok
+}
+
+func (p *parkBag) set(id string, meta ParkedWorkerMeta) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.byID[id] = meta
+}
+
+func (p *parkBag) delete(id string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.byID, id)
+}
+
+func (p *parkBag) clone() map[string]ParkedWorkerMeta {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make(map[string]ParkedWorkerMeta, len(p.byID))
+	for k, v := range p.byID {
+		out[k] = v
+	}
+	return out
+}
+
+func (p *parkBag) replace(m map[string]ParkedWorkerMeta) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.byID = m
+	if p.byID == nil {
+		p.byID = map[string]ParkedWorkerMeta{}
+	}
+}
+
+func (p *parkBag) exportInto(state map[string]any) {
+	cp := p.clone()
+	if len(cp) == 0 {
+		delete(state, parkedWorkersStateKey)
+		return
+	}
+	state[parkedWorkersStateKey] = cp
+}
+
+func (p *parkBag) loadFromState(state map[string]any) {
+	raw, ok := state[parkedWorkersStateKey]
+	if !ok || raw == nil {
+		p.replace(nil)
+		return
+	}
+	if m, ok := raw.(map[string]ParkedWorkerMeta); ok {
+		p.replace(m)
+		return
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		p.replace(nil)
+		return
+	}
+	var m map[string]ParkedWorkerMeta
+	if json.Unmarshal(b, &m) != nil || m == nil {
+		p.replace(nil)
+		return
+	}
+	p.replace(m)
+}
+
+// ParkedWorker returns durable park metadata for a spawn_worker tool call.
+func (s *SessionManager) ParkedWorker(toolCallID string) (ParkedWorkerMeta, bool) {
+	return s.parks.get(toolCallID)
+}
+
+// SetParkedWorker stores durable park metadata for a spawn_worker tool call.
+func (s *SessionManager) SetParkedWorker(toolCallID string, meta ParkedWorkerMeta) {
+	s.parks.set(toolCallID, meta)
+}
+
+// DeleteParkedWorker removes durable park metadata for a spawn_worker tool call.
+func (s *SessionManager) DeleteParkedWorker(toolCallID string) {
+	s.parks.delete(toolCallID)
+}

--- a/internal/session/permissions.go
+++ b/internal/session/permissions.go
@@ -1,0 +1,128 @@
+package session
+
+import (
+	"encoding/json"
+	"sync"
+)
+
+const (
+	permissionAllowKey = "_permission_always_allow"
+	permissionDenyKey  = "_permission_always_deny"
+)
+
+type permissionBag struct {
+	mu    sync.RWMutex
+	allow map[string]bool
+	deny  map[string]bool
+}
+
+func newPermissionBag() *permissionBag {
+	return &permissionBag{
+		allow: map[string]bool{},
+		deny:  map[string]bool{},
+	}
+}
+
+func (p *permissionBag) has(set map[string]bool, name string) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return set[name]
+}
+
+func (p *permissionBag) remember(set map[string]bool, name string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	set[name] = true
+}
+
+func (p *permissionBag) alwaysAllowed(name string) bool {
+	return p.has(p.allow, name)
+}
+
+func (p *permissionBag) alwaysDenied(name string) bool {
+	return p.has(p.deny, name)
+}
+
+func (p *permissionBag) rememberAllow(name string) {
+	p.remember(p.allow, name)
+}
+
+func (p *permissionBag) rememberDeny(name string) {
+	p.remember(p.deny, name)
+}
+
+func cloneBoolSet(m map[string]bool) map[string]bool {
+	out := make(map[string]bool, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func decodeBoolSet(raw any) map[string]bool {
+	if m, ok := raw.(map[string]bool); ok && m != nil {
+		return cloneBoolSet(m)
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return map[string]bool{}
+	}
+	var m map[string]bool
+	if json.Unmarshal(b, &m) != nil || m == nil {
+		return map[string]bool{}
+	}
+	return m
+}
+
+func (p *permissionBag) exportInto(state map[string]any) {
+	p.mu.RLock()
+	allow := cloneBoolSet(p.allow)
+	deny := cloneBoolSet(p.deny)
+	p.mu.RUnlock()
+	if len(allow) == 0 {
+		delete(state, permissionAllowKey)
+	} else {
+		state[permissionAllowKey] = allow
+	}
+	if len(deny) == 0 {
+		delete(state, permissionDenyKey)
+	} else {
+		state[permissionDenyKey] = deny
+	}
+}
+
+func (p *permissionBag) loadFromState(state map[string]any) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.allow = map[string]bool{}
+	p.deny = map[string]bool{}
+	if state == nil {
+		return
+	}
+	if raw, ok := state[permissionAllowKey]; ok && raw != nil {
+		p.allow = decodeBoolSet(raw)
+	}
+	if raw, ok := state[permissionDenyKey]; ok && raw != nil {
+		p.deny = decodeBoolSet(raw)
+	}
+}
+
+// PermissionAlwaysAllowed reports whether toolName was granted allow-always.
+func (s *SessionManager) PermissionAlwaysAllowed(toolName string) bool {
+	return s.perms.alwaysAllowed(toolName)
+}
+
+// PermissionAlwaysDenied reports whether toolName was granted reject-always.
+func (s *SessionManager) PermissionAlwaysDenied(toolName string) bool {
+	return s.perms.alwaysDenied(toolName)
+}
+
+// RememberPermissionAllow records allow-always for toolName.
+func (s *SessionManager) RememberPermissionAllow(toolName string) {
+	s.perms.rememberAllow(toolName)
+}
+
+// RememberPermissionDeny records reject-always for toolName.
+func (s *SessionManager) RememberPermissionDeny(toolName string) {
+	s.perms.rememberDeny(toolName)
+}

--- a/internal/session/plan.go
+++ b/internal/session/plan.go
@@ -14,10 +14,12 @@ const (
 	searchNamespaceStateKey = "_search_namespace"
 )
 
-// IsReservedRuntimeStateKey reports keys owned by SessionManager export.
+// IsReservedRuntimeStateKey reports keys owned by SessionManager modules.
 func IsReservedRuntimeStateKey(key string) bool {
 	switch key {
-	case planStateKey, planDocumentStateKey, planDocumentUpdatedKey, searchNamespaceStateKey:
+	case planStateKey, planDocumentStateKey, planDocumentUpdatedKey,
+		searchNamespaceStateKey, parkedWorkersStateKey,
+		permissionAllowKey, permissionDenyKey:
 		return true
 	default:
 		return false
@@ -26,6 +28,7 @@ func IsReservedRuntimeStateKey(key string) bool {
 
 // PlanStore holds the plan document and todo list for Adaptive Case Management.
 // It is a SessionManager module — not exposed on HarnessRuntime.
+// After NewPlanStore / NewSessionManager the receiver is never nil.
 type PlanStore struct {
 	mu              sync.RWMutex
 	todos           []Todo
@@ -40,9 +43,6 @@ func NewPlanStore() *PlanStore {
 
 // HasActive reports whether a todo list is present (write-lock unlock condition).
 func (p *PlanStore) HasActive() bool {
-	if p == nil {
-		return false
-	}
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return len(p.todos) > 0
@@ -51,9 +51,6 @@ func (p *PlanStore) HasActive() bool {
 // Get returns a shallow copy of the current todos, or nil if no plan was ever set.
 // An empty non-nil slice means an explicit empty plan (e.g. after deleting all todos).
 func (p *PlanStore) Get() []Todo {
-	if p == nil {
-		return nil
-	}
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	if p.todos == nil {
@@ -67,9 +64,6 @@ func (p *PlanStore) Get() []Todo {
 // Set replaces the todo list (caller should emit StreamEventPlanUpdate separately).
 // Pass nil to clear the plan entirely; pass a non-nil empty slice for an empty plan.
 func (p *PlanStore) Set(todos []Todo) {
-	if p == nil {
-		return
-	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if todos == nil {
@@ -83,9 +77,6 @@ func (p *PlanStore) Set(todos []Todo) {
 
 // Document returns the plaintext project plan draft.
 func (p *PlanStore) Document() string {
-	if p == nil {
-		return ""
-	}
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return p.document
@@ -95,9 +86,6 @@ func (p *PlanStore) Document() string {
 // Marks the document updated only when replacing an existing draft with different
 // text (edits), not on the initial install from create_plan.
 func (p *PlanStore) SetDocument(plan string) {
-	if p == nil {
-		return
-	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	prev := p.document
@@ -110,9 +98,6 @@ func (p *PlanStore) SetDocument(plan string) {
 // ConsumeDocumentUpdated returns whether the plan document was updated since the
 // last consume, and clears the flag.
 func (p *PlanStore) ConsumeDocumentUpdated() bool {
-	if p == nil {
-		return false
-	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if !p.documentUpdated {
@@ -126,12 +111,6 @@ func (p *PlanStore) ConsumeDocumentUpdated() bool {
 // Overwrites reserved keys with the current PlanStore contents.
 func (p *PlanStore) ExportInto(state map[string]any) {
 	if state == nil {
-		return
-	}
-	if p == nil {
-		delete(state, planStateKey)
-		delete(state, planDocumentStateKey)
-		delete(state, planDocumentUpdatedKey)
 		return
 	}
 	p.mu.RLock()
@@ -158,7 +137,7 @@ func (p *PlanStore) ExportInto(state map[string]any) {
 // LoadFromState hydrates the store from checkpoint RuntimeState (including
 // JSON-rehydrated []any / map shapes). Safe to call with nil state.
 func (p *PlanStore) LoadFromState(state map[string]any) {
-	if p == nil || state == nil {
+	if state == nil {
 		return
 	}
 	p.mu.Lock()
@@ -173,7 +152,6 @@ func (p *PlanStore) LoadFromState(state map[string]any) {
 			copy(cp, plan)
 			p.todos = cp
 		} else {
-			// Checkpoint reload: rehydrate from JSON-compatible types.
 			b, err := json.Marshal(v)
 			if err == nil {
 				var plan []Todo
@@ -191,8 +169,8 @@ func (p *PlanStore) LoadFromState(state map[string]any) {
 	}
 }
 
-// StripPlanKeys removes reserved plan keys from a runtime state map so they are
-// not exposed via user-facing StateGet after load.
+// StripPlanKeys removes reserved module keys from a runtime state map so they
+// are not exposed via user-facing StateGet after load.
 func StripPlanKeys(state map[string]any) {
 	if state == nil {
 		return
@@ -201,4 +179,7 @@ func StripPlanKeys(state map[string]any) {
 	delete(state, planDocumentStateKey)
 	delete(state, planDocumentUpdatedKey)
 	delete(state, searchNamespaceStateKey)
+	delete(state, parkedWorkersStateKey)
+	delete(state, permissionAllowKey)
+	delete(state, permissionDenyKey)
 }

--- a/internal/session/runtime.go
+++ b/internal/session/runtime.go
@@ -4,12 +4,11 @@ import (
 	"encoding/json"
 
 	"github.com/ryanaldo34/tacklr/interrupt"
-	"github.com/ryanaldo34/tacklr/stores"
 	"github.com/ryanaldo34/tacklr/streaming"
 )
 
 // Runtime is the tool-facing surface for a single harness turn:
-// EmitUpdate, StateGet/Set/Delete, RaiseInterrupt, Store, CurrentToolCallID.
+// EmitUpdate, StateGet/Set/Delete, RaiseInterrupt, CurrentToolCallID.
 //
 // Lifetime: create with NewRuntime at Run start (with the turn event channel);
 // discard when the turn ends. Session state lives on SessionManager and outlives
@@ -17,27 +16,34 @@ import (
 //
 // Invariants: out and session are always non-nil after NewRuntime.
 type Runtime struct {
-	Store             stores.BaseStore
-	CurrentToolCallID string
-
-	session *SessionManager
-	out     chan streaming.StreamEvent
+	session    *SessionManager
+	out        chan streaming.StreamEvent
+	toolCallID string
 }
 
 // NewRuntime builds a turn-scoped Runtime. ch and sm must be non-nil.
-func NewRuntime(ch chan streaming.StreamEvent, store stores.BaseStore, sm *SessionManager) Runtime {
+func NewRuntime(ch chan streaming.StreamEvent, sm *SessionManager) Runtime {
 	if ch == nil {
 		panic("session.NewRuntime: nil event channel")
 	}
 	if sm == nil {
 		panic("session.NewRuntime: nil SessionManager")
 	}
-	sm.ensure()
 	return Runtime{
-		Store:   store,
 		session: sm,
 		out:     ch,
 	}
+}
+
+// WithToolCallID returns a copy bound to the given tool call id.
+func (rt Runtime) WithToolCallID(id string) Runtime {
+	rt.toolCallID = id
+	return rt
+}
+
+// CurrentToolCallID is the tool call this Runtime is serving, or empty.
+func (rt Runtime) CurrentToolCallID() string {
+	return rt.toolCallID
 }
 
 // EmitUpdate sends a non-blocking tool progress update for the current call.
@@ -46,7 +52,7 @@ func (rt Runtime) EmitUpdate(message string) {
 	case rt.out <- streaming.StreamEvent{
 		Type:      streaming.StreamEventToolUpdate,
 		Content:   message,
-		MessageID: rt.CurrentToolCallID,
+		MessageID: rt.toolCallID,
 	}:
 	default:
 	}
@@ -70,8 +76,9 @@ func (rt Runtime) StateGet(key string) (any, bool) {
 }
 
 // StateSet stores a session value for tools and interceptors.
-func (rt Runtime) StateSet(key string, value any) {
-	rt.session.stateSet(key, value)
+// Reserved module keys return an error.
+func (rt Runtime) StateSet(key string, value any) error {
+	return rt.session.stateSet(key, value)
 }
 
 // StateDelete removes a session value.
@@ -81,12 +88,12 @@ func (rt Runtime) StateDelete(key string) {
 
 // RaiseInterrupt parks the current tool until the host resumes with a payload.
 func (rt Runtime) RaiseInterrupt(kind string, payload []byte) (interrupt.Interrupt, error) {
-	return rt.session.raiseInterrupt(rt.CurrentToolCallID, kind, payload)
+	return rt.session.raiseInterrupt(rt.toolCallID, kind, payload)
 }
 
 // AdoptInterrupt attaches a child interrupt to the current tool call.
 func (rt Runtime) AdoptInterrupt(intr interrupt.Interrupt) (interrupt.Interrupt, error) {
-	return rt.session.adoptInterrupt(rt.CurrentToolCallID, intr)
+	return rt.session.adoptInterrupt(rt.toolCallID, intr)
 }
 
 // TakeResolvedInterrupt removes and returns a resolved interrupt if present.
@@ -109,4 +116,24 @@ func (rt Runtime) ReturnInterrupt(id string, result []byte) (interrupt.Interrupt
 // Prefer SessionManager.HasPendingInterrupt when no turn Runtime is in hand.
 func (rt Runtime) HasPendingInterrupt() bool {
 	return rt.session.HasPendingInterrupt()
+}
+
+// PermissionAlwaysAllowed reports whether toolName was granted allow-always.
+func (rt Runtime) PermissionAlwaysAllowed(toolName string) bool {
+	return rt.session.PermissionAlwaysAllowed(toolName)
+}
+
+// PermissionAlwaysDenied reports whether toolName was granted reject-always.
+func (rt Runtime) PermissionAlwaysDenied(toolName string) bool {
+	return rt.session.PermissionAlwaysDenied(toolName)
+}
+
+// RememberPermissionAllow records allow-always for toolName.
+func (rt Runtime) RememberPermissionAllow(toolName string) {
+	rt.session.RememberPermissionAllow(toolName)
+}
+
+// RememberPermissionDeny records reject-always for toolName.
+func (rt Runtime) RememberPermissionDeny(toolName string) {
+	rt.session.RememberPermissionDeny(toolName)
 }

--- a/internal/session/runtime_namespace_test.go
+++ b/internal/session/runtime_namespace_test.go
@@ -11,10 +11,15 @@ import (
 // Legacy _search_namespace is reserved and never re-exported as user state.
 func TestSession_legacySearchNamespaceKey_strippedOnLoad(t *testing.T) {
 	sm := session.NewSessionManager()
+	id := uuid.New()
 	sm.LoadUserAndPlanState(map[string]any{
-		"_search_namespace": uuid.New().String(),
+		"_search_namespace": id.String(),
 		"user_key":          "v",
 	})
+	got, ok := sm.Search().Namespace()
+	if !ok || got != id {
+		t.Fatalf("legacy key must restore Search namespace, got %v ok=%v", got, ok)
+	}
 	cp, err := session.NewCheckpointer().Capture(nil, sm, nil, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -24,7 +24,7 @@ func TestCheckpointer_roundTrip(t *testing.T) {
 			}
 		}()
 		return c
-	}(), nil, sm)
+	}(), sm)
 	rt.StateSet("k", "v")
 
 	cp, err := session.NewCheckpointer().Capture(
@@ -54,7 +54,7 @@ func TestCheckpointer_roundTrip(t *testing.T) {
 			}
 		}()
 		return c
-	}(), nil, sm2)
+	}(), sm2)
 	if v, ok := rt2.StateGet("k"); !ok || v != "v" {
 		t.Fatalf("state %v %v", v, ok)
 	}
@@ -87,18 +87,6 @@ func TestCheckpointer_applyNilMaps_defaults(t *testing.T) {
 
 // TestPlanStore_lifecycle covers set/get/document/updated/export/load outcomes.
 func TestPlanStore_lifecycle(t *testing.T) {
-	var nilStore *session.PlanStore
-	if nilStore.HasActive() || nilStore.Get() != nil || nilStore.Document() != "" {
-		t.Fatal("nil plan store should be empty-safe")
-	}
-	nilStore.Set(nil)
-	nilStore.SetDocument("x")
-	if nilStore.ConsumeDocumentUpdated() {
-		t.Fatal("nil consume")
-	}
-	nilStore.ExportInto(nil)
-	nilStore.LoadFromState(nil)
-
 	p := session.NewPlanStore()
 	if p.HasActive() {
 		t.Fatal("empty has active")
@@ -168,12 +156,16 @@ func TestSessionManager_stateAndPlan_guards(t *testing.T) {
 			}
 		}()
 		return c
-	}(), nil, sm)
-	rt.StateSet("_plan", "blocked")
+	}(), sm)
+	if err := rt.StateSet("_plan", "blocked"); err == nil {
+		t.Fatal("reserved key should error on set")
+	}
 	if _, ok := rt.StateGet("_plan"); ok {
 		t.Fatal("reserved key blocked on get")
 	}
-	rt.StateSet("ok", 1)
+	if err := rt.StateSet("ok", 1); err != nil {
+		t.Fatal(err)
+	}
 	if v, ok := rt.StateGet("ok"); !ok || v != 1 {
 		t.Fatal("user state")
 	}
@@ -196,8 +188,8 @@ func TestSessionManager_stateAndPlan_guards(t *testing.T) {
 func TestRuntime_interrupts_raiseReturnAdopt(t *testing.T) {
 	sm := session.NewSessionManager()
 	ch := make(chan streaming.StreamEvent, 4)
-	rt := session.NewRuntime(ch, nil, sm)
-	rt.CurrentToolCallID = "tc1"
+	rt := session.NewRuntime(ch, sm)
+	rt = rt.WithToolCallID("tc1")
 
 	// Unknown type.
 	if _, err := rt.RaiseInterrupt("nope", nil); err == nil {
@@ -246,7 +238,7 @@ func TestRuntime_interrupts_raiseReturnAdopt(t *testing.T) {
 	}
 
 	// Raise after resolve short-circuits with resolved value (second raise path).
-	rt.CurrentToolCallID = "tc2"
+	rt = rt.WithToolCallID("tc2")
 	_, err = rt.RaiseInterrupt("user_selection_choice", []byte(`[{"title":"X"}]`))
 	if err == nil {
 		t.Fatal("park")
@@ -261,7 +253,7 @@ func TestRuntime_interrupts_raiseReturnAdopt(t *testing.T) {
 	}
 
 	// Adopt: first parks, second after resolve returns resolved.
-	rt.CurrentToolCallID = "tc3"
+	rt = rt.WithToolCallID("tc3")
 	parked := &interrupt.UserSelectionInterrupt{Options: []interrupt.UserChoice{{Title: "Z"}}}
 	_, err = rt.AdoptInterrupt(parked)
 	if err == nil {
@@ -270,11 +262,11 @@ func TestRuntime_interrupts_raiseReturnAdopt(t *testing.T) {
 	if _, err := rt.AdoptInterrupt(nil); err == nil {
 		t.Fatal("nil adopt")
 	}
-	rt.CurrentToolCallID = ""
+	rt = rt.WithToolCallID("")
 	if _, err := rt.AdoptInterrupt(parked); err == nil {
 		t.Fatal("empty tool call id")
 	}
-	rt.CurrentToolCallID = "tc3"
+	rt = rt.WithToolCallID("tc3")
 	if _, err := rt.ReturnInterrupt("tc3", []byte(`{"selectionIdx":0}`)); err != nil {
 		t.Fatal(err)
 	}
@@ -284,7 +276,7 @@ func TestRuntime_interrupts_raiseReturnAdopt(t *testing.T) {
 	}
 
 	// Tool permission raise + resolve.
-	rt.CurrentToolCallID = "perm"
+	rt = rt.WithToolCallID("perm")
 	_, err = rt.RaiseInterrupt("tool_permission", []byte(`{"toolName":"rm"}`))
 	if err == nil {
 		t.Fatal("park permission")
@@ -298,8 +290,8 @@ func TestRuntime_interrupts_raiseReturnAdopt(t *testing.T) {
 func TestRuntime_emitAndState_channels(t *testing.T) {
 	ch := make(chan streaming.StreamEvent, 2)
 	sm := session.NewSessionManager()
-	rt := session.NewRuntime(ch, nil, sm)
-	rt.CurrentToolCallID = "id1"
+	rt := session.NewRuntime(ch, sm)
+	rt = rt.WithToolCallID("id1")
 	rt.EmitUpdate("hello")
 	ev := <-ch
 	if ev.Type != streaming.StreamEventToolUpdate || ev.Content != "hello" || ev.MessageID != "id1" {
@@ -313,12 +305,14 @@ func TestRuntime_emitAndState_channels(t *testing.T) {
 
 	// Full channel drops non-blocking.
 	full := make(chan streaming.StreamEvent)
-	rtFull := session.NewRuntime(full, nil, sm)
+	rtFull := session.NewRuntime(full, sm)
 	rtFull.EmitUpdate("drop")
 	rtFull.EmitPlanUpdate(nil)
 
 	// SessionManager state without a turn bus.
-	sm.StateSet("z", true)
+	if err := sm.StateSet("z", true); err != nil {
+		t.Fatal(err)
+	}
 	if v, ok := sm.StateGet("z"); !ok || v != true {
 		t.Fatal("session state")
 	}
@@ -336,8 +330,8 @@ func TestSessionManager_snapshotLoadInterrupts_roundTrip(t *testing.T) {
 			}
 		}()
 		return c
-	}(), nil, sm)
-	rt.CurrentToolCallID = "c1"
+	}(), sm)
+	rt = rt.WithToolCallID("c1")
 	_, _ = rt.RaiseInterrupt("user_selection_choice", []byte(`[{"title":"A"}]`))
 	rt.StateSet("u", "v")
 	// reserved key should not appear as user state in snapshot
@@ -375,7 +369,7 @@ func TestSessionManager_snapshotLoadInterrupts_roundTrip(t *testing.T) {
 			}
 		}()
 		return c
-	}(), nil, sm2)
+	}(), sm2)
 	if v, ok := rt2.StateGet("u"); !ok || v != "v" {
 		t.Fatal("user state reload")
 	}
@@ -410,8 +404,8 @@ func TestInterruptMap_unknownType_errors(t *testing.T) {
 			}
 		}()
 		return c
-	}(), nil, sm)
-	rt.CurrentToolCallID = "x"
+	}(), sm)
+	rt = rt.WithToolCallID("x")
 	_, _ = rt.RaiseInterrupt("tool_permission", []byte(`{"toolName":"t"}`))
 	_, pending, _ := sm.SnapshotDurable()
 	b, err := json.Marshal(pending)

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -284,6 +284,20 @@ func TestRuntime_interrupts_raiseReturnAdopt(t *testing.T) {
 	if _, err := rt.ReturnInterrupt("perm", []byte(`{"optionId":"allow-once"}`)); err != nil {
 		t.Fatal(err)
 	}
+
+	// SessionManager facade: clear, then pending → return without a turn bus.
+	sm.ClearInterrupts()
+	rt = rt.WithToolCallID("sm1")
+	_, err = rt.RaiseInterrupt("tool_permission", []byte(`{"toolName":"ls"}`))
+	if err == nil {
+		t.Fatal("park after ClearInterrupts")
+	}
+	if _, ok := sm.PendingInterrupt("sm1"); !ok {
+		t.Fatal("PendingInterrupt after raise")
+	}
+	if _, err := sm.ReturnInterrupt("sm1", []byte(`{"optionId":"allow-once"}`)); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // TestRuntime_emitAndState_channels covers EmitUpdate/PlanUpdate non-blocking paths.

--- a/internal/testkit/model.go
+++ b/internal/testkit/model.go
@@ -25,22 +25,10 @@ type ScriptedModel struct {
 	LastInvokeTools []*tacklr.Tool
 }
 
-func (m *ScriptedModel) WithApiKey(string) tacklr.InferenceStrategy         { return m }
-func (m *ScriptedModel) WithModel(string) tacklr.InferenceStrategy          { return m }
-func (m *ScriptedModel) WithURL(string) tacklr.InferenceStrategy            { return m }
-func (m *ScriptedModel) WithReasoningLevel(string) tacklr.InferenceStrategy { return m }
-func (m *ScriptedModel) WithStructuredOutput(any) tacklr.InferenceStrategy  { return m }
 func (m *ScriptedModel) SupportsMIME(mimeType string) bool {
 	// Scripted models accept common binary types unless overridden later.
 	return true
 }
-func (m *ScriptedModel) SetSystemPrompt(p string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.SystemPrompts = append(m.SystemPrompts, p)
-}
-func (m *ScriptedModel) Reset()                       {}
-func (m *ScriptedModel) CompressContextWindow() error { return nil }
 func (m *ScriptedModel) MaxContextWindow() (int, error) {
 	return 0, nil
 }
@@ -58,7 +46,7 @@ func (m *ScriptedModel) CountTokens(ctx context.Context, msgs []*tacklr.Message,
 	return n, nil
 }
 
-func (m *ScriptedModel) Invoke(ctx context.Context, msgs []*tacklr.Message, tools []*tacklr.Tool) (chan tacklr.LLMResponseChunk, error) {
+func (m *ScriptedModel) Invoke(ctx context.Context, msgs []*tacklr.Message, tools []*tacklr.Tool, systemPrompt string) (chan tacklr.LLMResponseChunk, error) {
 	if m.InvokeErr != nil {
 		return nil, m.InvokeErr
 	}
@@ -71,6 +59,9 @@ func (m *ScriptedModel) Invoke(ctx context.Context, msgs []*tacklr.Message, tool
 	m.mu.Lock()
 	m.LastInvokeMsgs = msgs
 	m.LastInvokeTools = tools
+	if systemPrompt != "" {
+		m.SystemPrompts = append(m.SystemPrompts, systemPrompt)
+	}
 	m.mu.Unlock()
 	ch := make(chan tacklr.LLMResponseChunk)
 	go func() {

--- a/model_tasks.go
+++ b/model_tasks.go
@@ -69,18 +69,15 @@ type AbsorbResult struct {
 	SummaryChunks []LLMResponseChunk
 }
 
-// ModelTasks is Turn, Absorb, and Handoff against InferenceStrategy and ContextManager.
-type ModelTasks interface {
-	// Turn streams the next model step for the current window and tools.
+// modelTasks is Turn, Absorb, and Handoff against InferenceStrategy and ContextManager.
+type modelTasks interface {
 	Turn(ctx context.Context, tools []*Tool, systemPrompt string) (<-chan LLMResponseChunk, error)
-	// Absorb adds msg under window pressure (may summarize).
 	Absorb(ctx context.Context, msg *Message, tools []*Tool, systemPrompt string) (AbsorbResult, error)
-	// Handoff rebuilds context after complete_todo or plan edit.
 	Handoff(ctx context.Context, plan []Todo, planDoc string, tools []*Tool, systemPrompt string) error
 }
 
-// DefaultModelTasks is the product ModelTasks implementation.
-type DefaultModelTasks struct {
+// defaultModelTasks is the product modelTasks implementation.
+type defaultModelTasks struct {
 	model    InferenceStrategy
 	context  ContextManager
 	policy   ContextPolicy
@@ -90,10 +87,8 @@ type DefaultModelTasks struct {
 	countScratch []*Message // reused for progressive token counts
 }
 
-// NewDefaultModelTasks builds DefaultModelTasks for model, context, and policy.
-func NewDefaultModelTasks(model InferenceStrategy, ctx ContextManager, policy ContextPolicy, maxSize int) *DefaultModelTasks {
-	// newHarnessBase fills missing policy fields before this is called.
-	return &DefaultModelTasks{
+func newDefaultModelTasks(model InferenceStrategy, ctx ContextManager, policy ContextPolicy, maxSize int) *defaultModelTasks {
+	return &defaultModelTasks{
 		model:   model,
 		context: ctx,
 		policy:  policy,
@@ -101,22 +96,19 @@ func NewDefaultModelTasks(model InferenceStrategy, ctx ContextManager, policy Co
 	}
 }
 
-func (t *DefaultModelTasks) Turn(ctx context.Context, tools []*Tool, systemPrompt string) (<-chan LLMResponseChunk, error) {
+func (t *defaultModelTasks) Turn(ctx context.Context, tools []*Tool, systemPrompt string) (<-chan LLMResponseChunk, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 	// Context is only reshaped on Absorb pressure (token threshold) or Handoff
 	// after complete_todo / plan revision — never by dropping tool history here.
-	if systemPrompt != "" {
-		t.model.SetSystemPrompt(systemPrompt)
-	}
 	msgs := t.context.Messages()
 	t.modelSeq++
 	if src, ok := t.model.(modelIdentityProvider); ok {
 		ctx = telemetry.ContextWithModelIdentity(ctx, src.ModelTelemetryIdentity())
 	}
 	ctx, span := telemetry.StartModelSpan(ctx, telemetry.ModelPhaseTurn, t.modelSeq, windowShape(msgs))
-	ch, err := t.model.Invoke(ctx, msgs, tools)
+	ch, err := t.model.Invoke(ctx, msgs, tools, systemPrompt)
 	if err != nil {
 		span.End(err, telemetry.TokenUsage{})
 		return nil, err
@@ -124,11 +116,11 @@ func (t *DefaultModelTasks) Turn(ctx context.Context, tools []*Tool, systemPromp
 	return watchModelStream(ctx, span, ch), nil
 }
 
-func (t *DefaultModelTasks) Absorb(ctx context.Context, msg *Message, tools []*Tool, systemPrompt string) (AbsorbResult, error) {
+func (t *defaultModelTasks) Absorb(ctx context.Context, msg *Message, tools []*Tool, systemPrompt string) (AbsorbResult, error) {
 	if err := ctx.Err(); err != nil {
 		return AbsorbResult{}, err
 	}
-	window, chunks, _, err := t.absorbFit(ctx, t.context.Messages(), msg, tools, systemPrompt)
+	window, chunks, _, err := t.absorbFit(ctx, t.context.Messages(), msg, tools)
 	if err != nil {
 		return AbsorbResult{}, err
 	}
@@ -136,7 +128,7 @@ func (t *DefaultModelTasks) Absorb(ctx context.Context, msg *Message, tools []*T
 	return AbsorbResult{SummaryChunks: chunks}, nil
 }
 
-func (t *DefaultModelTasks) Handoff(ctx context.Context, plan []Todo, planDoc string, tools []*Tool, systemPrompt string) error {
+func (t *defaultModelTasks) Handoff(ctx context.Context, plan []Todo, planDoc string, tools []*Tool, systemPrompt string) error {
 	open := 0
 	for i := range plan {
 		if plan[i].Status != streaming.TodoStatusCompleted {
@@ -146,7 +138,7 @@ func (t *DefaultModelTasks) Handoff(ctx context.Context, plan []Todo, planDoc st
 	ctx, span := telemetry.StartHandoffSpan(ctx, open)
 	slog.InfoContext(ctx, "running context handoff", "area", telemetry.AreaModelTasks, "open_todos", open)
 
-	window, usedFallback, err := handoffGenerate(ctx, t.context.Messages(), plan, planDoc, t.model, tools, systemPrompt)
+	window, usedFallback, err := handoffGenerate(ctx, t.context.Messages(), plan, planDoc, t.model, tools)
 	if err != nil {
 		span.End(telemetry.HandoffOutcomeError, err)
 		return err
@@ -162,12 +154,11 @@ func (t *DefaultModelTasks) Handoff(ctx context.Context, plan []Todo, planDoc st
 
 // absorbFit collapses under pressure then appends newMsg.
 // Uses InferenceStrategy.CountTokens (provider-specific) and Invoke for summary.
-func (t *DefaultModelTasks) absorbFit(
+func (t *defaultModelTasks) absorbFit(
 	ctx context.Context,
 	window []*Message,
 	newMsg *Message,
 	tools []*Tool,
-	restoreSystemPrompt string,
 ) (out []*Message, chunks []LLMResponseChunk, compressed bool, err error) {
 	model := t.model
 	policy := t.policy
@@ -196,15 +187,10 @@ func (t *DefaultModelTasks) absorbFit(
 	sumPrompt.Grow(280 + len(newMsg.Content))
 	sumPrompt.WriteString("Please summarize the entire message history into a single, concise summary including key items for your current and past tasks with a primary focus on your current task. Current task or follow-up question to answer: ")
 	sumPrompt.WriteString(newMsg.Content)
-	model.SetSystemPrompt(sumPrompt.String())
-
 	anchorLen := protectedPrefixLen(window)
 	anchors := window[:anchorLen]
 	unprotected := window[anchorLen:]
 	if len(unprotected) == 0 {
-		if restoreSystemPrompt != "" {
-			model.SetSystemPrompt(restoreSystemPrompt)
-		}
 		return slices.Clone(countView), nil, false, nil
 	}
 
@@ -255,7 +241,7 @@ func (t *DefaultModelTasks) absorbFit(
 		mctx = telemetry.ContextWithModelIdentity(ctx, src.ModelTelemetryIdentity())
 	}
 	mctx, mspan := telemetry.StartModelSpan(mctx, telemetry.ModelPhaseCompress, t.modelSeq, windowShape(compressSrc))
-	events, err := model.Invoke(mctx, compressSrc, nil)
+	events, err := model.Invoke(mctx, compressSrc, nil, sumPrompt.String())
 	if err != nil {
 		mspan.End(err, telemetry.TokenUsage{})
 		return nil, nil, true, fmt.Errorf("context compress invoke failed: %w", err)
@@ -295,14 +281,11 @@ func (t *DefaultModelTasks) absorbFit(
 	out = append(out, rest...)
 	out = append(out, newMsg)
 
-	if restoreSystemPrompt != "" {
-		model.SetSystemPrompt(restoreSystemPrompt)
-	}
 	return out, outChunks, true, nil
 }
 
 // stageMessages returns t.countScratch resized to n (grows capacity when needed).
-func (t *DefaultModelTasks) stageMessages(n int) []*Message {
+func (t *defaultModelTasks) stageMessages(n int) []*Message {
 	if cap(t.countScratch) < n {
 		t.countScratch = make([]*Message, n)
 	} else {
@@ -318,7 +301,6 @@ func handoffGenerate(
 	planDoc string,
 	model InferenceStrategy,
 	tools []*Tool,
-	restoreSystemPrompt string,
 ) ([]*Message, bool, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, false, err
@@ -352,7 +334,6 @@ Current plan todos:
 	prompt.WriteString(handoffPreamble)
 	prompt.WriteString(planB.String())
 
-	model.SetSystemPrompt(prompt.String())
 	// Handoff is a pure writing task — no tools. On model failure, install a
 	// plan-derived handoff so ACM still rebuilds context.
 	mctx := ctx
@@ -360,7 +341,7 @@ Current plan todos:
 		mctx = telemetry.ContextWithModelIdentity(ctx, src.ModelTelemetryIdentity())
 	}
 	mctx, mspan := telemetry.StartModelSpan(mctx, telemetry.ModelPhaseHandoff, 0, windowShape(window))
-	events, err := model.Invoke(mctx, window, nil)
+	events, err := model.Invoke(mctx, window, nil, prompt.String())
 	var lastCompletedMessage string
 	usedFallback := false
 	if err != nil {
@@ -414,9 +395,6 @@ Current plan todos:
 			Role:    RoleDeveloper,
 			Content: continuePlanNudge,
 		})
-	}
-	if restoreSystemPrompt != "" {
-		model.SetSystemPrompt(restoreSystemPrompt)
 	}
 	return out, usedFallback, nil
 }

--- a/server/acp_elicitation_test.go
+++ b/server/acp_elicitation_test.go
@@ -40,7 +40,7 @@ func TestACP_elicitationForm_resolvesInterruptAndCompletes(t *testing.T) {
 	optionsJSON := `[{"title":"Option A","description":"First","isRecommended":true},{"title":"Option B","description":"Second","isRecommended":false}]`
 	interruptTool := tacklr.NewTool(tacklr.ToolConfig{
 		Name: "ask_user",
-		Handler: func(ctx context.Context, _ struct{}, runtime *tacklr.HarnessRuntime) (string, error) {
+		Handler: func(ctx context.Context, _ struct{}, runtime tacklr.HarnessRuntime) (string, error) {
 			intr, err := runtime.RaiseInterrupt("user_selection_choice", []byte(optionsJSON))
 			if err != nil {
 				return "", err
@@ -704,7 +704,7 @@ func TestACP_elicitationForm_declineEndsPrompt(t *testing.T) {
 	optionsJSON := `[{"title":"A","description":"","isRecommended":true},{"title":"B","description":"","isRecommended":false}]`
 	interruptTool := tacklr.NewTool(tacklr.ToolConfig{
 		Name: "ask_user",
-		Handler: func(ctx context.Context, _ struct{}, runtime *tacklr.HarnessRuntime) (string, error) {
+		Handler: func(ctx context.Context, _ struct{}, runtime tacklr.HarnessRuntime) (string, error) {
 			_, err := runtime.RaiseInterrupt("user_selection_choice", []byte(optionsJSON))
 			return "", err
 		},
@@ -820,7 +820,7 @@ func TestACP_elicitationForm_cancelEndsPrompt(t *testing.T) {
 	optionsJSON := `[{"title":"A","description":"","isRecommended":true},{"title":"B","description":"","isRecommended":false}]`
 	interruptTool := tacklr.NewTool(tacklr.ToolConfig{
 		Name: "ask_user",
-		Handler: func(ctx context.Context, _ struct{}, runtime *tacklr.HarnessRuntime) (string, error) {
+		Handler: func(ctx context.Context, _ struct{}, runtime tacklr.HarnessRuntime) (string, error) {
 			_, err := runtime.RaiseInterrupt("user_selection_choice", []byte(optionsJSON))
 			return "", err
 		},
@@ -939,7 +939,7 @@ func TestACP_elicitation_malformedInterruptEndsTurn(t *testing.T) {
 	optionsJSON := `[{"title":"only-one"}]` // < 2 options
 	interruptTool := tacklr.NewTool(tacklr.ToolConfig{
 		Name: "ask_user",
-		Handler: func(ctx context.Context, _ struct{}, runtime *tacklr.HarnessRuntime) (string, error) {
+		Handler: func(ctx context.Context, _ struct{}, runtime tacklr.HarnessRuntime) (string, error) {
 			_, err := runtime.RaiseInterrupt("user_selection_choice", []byte(optionsJSON))
 			return "", err
 		},

--- a/server/acp_protocol.go
+++ b/server/acp_protocol.go
@@ -248,8 +248,8 @@ func (p *acpProtocol) handleSessionTurn(ctx context.Context, env ProtocolEnv, pr
 		stream.Close()
 	}()
 	threadID := req.ThreadID
-	if stream.Harness != nil && stream.Harness.SessionID() != "" {
-		threadID = stream.Harness.SessionID()
+	if stream.SessionID() != "" {
+		threadID = stream.SessionID()
 	}
 	err = runTurnStream(ctx, env, p, threadID, stream, pr.ID)
 	if err != nil && !IsClientError(err) {
@@ -385,10 +385,7 @@ func resolveSelectionViaElicitation(ctx context.Context, env ProtocolEnv, thread
 	if err != nil {
 		return nil, fmt.Errorf("parse selection interrupt: %w", err)
 	}
-	question := ""
-	if stream.Harness != nil {
-		question = stream.Harness.AskUserQuestion(ev.MessageID)
-	}
+	question := stream.AskUserQuestion(ev.MessageID)
 	params, err := SelectionToElicitationParams(threadID, ev.MessageID, question, opts)
 	if err != nil {
 		return nil, err

--- a/server/acp_test.go
+++ b/server/acp_test.go
@@ -1035,7 +1035,7 @@ func TestHandleRPC_sessionPrompt_toolProgress(t *testing.T) {
 
 	progressTool := tacklr.NewTool(tacklr.ToolConfig{
 		Name: "progress_demo",
-		Handler: func(ctx context.Context, _ struct{}, runtime *tacklr.HarnessRuntime) (string, error) {
+		Handler: func(ctx context.Context, _ struct{}, runtime tacklr.HarnessRuntime) (string, error) {
 			runtime.EmitUpdate("starting work...")
 			runtime.EmitUpdate("50% complete")
 			runtime.EmitUpdate("almost done")

--- a/server/handler_failure_paths_test.go
+++ b/server/handler_failure_paths_test.go
@@ -53,7 +53,7 @@ func TestEventStream_closeAndResume(t *testing.T) {
 		t.Fatal("want no harness")
 	}
 	// Resume with cancelled runCtx falls back to parent.
-	h := tacklr.NewAgent(context.Background(), tacklr.AgentOptions{
+	h := mustAgent(t, tacklr.AgentOptions{
 		Config: tacklr.Config{},
 		Model: &mockInferenceStrategy{
 			invokeFn: func(ctx context.Context, msgs []*tacklr.Message, tools []*tacklr.Tool, ch chan<- tacklr.LLMResponseChunk) {
@@ -65,7 +65,7 @@ func TestEventStream_closeAndResume(t *testing.T) {
 	done := context.Background()
 	cancelled, cancel := context.WithCancel(context.Background())
 	cancel()
-	es = &EventStream{Harness: h, runCtx: cancelled, cancel: func() {}}
+	es = &EventStream{harness: h, runCtx: cancelled, cancel: func() {}}
 	ch, err := es.ResumeInterrupts(done, map[string][]byte{})
 	if err != nil {
 		// empty responses may still succeed starting Run with ""
@@ -343,8 +343,8 @@ func TestResolveSelectionViaElicitation_withQuestion(t *testing.T) {
 	optionsJSON := `[{"title":"A","description":"","isRecommended":true},{"title":"B","description":"","isRecommended":false}]`
 	tool := tacklr.NewTool(tacklr.ToolConfig{
 		Name: "ask_user",
-		Handler: func(ctx context.Context, _ struct{}, runtime *tacklr.HarnessRuntime) (string, error) {
-			runtime.StateSet("_ask_user_question:"+runtime.CurrentToolCallID, "Which?")
+		Handler: func(ctx context.Context, _ struct{}, runtime tacklr.HarnessRuntime) (string, error) {
+			_ = runtime.StateSet("_ask_user_question:"+runtime.CurrentToolCallID(), "Which?")
 			intr, err := runtime.RaiseInterrupt("user_selection_choice", []byte(optionsJSON))
 			if err != nil {
 				return "", err
@@ -366,7 +366,7 @@ func TestResolveSelectionViaElicitation_withQuestion(t *testing.T) {
 			ch <- tacklr.LLMResponseChunk{Type: tacklr.StreamEventMessage, Content: "done", IsComplete: true}
 		},
 	}
-	h := tacklr.NewAgent(context.Background(), tacklr.AgentOptions{
+	h := mustAgent(t, tacklr.AgentOptions{
 		Config: tacklr.Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Store:  testStore(t),
@@ -389,7 +389,7 @@ func TestResolveSelectionViaElicitation_withQuestion(t *testing.T) {
 	w := &recordingWriter{}
 	bridge := NewClientBridge(w)
 	env := ProtocolEnv{Conn: &Conn{RPC: bridge, Caps: ClientCapabilities{ElicitationForm: true}}}
-	stream := &EventStream{Harness: h, runCtx: context.Background()}
+	stream := &EventStream{harness: h, runCtx: context.Background()}
 
 	type res struct {
 		ch  <-chan streaming.StreamEvent

--- a/server/permission_resolve_test.go
+++ b/server/permission_resolve_test.go
@@ -186,7 +186,7 @@ func TestResolvePermissionViaRequest_outcomes(t *testing.T) {
 				ch <- tacklr.LLMResponseChunk{IsComplete: true}
 			},
 		}
-		h := tacklr.NewAgent(context.Background(), tacklr.AgentOptions{
+		h := mustAgent(t, tacklr.AgentOptions{
 			Config:    tacklr.Config{MaxWindowSize: 8192},
 			SessionID: "sess-perm-resolve",
 			Model:     ms,
@@ -215,7 +215,7 @@ func TestResolvePermissionViaRequest_outcomes(t *testing.T) {
 		w := &recordingWriter{}
 		bridge := NewClientBridge(w)
 		env := ProtocolEnv{Conn: &Conn{RPC: bridge}}
-		stream := &EventStream{Harness: h, runCtx: context.Background()}
+		stream := &EventStream{harness: h, runCtx: context.Background()}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()

--- a/server/registry.go
+++ b/server/registry.go
@@ -97,11 +97,35 @@ type TurnRequest struct {
 // ResumeInterrupts must run before Close (same turn, same harness).
 type EventStream struct {
 	Events  <-chan streaming.StreamEvent
-	Harness *tacklr.AgentHarness
+	harness *tacklr.AgentHarness
 	runCtx  context.Context
 	cancel  context.CancelFunc
 	closed  bool
 	mu      sync.Mutex
+}
+
+// SessionID is the durable harness thread id, or empty.
+func (s *EventStream) SessionID() string {
+	if s == nil || s.harness == nil {
+		return ""
+	}
+	return s.harness.SessionID()
+}
+
+// AskUserQuestion returns the ask_user_choice question for toolCallID, or empty.
+func (s *EventStream) AskUserQuestion(toolCallID string) string {
+	if s == nil || s.harness == nil {
+		return ""
+	}
+	return s.harness.AskUserQuestion(toolCallID)
+}
+
+// VFS is the session mount table, or nil.
+func (s *EventStream) VFS() *vfs.MountSession {
+	if s == nil || s.harness == nil {
+		return nil
+	}
+	return s.harness.VFS()
 }
 
 // TurnContext is the context for this turn (cancelled by session/cancel or parent).
@@ -131,8 +155,8 @@ func (s *EventStream) Close() {
 	if s.cancel != nil {
 		s.cancel()
 	}
-	closeTurnHarness(s.Harness)
-	s.Harness = nil
+	closeTurnHarness(s.harness)
+	s.harness = nil
 }
 
 func closeTurnHarness(h *tacklr.AgentHarness) {
@@ -145,14 +169,14 @@ func closeTurnHarness(h *tacklr.AgentHarness) {
 // ResumeInterrupts resolves pending interrupts and returns a new event stream
 // from the same harness (ACP mid-turn elicitation resume).
 func (s *EventStream) ResumeInterrupts(ctx context.Context, responses map[string][]byte) (<-chan streaming.StreamEvent, error) {
-	if s.Harness == nil {
+	if s.harness == nil {
 		return nil, fmt.Errorf("event stream: no harness for resume")
 	}
 	c := s.runCtx
 	if c.Err() != nil {
 		c = ctx
 	}
-	return s.Harness.ReturnFromInterrupt(c, responses)
+	return s.harness.ReturnFromInterrupt(c, responses)
 }
 
 // Registry serves agents over wire protocols (ACP, SSE, and others).
@@ -323,7 +347,10 @@ func (r *Registry) sessionVFS(ctx context.Context, threadID string, spec *AgentS
 	if ms, ok := r.mounts[threadID]; ok {
 		return ms, nil
 	}
-	ms := vfs.NewMountSession(threadID, spec.FSRegistry)
+	ms, err := vfs.NewMountSession(threadID, spec.FSRegistry)
+	if err != nil {
+		return nil, err
+	}
 	if err := ms.Materialize(ctx, spec.FSBootstrap); err != nil {
 		return nil, err
 	}
@@ -488,7 +515,7 @@ func (r *Registry) RunTurn(ctx context.Context, req TurnRequest) (*EventStream, 
 
 	return &EventStream{
 		Events:  out,
-		Harness: h,
+		harness: h,
 		runCtx:  turnCtx,
 		cancel:  cancel,
 	}, nil
@@ -578,12 +605,20 @@ func (r *Registry) loadAgent(ctx context.Context, agentID, threadID string, load
 		case err == nil:
 			h = loaded
 		case errors.Is(err, stores.ErrSessionNotFound) && allowMissingCheckpoint:
-			h = tacklr.NewAgent(ctx, opts)
+			created, err := tacklr.NewAgent(ctx, opts)
+			if err != nil {
+				return nil, nil, err
+			}
+			h = created
 		default:
 			return nil, nil, err
 		}
 	} else {
-		h = tacklr.NewAgent(ctx, opts)
+		created, err := tacklr.NewAgent(ctx, opts)
+		if err != nil {
+			return nil, nil, err
+		}
+		h = created
 	}
 
 	if err := r.ensureSessionFuse(ctx, h, threadID); err != nil {

--- a/server/registry_session_test.go
+++ b/server/registry_session_test.go
@@ -351,55 +351,18 @@ func TestRunTurn_fuseMountFailHard(t *testing.T) {
 	drainTurn(t, s)
 }
 
-// TestRunTurn_askUserQuestion_visibleOnStream is the host EventStream
-// outcome: ask_user_choice parks the turn and AskUserQuestion returns the
-// question until Close releases the harness.
-func TestRunTurn_askUserQuestion_visibleOnStream(t *testing.T) {
-	ctx := context.Background()
-	model := &mockInferenceStrategy{
-		invokeFn: func(ctx context.Context, msgs []*tacklr.Message, tools []*tacklr.Tool, ch chan<- tacklr.LLMResponseChunk) {
-			ch <- tacklr.LLMResponseChunk{Type: tacklr.StreamEventFunctionCall, ToolCalls: []tacklr.ToolCall{
-				{ID: "ask1", CallID: "ask1", Name: "ask_user_choice",
-					Arguments: `{"question":"Pick?","choices":[{"title":"A"},{"title":"B"}]}`},
-			}, IsComplete: true}
-			ch <- tacklr.LLMResponseChunk{IsComplete: true}
-		},
-	}
-	r := NewRegistry(testStore(t), "default")
-	r.Register("default", AgentSpec{
-		Config: tacklr.Config{MaxWindowSize: 8192},
-		Model:  model,
-	})
-	thread := "sess-ask"
-	s, err := r.RunTurn(ctx, TurnRequest{AgentID: "default", ThreadID: thread, Prompt: "ask"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { r.DropLiveHarness(thread) })
-	var sawInterrupt bool
-	for ev := range s.Events {
-		if ev.Type == streaming.StreamEventInterrupt {
-			sawInterrupt = true
-		}
-	}
-	if !sawInterrupt {
-		t.Fatal("expected ask_user_choice interrupt")
-	}
-	if s.SessionID() != thread {
-		t.Fatalf("SessionID = %q", s.SessionID())
-	}
-	if q := s.AskUserQuestion("ask1"); q != "Pick?" {
-		t.Fatalf("AskUserQuestion = %q", q)
-	}
-	s.Close()
-	if s.AskUserQuestion("ask1") != "" || s.SessionID() != "" {
-		t.Fatal("Close must release host accessors")
-	}
-}
+type flipProjection struct{ calls int }
 
-// TestRunTurn_directProjection_inProcessVFS is the host opt-in: DirectProjection
-// publishes an in-process mount table (write/read) without a kernel HostDir.
-func TestRunTurn_directProjection_inProcessVFS(t *testing.T) {
+func (p *flipProjection) Available() bool {
+	p.calls++
+	return p.calls == 1
+}
+func (p *flipProjection) Attach(*vfs.MountSession, string) error { return nil }
+
+// TestRunTurn_vfsProjection_inProcessAndFlip covers the two host projection
+// outcomes that are not already hit by the FUSE two-turn test: DirectProjection
+// write/read across turns, and a projection that refuses Attach after construct.
+func TestRunTurn_vfsProjection_inProcessAndFlip(t *testing.T) {
 	ctx := context.Background()
 	r := NewRegistry(testStore(t), "default",
 		WithVFSProjection(DirectProjection{}),
@@ -412,62 +375,64 @@ func TestRunTurn_directProjection_inProcessVFS(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { r.DropLiveHarness(thread) })
-	ms := s.VFS()
-	if ms == nil {
-		t.Fatal("want in-process VFS")
-	}
-	if err := ms.WriteFile(ctx, "/work/note.md", []byte("direct\n")); err != nil {
+	if err := s.VFS().WriteFile(ctx, "/work/note.md", []byte("direct\n")); err != nil {
 		t.Fatal(err)
 	}
-	got, err := ms.ReadFile(ctx, "/work/note.md")
-	if err != nil || string(got) != "direct\n" {
-		t.Fatalf("ReadFile = %q err=%v", got, err)
-	}
 	drainTurn(t, s)
-
 	s2, err := r.RunTurn(ctx, TurnRequest{AgentID: "default", ThreadID: thread, Prompt: "again"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	got, err = s2.VFS().ReadFile(ctx, "/work/note.md")
+	got, err := s2.VFS().ReadFile(ctx, "/work/note.md")
 	if err != nil || string(got) != "direct\n" {
 		t.Fatalf("second turn VFS = %q err=%v", got, err)
 	}
 	drainTurn(t, s2)
+
+	flip := NewRegistry(testStore(t), "default", WithVFSProjection(&flipProjection{}))
+	flip.Register("default", vfsSpec(t, okModel(), "/work"))
+	sf, err := flip.RunTurn(ctx, TurnRequest{AgentID: "default", ThreadID: "sess-flip", Prompt: "hi"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { flip.DropLiveHarness("sess-flip") })
+	if err := sf.VFS().WriteFile(ctx, "/work/ok.md", []byte("ok\n")); err != nil {
+		t.Fatal(err)
+	}
+	drainTurn(t, sf)
 }
 
-// TestRegistry_AgentModel_defaultID is the host lookup outcome: empty agent
-// id resolves to the registry default model's strategy.
-func TestRegistry_AgentModel_defaultID(t *testing.T) {
-	model := okModel()
-	r := NewRegistry(testStore(t), "default")
-	r.Register("default", AgentSpec{Config: tacklr.Config{MaxWindowSize: 8192}, Model: model})
-	if r.AgentModel("") != model || r.AgentModel("default") != model {
-		t.Fatal("empty and default ids must return the registered model")
-	}
-	opts := r.ConfigOptions("default")
-	if len(opts) == 0 || opts[0].CurrentValue != "default" || len(opts[0].Options) == 0 || opts[0].Options[0].Value != "default" {
-		t.Fatalf("ConfigOptions = %+v", opts)
-	}
-}
-
-// TestRunTurn_whitespaceThreadID_vfsConstructError is fail-closed VFS
-// construct: a blank thread id cannot open a mount session.
-func TestRunTurn_whitespaceThreadID_vfsConstructError(t *testing.T) {
+// TestRunTurn_constructFailures is fail-closed construct: blank thread id,
+// unknown VFS profile, missing skill dir, and FuseProjection session-id sanitize.
+func TestRunTurn_constructFailures(t *testing.T) {
+	ctx := context.Background()
 	r := NewRegistry(testStore(t), "default", WithVFSProjection(DirectProjection{}))
 	r.Register("default", vfsSpec(t, okModel(), "/work"))
-	_, err := r.RunTurn(context.Background(), TurnRequest{
-		AgentID: "default", ThreadID: "   ", Prompt: "hi",
-	})
+	_, err := r.RunTurn(ctx, TurnRequest{AgentID: "default", ThreadID: "   ", Prompt: "hi"})
 	if err == nil || !strings.Contains(err.Error(), "session id") {
 		t.Fatalf("want session id construct error, got %v", err)
 	}
-}
 
-// TestFuseProjection_attach_sanitizesDotSessionID is the host mount-path
-// outcome: "." / ".." / empty session ids are rewritten before Attach.
-func TestFuseProjection_attach_sanitizesDotSessionID(t *testing.T) {
-	ctx := context.Background()
+	bad := vfsSpec(t, okModel(), "/work")
+	bad.FSBootstrap = []vfs.MountSpec{{Point: "/work", Profile: "nope"}}
+	r.Register("default", bad)
+	_, err = r.RunTurn(ctx, TurnRequest{AgentID: "default", ThreadID: "sess-bad-profile", Prompt: "hi"})
+	if err == nil || !strings.Contains(err.Error(), "nope") {
+		t.Fatalf("want unknown profile error, got %v", err)
+	}
+
+	r.Register("default", AgentSpec{
+		Config: tacklr.Config{
+			MaxWindowSize:    8192,
+			SkillDirectories: []string{filepath.Join(t.TempDir(), "does-not-exist")},
+		},
+		Model: okModel(),
+	})
+	_, err = r.RunTurn(ctx, TurnRequest{AgentID: "default", ThreadID: "sess-skills", Prompt: "hi"})
+	if err == nil || !strings.Contains(err.Error(), "initialize skills") {
+		t.Fatalf("want skills construct error, got %v", err)
+	}
+
 	reg := vfs.NewBackendRegistry()
 	if err := reg.Register(vfs.LocalFactory{ID: "local", Base: t.TempDir()}); err != nil {
 		t.Fatal(err)
@@ -477,7 +442,7 @@ func TestFuseProjection_attach_sanitizesDotSessionID(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = ms.Close() })
-	err := FuseProjection{}.Attach(ms, ".")
+	err = FuseProjection{}.Attach(ms, ".")
 	if vfs.FuseAvailable() {
 		if err != nil {
 			t.Fatal(err)
@@ -489,69 +454,5 @@ func TestFuseProjection_attach_sanitizesDotSessionID(t *testing.T) {
 	}
 	if err == nil {
 		t.Fatal("want Attach error when FUSE is unavailable")
-	}
-}
-
-// TestRunTurn_missingSkillDirectory_constructError is fail-closed construct
-// through the registry: a missing SkillDirectories path surfaces from RunTurn.
-func TestRunTurn_missingSkillDirectory_constructError(t *testing.T) {
-	r := NewRegistry(testStore(t), "default")
-	r.Register("default", AgentSpec{
-		Config: tacklr.Config{
-			MaxWindowSize:    8192,
-			SkillDirectories: []string{filepath.Join(t.TempDir(), "does-not-exist")},
-		},
-		Model: okModel(),
-	})
-	_, err := r.RunTurn(context.Background(), TurnRequest{
-		AgentID: "default", ThreadID: "sess-skills", Prompt: "hi",
-	})
-	if err == nil || !strings.Contains(err.Error(), "initialize skills") {
-		t.Fatalf("want skills construct error, got %v", err)
-	}
-}
-
-type flipProjection struct{ calls int }
-
-func (p *flipProjection) Available() bool {
-	p.calls++
-	return p.calls == 1
-}
-func (p *flipProjection) Attach(*vfs.MountSession, string) error { return nil }
-
-// TestRunTurn_projectionUnavailableAfterConstruct_stillCompletes: the host
-// projection can refuse Attach after the mount table is built; the turn still
-// answers and VFS tools stay in-process.
-func TestRunTurn_projectionUnavailableAfterConstruct_stillCompletes(t *testing.T) {
-	ctx := context.Background()
-	r := NewRegistry(testStore(t), "default", WithVFSProjection(&flipProjection{}))
-	r.Register("default", vfsSpec(t, okModel(), "/work"))
-	thread := "sess-flip"
-	s, err := r.RunTurn(ctx, TurnRequest{AgentID: "default", ThreadID: thread, Prompt: "hi"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { r.DropLiveHarness(thread) })
-	if s.VFS() == nil {
-		t.Fatal("want in-process VFS after construct")
-	}
-	if err := s.VFS().WriteFile(ctx, "/work/ok.md", []byte("ok\n")); err != nil {
-		t.Fatal(err)
-	}
-	drainTurn(t, s)
-}
-
-// TestRunTurn_unknownVFSProfile_constructError is fail-closed materialize:
-// an unknown bootstrap profile surfaces from RunTurn.
-func TestRunTurn_unknownVFSProfile_constructError(t *testing.T) {
-	r := NewRegistry(testStore(t), "default", WithVFSProjection(DirectProjection{}))
-	spec := vfsSpec(t, okModel(), "/work")
-	spec.FSBootstrap = []vfs.MountSpec{{Point: "/work", Profile: "nope"}}
-	r.Register("default", spec)
-	_, err := r.RunTurn(context.Background(), TurnRequest{
-		AgentID: "default", ThreadID: "sess-bad-profile", Prompt: "hi",
-	})
-	if err == nil || !strings.Contains(err.Error(), "nope") {
-		t.Fatalf("want unknown profile error, got %v", err)
 	}
 }

--- a/server/registry_session_test.go
+++ b/server/registry_session_test.go
@@ -396,3 +396,162 @@ func TestRunTurn_askUserQuestion_visibleOnStream(t *testing.T) {
 		t.Fatal("Close must release host accessors")
 	}
 }
+
+// TestRunTurn_directProjection_inProcessVFS is the host opt-in: DirectProjection
+// publishes an in-process mount table (write/read) without a kernel HostDir.
+func TestRunTurn_directProjection_inProcessVFS(t *testing.T) {
+	ctx := context.Background()
+	r := NewRegistry(testStore(t), "default",
+		WithVFSProjection(DirectProjection{}),
+		WithTracer(telemetry.Tracer()),
+	)
+	r.Register("default", vfsSpec(t, okModel(), "/work"))
+	thread := "sess-direct"
+	s, err := r.RunTurn(ctx, TurnRequest{AgentID: "default", ThreadID: thread, Prompt: "hi"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { r.DropLiveHarness(thread) })
+	ms := s.VFS()
+	if ms == nil {
+		t.Fatal("want in-process VFS")
+	}
+	if err := ms.WriteFile(ctx, "/work/note.md", []byte("direct\n")); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ms.ReadFile(ctx, "/work/note.md")
+	if err != nil || string(got) != "direct\n" {
+		t.Fatalf("ReadFile = %q err=%v", got, err)
+	}
+	drainTurn(t, s)
+
+	s2, err := r.RunTurn(ctx, TurnRequest{AgentID: "default", ThreadID: thread, Prompt: "again"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err = s2.VFS().ReadFile(ctx, "/work/note.md")
+	if err != nil || string(got) != "direct\n" {
+		t.Fatalf("second turn VFS = %q err=%v", got, err)
+	}
+	drainTurn(t, s2)
+}
+
+// TestRegistry_AgentModel_defaultID is the host lookup outcome: empty agent
+// id resolves to the registry default model's strategy.
+func TestRegistry_AgentModel_defaultID(t *testing.T) {
+	model := okModel()
+	r := NewRegistry(testStore(t), "default")
+	r.Register("default", AgentSpec{Config: tacklr.Config{MaxWindowSize: 8192}, Model: model})
+	if r.AgentModel("") != model || r.AgentModel("default") != model {
+		t.Fatal("empty and default ids must return the registered model")
+	}
+	opts := r.ConfigOptions("default")
+	if len(opts) == 0 || opts[0].CurrentValue != "default" || len(opts[0].Options) == 0 || opts[0].Options[0].Value != "default" {
+		t.Fatalf("ConfigOptions = %+v", opts)
+	}
+}
+
+// TestRunTurn_whitespaceThreadID_vfsConstructError is fail-closed VFS
+// construct: a blank thread id cannot open a mount session.
+func TestRunTurn_whitespaceThreadID_vfsConstructError(t *testing.T) {
+	r := NewRegistry(testStore(t), "default", WithVFSProjection(DirectProjection{}))
+	r.Register("default", vfsSpec(t, okModel(), "/work"))
+	_, err := r.RunTurn(context.Background(), TurnRequest{
+		AgentID: "default", ThreadID: "   ", Prompt: "hi",
+	})
+	if err == nil || !strings.Contains(err.Error(), "session id") {
+		t.Fatalf("want session id construct error, got %v", err)
+	}
+}
+
+// TestFuseProjection_attach_sanitizesDotSessionID is the host mount-path
+// outcome: "." / ".." / empty session ids are rewritten before Attach.
+func TestFuseProjection_attach_sanitizesDotSessionID(t *testing.T) {
+	ctx := context.Background()
+	reg := vfs.NewBackendRegistry()
+	if err := reg.Register(vfs.LocalFactory{ID: "local", Base: t.TempDir()}); err != nil {
+		t.Fatal(err)
+	}
+	ms := vfs.MustNewMountSession("dot-sess", reg)
+	if err := ms.Materialize(ctx, []vfs.MountSpec{{Point: "/work", Profile: "local"}}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ms.Close() })
+	err := FuseProjection{}.Attach(ms, ".")
+	if vfs.FuseAvailable() {
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(ms.HostDir(), "session") {
+			t.Fatalf("HostDir = %q, want sanitized session path", ms.HostDir())
+		}
+		return
+	}
+	if err == nil {
+		t.Fatal("want Attach error when FUSE is unavailable")
+	}
+}
+
+// TestRunTurn_missingSkillDirectory_constructError is fail-closed construct
+// through the registry: a missing SkillDirectories path surfaces from RunTurn.
+func TestRunTurn_missingSkillDirectory_constructError(t *testing.T) {
+	r := NewRegistry(testStore(t), "default")
+	r.Register("default", AgentSpec{
+		Config: tacklr.Config{
+			MaxWindowSize:    8192,
+			SkillDirectories: []string{filepath.Join(t.TempDir(), "does-not-exist")},
+		},
+		Model: okModel(),
+	})
+	_, err := r.RunTurn(context.Background(), TurnRequest{
+		AgentID: "default", ThreadID: "sess-skills", Prompt: "hi",
+	})
+	if err == nil || !strings.Contains(err.Error(), "initialize skills") {
+		t.Fatalf("want skills construct error, got %v", err)
+	}
+}
+
+type flipProjection struct{ calls int }
+
+func (p *flipProjection) Available() bool {
+	p.calls++
+	return p.calls == 1
+}
+func (p *flipProjection) Attach(*vfs.MountSession, string) error { return nil }
+
+// TestRunTurn_projectionUnavailableAfterConstruct_stillCompletes: the host
+// projection can refuse Attach after the mount table is built; the turn still
+// answers and VFS tools stay in-process.
+func TestRunTurn_projectionUnavailableAfterConstruct_stillCompletes(t *testing.T) {
+	ctx := context.Background()
+	r := NewRegistry(testStore(t), "default", WithVFSProjection(&flipProjection{}))
+	r.Register("default", vfsSpec(t, okModel(), "/work"))
+	thread := "sess-flip"
+	s, err := r.RunTurn(ctx, TurnRequest{AgentID: "default", ThreadID: thread, Prompt: "hi"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { r.DropLiveHarness(thread) })
+	if s.VFS() == nil {
+		t.Fatal("want in-process VFS after construct")
+	}
+	if err := s.VFS().WriteFile(ctx, "/work/ok.md", []byte("ok\n")); err != nil {
+		t.Fatal(err)
+	}
+	drainTurn(t, s)
+}
+
+// TestRunTurn_unknownVFSProfile_constructError is fail-closed materialize:
+// an unknown bootstrap profile surfaces from RunTurn.
+func TestRunTurn_unknownVFSProfile_constructError(t *testing.T) {
+	r := NewRegistry(testStore(t), "default", WithVFSProjection(DirectProjection{}))
+	spec := vfsSpec(t, okModel(), "/work")
+	spec.FSBootstrap = []vfs.MountSpec{{Point: "/work", Profile: "nope"}}
+	r.Register("default", spec)
+	_, err := r.RunTurn(context.Background(), TurnRequest{
+		AgentID: "default", ThreadID: "sess-bad-profile", Prompt: "hi",
+	})
+	if err == nil || !strings.Contains(err.Error(), "nope") {
+		t.Fatalf("want unknown profile error, got %v", err)
+	}
+}

--- a/server/registry_session_test.go
+++ b/server/registry_session_test.go
@@ -99,8 +99,17 @@ func TestRunTurn_twoTurnsKeepHostDirOrList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if s1.SessionID() != thread {
+		t.Fatalf("SessionID = %q, want %q", s1.SessionID(), thread)
+	}
+	if s1.VFS() == nil {
+		t.Fatal("want VFS on first turn")
+	}
 	h1 := s1.harness
 	drainTurn(t, s1)
+	if s1.SessionID() != "" || s1.VFS() != nil {
+		t.Fatal("Close must release SessionID and VFS")
+	}
 
 	s2, err := r.RunTurn(ctx, TurnRequest{AgentID: "default", ThreadID: thread, Prompt: "two"})
 	if err != nil {
@@ -110,7 +119,10 @@ func TestRunTurn_twoTurnsKeepHostDirOrList(t *testing.T) {
 	if h2 == h1 {
 		t.Fatal("want a new harness each turn")
 	}
-	ms := h2.VFS()
+	if s2.SessionID() != thread {
+		t.Fatalf("SessionID = %q, want %q", s2.SessionID(), thread)
+	}
+	ms := s2.VFS()
 	if ms == nil {
 		t.Fatal("want VFS")
 	}
@@ -183,7 +195,7 @@ func TestRunTurn_unavailableProjectionStillCompletes(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { r.DropLiveHarness("sess-noproj") })
-	if s.harness.VFS() != nil {
+	if s.VFS() != nil {
 		t.Fatal("want no VFS when projection is unavailable")
 	}
 	var saw bool
@@ -238,11 +250,14 @@ func TestRunTurn_failedResumeThenFreshPrompt(t *testing.T) {
 	if s3.harness == h1 {
 		t.Fatal("want a new harness after dump")
 	}
-	if vfs.FuseAvailable() && s3.harness.VFS().HostDir() == "" {
+	if s3.SessionID() != thread {
+		t.Fatalf("SessionID = %q, want %q", s3.SessionID(), thread)
+	}
+	if vfs.FuseAvailable() && s3.VFS().HostDir() == "" {
 		t.Fatal("HostDir empty on third prompt")
 	}
 	if !vfs.FuseAvailable() {
-		if _, err := s3.harness.VFS().ReadDir(ctx, "/work"); err != nil {
+		if _, err := s3.VFS().ReadDir(ctx, "/work"); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -272,11 +287,14 @@ func TestRunTurn_coldRunHarnessFailureThenFreshPrompt(t *testing.T) {
 	if s3.harness == nil {
 		t.Fatal("want constructed harness")
 	}
+	if s3.SessionID() != thread {
+		t.Fatalf("SessionID = %q, want %q", s3.SessionID(), thread)
+	}
 	if vfs.FuseAvailable() {
-		if s3.harness.VFS() == nil || s3.harness.VFS().HostDir() == "" {
+		if s3.VFS() == nil || s3.VFS().HostDir() == "" {
 			t.Fatal("want live HostDir on reconstructed harness")
 		}
-	} else if _, err := s3.harness.VFS().ReadDir(ctx, "/work"); err != nil {
+	} else if _, err := s3.VFS().ReadDir(ctx, "/work"); err != nil {
 		t.Fatal(err)
 	}
 	drainTurn(t, s3)
@@ -324,8 +342,57 @@ func TestRunTurn_fuseMountFailHard(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { r.DropLiveHarness(thread) })
-	if s.harness.VFS().HostDir() == "" {
+	if s.SessionID() != thread {
+		t.Fatalf("SessionID = %q, want %q", s.SessionID(), thread)
+	}
+	if s.VFS().HostDir() == "" {
 		t.Fatal("want HostDir after unblocked remount")
 	}
 	drainTurn(t, s)
+}
+
+// TestRunTurn_askUserQuestion_visibleOnStream is the host EventStream
+// outcome: ask_user_choice parks the turn and AskUserQuestion returns the
+// question until Close releases the harness.
+func TestRunTurn_askUserQuestion_visibleOnStream(t *testing.T) {
+	ctx := context.Background()
+	model := &mockInferenceStrategy{
+		invokeFn: func(ctx context.Context, msgs []*tacklr.Message, tools []*tacklr.Tool, ch chan<- tacklr.LLMResponseChunk) {
+			ch <- tacklr.LLMResponseChunk{Type: tacklr.StreamEventFunctionCall, ToolCalls: []tacklr.ToolCall{
+				{ID: "ask1", CallID: "ask1", Name: "ask_user_choice",
+					Arguments: `{"question":"Pick?","choices":[{"title":"A"},{"title":"B"}]}`},
+			}, IsComplete: true}
+			ch <- tacklr.LLMResponseChunk{IsComplete: true}
+		},
+	}
+	r := NewRegistry(testStore(t), "default")
+	r.Register("default", AgentSpec{
+		Config: tacklr.Config{MaxWindowSize: 8192},
+		Model:  model,
+	})
+	thread := "sess-ask"
+	s, err := r.RunTurn(ctx, TurnRequest{AgentID: "default", ThreadID: thread, Prompt: "ask"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { r.DropLiveHarness(thread) })
+	var sawInterrupt bool
+	for ev := range s.Events {
+		if ev.Type == streaming.StreamEventInterrupt {
+			sawInterrupt = true
+		}
+	}
+	if !sawInterrupt {
+		t.Fatal("expected ask_user_choice interrupt")
+	}
+	if s.SessionID() != thread {
+		t.Fatalf("SessionID = %q", s.SessionID())
+	}
+	if q := s.AskUserQuestion("ask1"); q != "Pick?" {
+		t.Fatalf("AskUserQuestion = %q", q)
+	}
+	s.Close()
+	if s.AskUserQuestion("ask1") != "" || s.SessionID() != "" {
+		t.Fatal("Close must release host accessors")
+	}
 }

--- a/server/registry_session_test.go
+++ b/server/registry_session_test.go
@@ -99,14 +99,14 @@ func TestRunTurn_twoTurnsKeepHostDirOrList(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h1 := s1.Harness
+	h1 := s1.harness
 	drainTurn(t, s1)
 
 	s2, err := r.RunTurn(ctx, TurnRequest{AgentID: "default", ThreadID: thread, Prompt: "two"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	h2 := s2.Harness
+	h2 := s2.harness
 	if h2 == h1 {
 		t.Fatal("want a new harness each turn")
 	}
@@ -183,7 +183,7 @@ func TestRunTurn_unavailableProjectionStillCompletes(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { r.DropLiveHarness("sess-noproj") })
-	if s.Harness.VFS() != nil {
+	if s.harness.VFS() != nil {
 		t.Fatal("want no VFS when projection is unavailable")
 	}
 	var saw bool
@@ -218,7 +218,7 @@ func TestRunTurn_failedResumeThenFreshPrompt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h1 := s1.Harness
+	h1 := s1.harness
 	drainTurn(t, s1)
 
 	_, err = r.RunTurn(ctx, TurnRequest{
@@ -235,14 +235,14 @@ func TestRunTurn_failedResumeThenFreshPrompt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s3.Harness == h1 {
+	if s3.harness == h1 {
 		t.Fatal("want a new harness after dump")
 	}
-	if vfs.FuseAvailable() && s3.Harness.VFS().HostDir() == "" {
+	if vfs.FuseAvailable() && s3.harness.VFS().HostDir() == "" {
 		t.Fatal("HostDir empty on third prompt")
 	}
 	if !vfs.FuseAvailable() {
-		if _, err := s3.Harness.VFS().ReadDir(ctx, "/work"); err != nil {
+		if _, err := s3.harness.VFS().ReadDir(ctx, "/work"); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -269,14 +269,14 @@ func TestRunTurn_coldRunHarnessFailureThenFreshPrompt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if s3.Harness == nil {
+	if s3.harness == nil {
 		t.Fatal("want constructed harness")
 	}
 	if vfs.FuseAvailable() {
-		if s3.Harness.VFS() == nil || s3.Harness.VFS().HostDir() == "" {
+		if s3.harness.VFS() == nil || s3.harness.VFS().HostDir() == "" {
 			t.Fatal("want live HostDir on reconstructed harness")
 		}
-	} else if _, err := s3.Harness.VFS().ReadDir(ctx, "/work"); err != nil {
+	} else if _, err := s3.harness.VFS().ReadDir(ctx, "/work"); err != nil {
 		t.Fatal(err)
 	}
 	drainTurn(t, s3)
@@ -324,7 +324,7 @@ func TestRunTurn_fuseMountFailHard(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { r.DropLiveHarness(thread) })
-	if s.Harness.VFS().HostDir() == "" {
+	if s.harness.VFS().HostDir() == "" {
 		t.Fatal("want HostDir after unblocked remount")
 	}
 	drainTurn(t, s)

--- a/server/sse_protocol.go
+++ b/server/sse_protocol.go
@@ -81,8 +81,8 @@ func (p sseProtocol) handleSSE(env ProtocolEnv, w http.ResponseWriter, r *http.R
 		stream.Cancel()
 		stream.Close()
 	}()
-	if stream.Harness != nil && stream.Harness.SessionID() != "" {
-		threadID = stream.Harness.SessionID()
+	if stream.SessionID() != "" {
+		threadID = stream.SessionID()
 	}
 
 	w.Header().Set("Content-Type", "text/event-stream")
@@ -144,8 +144,8 @@ func (p sseProtocol) handleWS(env ProtocolEnv, w http.ResponseWriter, r *http.Re
 		stream.Cancel()
 		stream.Close()
 	}()
-	if stream.Harness != nil && stream.Harness.SessionID() != "" {
-		threadID = stream.Harness.SessionID()
+	if stream.SessionID() != "" {
+		threadID = stream.SessionID()
 	}
 	if err := wsWriteJSON(ctx, c, wsServerEvent{Type: "thread", Content: threadID}); err != nil {
 		return

--- a/server/sse_test.go
+++ b/server/sse_test.go
@@ -62,7 +62,7 @@ func makeInterruptTool(t *testing.T, optionsJSON string) *tacklr.Tool {
 	t.Helper()
 	return tacklr.NewTool(tacklr.ToolConfig{
 		Name: "ask_user",
-		Handler: func(ctx context.Context, _ struct{}, runtime *tacklr.HarnessRuntime) (string, error) {
+		Handler: func(ctx context.Context, _ struct{}, runtime tacklr.HarnessRuntime) (string, error) {
 			intr, err := runtime.RaiseInterrupt("user_selection_choice", []byte(optionsJSON))
 			if err != nil {
 				return "", err

--- a/server/testutil_test.go
+++ b/server/testutil_test.go
@@ -19,15 +19,7 @@ type mockInferenceStrategy struct {
 	callNum        atomic.Int64
 }
 
-func (m *mockInferenceStrategy) WithApiKey(string) tacklr.InferenceStrategy         { return m }
-func (m *mockInferenceStrategy) WithModel(string) tacklr.InferenceStrategy          { return m }
-func (m *mockInferenceStrategy) WithURL(string) tacklr.InferenceStrategy            { return m }
-func (m *mockInferenceStrategy) WithReasoningLevel(string) tacklr.InferenceStrategy { return m }
-func (m *mockInferenceStrategy) WithStructuredOutput(any) tacklr.InferenceStrategy  { return m }
-func (m *mockInferenceStrategy) SetSystemPrompt(string)                             {}
-func (m *mockInferenceStrategy) Reset()                                             {}
-func (m *mockInferenceStrategy) CompressContextWindow() error                       { return nil }
-func (m *mockInferenceStrategy) MaxContextWindow() (int, error)                     { return 0, nil }
+func (m *mockInferenceStrategy) MaxContextWindow() (int, error) { return 0, nil }
 func (m *mockInferenceStrategy) SupportsMIME(mimeType string) bool {
 	if m.supportsMIMEFn != nil {
 		return m.supportsMIMEFn(mimeType)
@@ -38,7 +30,7 @@ func (m *mockInferenceStrategy) SupportsMIME(mimeType string) bool {
 func (m *mockInferenceStrategy) CountTokens(ctx context.Context, msgs []*tacklr.Message, tools []*tacklr.Tool) (int, error) {
 	return 0, nil
 }
-func (m *mockInferenceStrategy) Invoke(ctx context.Context, msgs []*tacklr.Message, tools []*tacklr.Tool) (chan tacklr.LLMResponseChunk, error) {
+func (m *mockInferenceStrategy) Invoke(ctx context.Context, msgs []*tacklr.Message, tools []*tacklr.Tool, _ string) (chan tacklr.LLMResponseChunk, error) {
 	if m.invokeErr != nil {
 		return nil, m.invokeErr
 	}
@@ -51,6 +43,15 @@ func (m *mockInferenceStrategy) Invoke(ctx context.Context, msgs []*tacklr.Messa
 		}
 	}()
 	return ch, nil
+}
+
+func mustAgent(t *testing.T, opts tacklr.AgentOptions) *tacklr.AgentHarness {
+	t.Helper()
+	h, err := tacklr.NewAgent(context.Background(), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
 }
 
 func testStore(t *testing.T) *stores.InMemoryStore {

--- a/server/wire_outcomes_test.go
+++ b/server/wire_outcomes_test.go
@@ -122,7 +122,10 @@ func TestWireAndConstruct_outcomes(t *testing.T) {
 
 	// --- Registry DefaultAgent / options ---
 	_ = NewRegistry(testStore(t), "d", WithTracer(nil), nil)
-	r2 := NewRegistry(testStore(t), "d", WithTracer(nil))
+	r2 := NewRegistry(testStore(t), "d", WithTracer(nil), func(reg *Registry) {
+		reg.tracer = nil
+		reg.instruments = nil
+	})
 	if r2.DefaultAgent() != "d" {
 		t.Fatal(r2.DefaultAgent())
 	}

--- a/subagents.go
+++ b/subagents.go
@@ -10,13 +10,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ryanaldo34/tacklr/internal/session"
 	"github.com/ryanaldo34/tacklr/interrupt"
 	"github.com/ryanaldo34/tacklr/streaming"
 )
 
 // Worker failures wrap the package categories (ErrNotFound, ErrInvalid, ErrFailed).
-
-const parkedWorkersStateKey = "_parked_workers"
 
 // SubAgent describes a specialized worker that a harness can spawn via the
 // spawn_worker tool. Specs may nest via SubAgents so interrupt propagation
@@ -34,35 +33,30 @@ type SubAgent struct {
 	SubAgents []*SubAgent
 }
 
-// parkedWorkerMeta is durable park metadata stored in user State (SessionManager bag).
-// Live harness pointers are not stored here; they live in parkedWorkersLive.
-type parkedWorkerMeta struct {
-	WorkerName        string   `json:"workerName"`
-	WorkerSessionID   string   `json:"workerSessionId"`
-	Task              string   `json:"task"`
-	ChildInterruptIDs []string `json:"childInterruptIds"`
-}
+// parkedWorkerMeta is durable park metadata. Live harness pointers live in parkedWorkersLive.
+type parkedWorkerMeta = session.ParkedWorkerMeta
 
 // initSubAgentWorkers registers worker specs. Invalid or duplicate specs are
 // constructor errors (panic): a misconfigured host must not start a harness
 // that silently drops workers.
-func (h *AgentHarness) initSubAgentWorkers(specs []*SubAgent) {
+func (h *AgentHarness) initSubAgentWorkers(specs []*SubAgent) error {
 	for _, spec := range specs {
 		if spec == nil {
-			panic("tacklr: SubAgent must not be nil")
+			return fmt.Errorf("tacklr: SubAgent must not be nil")
 		}
 		if spec.WorkerName == "" {
-			panic("tacklr: SubAgent.WorkerName is required")
+			return fmt.Errorf("tacklr: SubAgent.WorkerName is required")
 		}
 		if spec.Model == nil {
-			panic("tacklr: SubAgent.Model is required")
+			return fmt.Errorf("tacklr: SubAgent.Model is required")
 		}
 		if _, exists := h.subagents[spec.WorkerName]; exists {
-			panic("tacklr: duplicate SubAgent worker name " + spec.WorkerName)
+			return fmt.Errorf("tacklr: duplicate SubAgent worker name %s", spec.WorkerName)
 		}
 		cp := *spec
 		h.subagents[spec.WorkerName] = &cp
 	}
+	return nil
 }
 
 // workerNames returns registered worker names in sorted order.
@@ -121,11 +115,11 @@ func (a *AgentHarness) runWorker(ctx context.Context, workerName, task string, r
 	if !ok {
 		return "", fmt.Errorf("worker %q: %w", workerName, ErrNotFound)
 	}
-	if strings.TrimSpace(task) == "" && a.getParkMeta(runtime.CurrentToolCallID) == nil {
+	if strings.TrimSpace(task) == "" && a.getParkMeta(runtime.CurrentToolCallID()) == nil {
 		return "", fmt.Errorf("worker %q: empty task: %w", workerName, ErrInvalid)
 	}
 
-	toolCallID := runtime.CurrentToolCallID
+	toolCallID := runtime.CurrentToolCallID()
 	logAttrs := []any{
 		"area", "subagent",
 		"session_id", a.sessionId,
@@ -165,7 +159,11 @@ func (a *AgentHarness) runWorker(ctx context.Context, workerName, task string, r
 		closeOnExit = !live
 	} else {
 		slog.Info("spawning worker", logAttrs...)
-		worker = a.newWorkerHarness(workerCtx, workerName, toolCallID, spec)
+		var err error
+		worker, err = a.newWorkerHarness(workerCtx, workerName, toolCallID, spec)
+		if err != nil {
+			return "", fmt.Errorf("worker %q: %w", workerName, err)
+		}
 		closeOnExit = true
 	}
 
@@ -259,11 +257,14 @@ func (a *AgentHarness) runWorker(ctx context.Context, workerName, task string, r
 	return "", err
 }
 
-func (a *AgentHarness) newWorkerHarness(ctx context.Context, workerName, parentToolCallID string, spec *SubAgent) *AgentHarness {
+func (a *AgentHarness) newWorkerHarness(ctx context.Context, workerName, parentToolCallID string, spec *SubAgent) (*AgentHarness, error) {
 	sessionID := workerSessionID(a.sessionId, workerName, parentToolCallID)
-	worker := NewAgent(ctx, a.workerOptsForSpawn(spec))
+	worker, err := NewAgent(ctx, a.workerOptsForSpawn(spec))
+	if err != nil {
+		return nil, err
+	}
 	worker.sessionId = sessionID
-	return worker
+	return worker, nil
 }
 
 func workerSessionID(parentSessionID, workerName, parentToolCallID string) string {
@@ -274,7 +275,7 @@ func workerSessionID(parentSessionID, workerName, parentToolCallID string) strin
 }
 
 // workerOptsFromSpec builds shared worker options: host mount, brain,
-// shared index bridge, and skipPlanningLock. Omits SearchNamespace so
+// shared index bridge, and DisablePlanningLock. Omits SearchNamespace so
 // resume keeps the checkpointed worker session value.
 func (a *AgentHarness) workerOptsFromSpec(spec *SubAgent) AgentOptions {
 	return AgentOptions{
@@ -293,7 +294,7 @@ func (a *AgentHarness) workerOptsFromSpec(spec *SubAgent) AgentOptions {
 		MountSession:         a.VFS(),
 		RunCommandUnattended: a.runCommandUnattended,
 		shareIndexBridge:     a.vfsBridge,
-		skipPlanningLock:     true,
+		DisablePlanningLock:  true,
 	}
 }
 
@@ -382,19 +383,16 @@ func (p parkStore) get(toolCallID string) *parkedWorkerMeta {
 	if toolCallID == "" {
 		return nil
 	}
-	parks := p.load()
-	if meta, ok := parks[toolCallID]; ok {
-		cp := meta
-		return &cp
+	meta, ok := p.h.session.ParkedWorker(toolCallID)
+	if !ok {
+		return nil
 	}
-	return nil
+	cp := meta
+	return &cp
 }
 
 func (p parkStore) set(toolCallID string, meta parkedWorkerMeta, worker *AgentHarness) {
-	parks := p.load()
-	parks[toolCallID] = meta
-	p.store(parks)
-
+	p.h.session.SetParkedWorker(toolCallID, meta)
 	p.h.parkMu.Lock()
 	if worker != nil {
 		p.h.parkedWorkersLive[toolCallID] = worker
@@ -406,11 +404,7 @@ func (p parkStore) clear(toolCallID string) {
 	if toolCallID == "" {
 		return
 	}
-	parks := p.load()
-	if _, ok := parks[toolCallID]; ok {
-		delete(parks, toolCallID)
-		p.store(parks)
-	}
+	p.h.session.DeleteParkedWorker(toolCallID)
 	p.h.parkMu.Lock()
 	live := p.h.parkedWorkersLive[toolCallID]
 	delete(p.h.parkedWorkersLive, toolCallID)
@@ -421,30 +415,6 @@ func (p parkStore) clear(toolCallID string) {
 	if p.h.interruptPayloads != nil {
 		delete(p.h.interruptPayloads, toolCallID)
 	}
-}
-
-func (p parkStore) load() map[string]parkedWorkerMeta {
-	raw, ok := p.h.session.StateGet(parkedWorkersStateKey)
-	if !ok || raw == nil {
-		return map[string]parkedWorkerMeta{}
-	}
-	m, ok := raw.(map[string]parkedWorkerMeta)
-	if !ok || m == nil {
-		return map[string]parkedWorkerMeta{}
-	}
-	out := make(map[string]parkedWorkerMeta, len(m))
-	for k, v := range m {
-		out[k] = v
-	}
-	return out
-}
-
-func (p parkStore) store(parks map[string]parkedWorkerMeta) {
-	if len(parks) == 0 {
-		p.h.session.StateDelete(parkedWorkersStateKey)
-		return
-	}
-	p.h.session.StateSet(parkedWorkersStateKey, parks)
 }
 
 // workerDrainResult is the outcome of draining a child event stream.

--- a/subagents_test.go
+++ b/subagents_test.go
@@ -26,12 +26,9 @@ import (
 func TestNewAgent_rejectsInvalidSubAgents(t *testing.T) {
 	ok := &mockStrategy{}
 	t.Run("nil model", func(t *testing.T) {
-		defer func() {
-			if recover() == nil {
-				t.Fatal("expected constructor panic")
-			}
-		}()
-		NewAgent(context.Background(), AgentOptions{Config: Config{MaxWindowSize: 8192}})
+		if _, err := NewAgent(context.Background(), AgentOptions{Config: Config{MaxWindowSize: 8192}}); err == nil {
+			t.Fatal("expected constructor error")
+		}
 	})
 	cases := []struct {
 		name  string
@@ -47,14 +44,11 @@ func TestNewAgent_rejectsInvalidSubAgents(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			defer func() {
-				if recover() == nil {
-					t.Fatal("expected constructor panic")
-				}
-			}()
-			NewAgent(context.Background(), AgentOptions{
+			if _, err := NewAgent(context.Background(), AgentOptions{
 				Config: Config{MaxWindowSize: 8192}, Model: ok, SubAgents: tc.specs,
-			})
+			}); err == nil {
+				t.Fatal("expected constructor error")
+			}
 		})
 	}
 }
@@ -145,7 +139,7 @@ func TestSpawnWorker_success(t *testing.T) {
 		}
 	}
 
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192, MaxTurnRequests: 16},
 		Model:  parent,
 		Store:  stores.NewInMemoryStore(),
@@ -224,7 +218,7 @@ func TestSpawnWorker_contextCancel(t *testing.T) {
 			toolCall("c1", "spawn_worker", `{"worker_name":"researcher","task_description_and_context":"do work"}`),
 		}, IsComplete: true}
 	}
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  parent,
 		SubAgents: []*SubAgent{
@@ -245,7 +239,7 @@ func TestSpawnWorker_interruptPropagatesAndResumes(t *testing.T) {
 	optionsJSON := `[{"title":"A","description":"a","isRecommended":true},{"title":"B","description":"b","isRecommended":false}]`
 	interruptTool := NewTool(ToolConfig{
 		Name: "ask_user",
-		Handler: func(ctx context.Context, _ struct{}, runtime *HarnessRuntime) (string, error) {
+		Handler: func(ctx context.Context, _ struct{}, runtime HarnessRuntime) (string, error) {
 			intr, err := runtime.RaiseInterrupt("user_selection_choice", []byte(optionsJSON))
 			if err != nil {
 				return "", err
@@ -294,7 +288,7 @@ func TestSpawnWorker_interruptPropagatesAndResumes(t *testing.T) {
 
 	// Store save failures must not drop a live interrupt — park stays in-process.
 	store := failSaveStore{InMemoryStore: stores.NewInMemoryStore()}
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		SessionID: "sess-root",
 		Config:    Config{MaxWindowSize: 8192},
 		Model:     parentModel,
@@ -354,7 +348,7 @@ func TestSpawnWorker_interruptPropagatesAndResumes(t *testing.T) {
 	}
 
 	// No store: dropping the live park must fail resume (nothing durable to attach).
-	volatile := NewAgent(context.Background(), AgentOptions{
+	volatile := mustNewAgent(t, context.Background(), AgentOptions{
 		SessionID: "sess-volatile",
 		Config:    Config{MaxWindowSize: 8192},
 		Model:     parentModel,
@@ -403,7 +397,7 @@ func TestSpawnWorker_nestedInterruptPropagates(t *testing.T) {
 	optionsJSON := `[{"title":"NestedA","description":"a","isRecommended":true}]`
 	interruptTool := NewTool(ToolConfig{
 		Name: "ask_user",
-		Handler: func(ctx context.Context, _ struct{}, runtime *HarnessRuntime) (string, error) {
+		Handler: func(ctx context.Context, _ struct{}, runtime HarnessRuntime) (string, error) {
 			intr, err := runtime.RaiseInterrupt("user_selection_choice", []byte(optionsJSON))
 			if err != nil {
 				return "", err
@@ -468,7 +462,7 @@ func TestSpawnWorker_nestedInterruptPropagates(t *testing.T) {
 	}
 
 	store := stores.NewInMemoryStore()
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		SessionID: "sess-nested",
 		Config:    Config{MaxWindowSize: 8192},
 		Model:     rootModel,
@@ -529,7 +523,7 @@ func TestSpawnWorker_interruptSurvivesSessionReload(t *testing.T) {
 	optionsJSON := `[{"title":"ReloadA","description":"a","isRecommended":true}]`
 	interruptTool := NewTool(ToolConfig{
 		Name: "ask_user",
-		Handler: func(ctx context.Context, _ struct{}, runtime *HarnessRuntime) (string, error) {
+		Handler: func(ctx context.Context, _ struct{}, runtime HarnessRuntime) (string, error) {
 			intr, err := runtime.RaiseInterrupt("user_selection_choice", []byte(optionsJSON))
 			if err != nil {
 				return "", err
@@ -582,7 +576,7 @@ func TestSpawnWorker_interruptSurvivesSessionReload(t *testing.T) {
 			{WorkerName: "researcher", Model: workerModel, Tools: []*Tool{interruptTool}},
 		},
 	}
-	h := NewAgent(context.Background(), opts)
+	h := mustNewAgent(t, context.Background(), opts)
 
 	events, err := h.Run(context.Background(), "start")
 	if err != nil {
@@ -647,7 +641,7 @@ func (failSaveStore) SaveSession(context.Context, string, stores.SessionCheckpoi
 func newWorkerHost(t *testing.T) (*AgentHarness, *AgentHarness, *vfs.MountSession, *brain.Engine, uuid.UUID) {
 	t.Helper()
 	parent, ms, eng, ns := vfsIndexHarness(t, true)
-	worker := NewAgent(context.Background(), parent.workerOptsForSpawn(&SubAgent{WorkerName: "researcher", Model: &mockStrategy{}}))
+	worker := mustNewAgent(t, context.Background(), parent.workerOptsForSpawn(&SubAgent{WorkerName: "researcher", Model: &mockStrategy{}}))
 	t.Cleanup(worker.Close)
 	return parent, worker, ms, eng, ns
 }
@@ -733,7 +727,7 @@ func TestSpawnWorker_resumeKeepsParentVFS(t *testing.T) {
 	optionsJSON := `[{"title":"A","description":"a","isRecommended":true}]`
 	interruptTool := NewTool(ToolConfig{
 		Name: "ask_user",
-		Handler: func(ctx context.Context, _ struct{}, runtime *HarnessRuntime) (string, error) {
+		Handler: func(ctx context.Context, _ struct{}, runtime HarnessRuntime) (string, error) {
 			intr, err := runtime.RaiseInterrupt("user_selection_choice", []byte(optionsJSON))
 			if err != nil {
 				return "", err
@@ -798,7 +792,7 @@ func TestSpawnWorker_resumeKeepsParentVFS(t *testing.T) {
 	if err := reg.Register(vfs.LocalFactory{ID: "scratch", Base: t.TempDir()}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession(t.Name(), reg)
+	ms := vfs.MustNewMountSession(t.Name(), reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
@@ -818,7 +812,7 @@ func TestSpawnWorker_resumeKeepsParentVFS(t *testing.T) {
 			{WorkerName: "researcher", Model: workerModel, Tools: []*Tool{interruptTool}},
 		},
 	}
-	parent := NewAgent(ctx, opts)
+	parent := mustNewAgent(t, ctx, opts)
 
 	events, err := parent.Run(ctx, "park worker")
 	if err != nil {

--- a/subagents_test.go
+++ b/subagents_test.go
@@ -139,7 +139,7 @@ func TestSpawnWorker_success(t *testing.T) {
 		}
 	}
 
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192, MaxTurnRequests: 16},
 		Model:  parent,
 		Store:  stores.NewInMemoryStore(),
@@ -218,7 +218,7 @@ func TestSpawnWorker_contextCancel(t *testing.T) {
 			toolCall("c1", "spawn_worker", `{"worker_name":"researcher","task_description_and_context":"do work"}`),
 		}, IsComplete: true}
 	}
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  parent,
 		SubAgents: []*SubAgent{
@@ -288,7 +288,7 @@ func TestSpawnWorker_interruptPropagatesAndResumes(t *testing.T) {
 
 	// Store save failures must not drop a live interrupt — park stays in-process.
 	store := failSaveStore{InMemoryStore: stores.NewInMemoryStore()}
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		SessionID: "sess-root",
 		Config:    Config{MaxWindowSize: 8192},
 		Model:     parentModel,
@@ -348,7 +348,7 @@ func TestSpawnWorker_interruptPropagatesAndResumes(t *testing.T) {
 	}
 
 	// No store: dropping the live park must fail resume (nothing durable to attach).
-	volatile := mustNewAgent(t, context.Background(), AgentOptions{
+	volatile := mustNewAgent(t, AgentOptions{
 		SessionID: "sess-volatile",
 		Config:    Config{MaxWindowSize: 8192},
 		Model:     parentModel,
@@ -462,7 +462,7 @@ func TestSpawnWorker_nestedInterruptPropagates(t *testing.T) {
 	}
 
 	store := stores.NewInMemoryStore()
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		SessionID: "sess-nested",
 		Config:    Config{MaxWindowSize: 8192},
 		Model:     rootModel,
@@ -576,7 +576,7 @@ func TestSpawnWorker_interruptSurvivesSessionReload(t *testing.T) {
 			{WorkerName: "researcher", Model: workerModel, Tools: []*Tool{interruptTool}},
 		},
 	}
-	h := mustNewAgent(t, context.Background(), opts)
+	h := mustNewAgent(t, opts)
 
 	events, err := h.Run(context.Background(), "start")
 	if err != nil {
@@ -641,7 +641,7 @@ func (failSaveStore) SaveSession(context.Context, string, stores.SessionCheckpoi
 func newWorkerHost(t *testing.T) (*AgentHarness, *AgentHarness, *vfs.MountSession, *brain.Engine, uuid.UUID) {
 	t.Helper()
 	parent, ms, eng, ns := vfsIndexHarness(t, true)
-	worker := mustNewAgent(t, context.Background(), parent.workerOptsForSpawn(&SubAgent{WorkerName: "researcher", Model: &mockStrategy{}}))
+	worker := mustNewAgent(t, parent.workerOptsForSpawn(&SubAgent{WorkerName: "researcher", Model: &mockStrategy{}}))
 	t.Cleanup(worker.Close)
 	return parent, worker, ms, eng, ns
 }
@@ -812,7 +812,7 @@ func TestSpawnWorker_resumeKeepsParentVFS(t *testing.T) {
 			{WorkerName: "researcher", Model: workerModel, Tools: []*Tool{interruptTool}},
 		},
 	}
-	parent := mustNewAgent(t, ctx, opts)
+	parent := mustNewAgent(t, opts)
 
 	events, err := parent.Run(ctx, "park worker")
 	if err != nil {

--- a/tacklr_test.go
+++ b/tacklr_test.go
@@ -183,7 +183,7 @@ func TestAgentHarness_Run(t *testing.T) {
 				events <- LLMResponseChunk{Type: StreamEventMessage, Content: "Hello!", IsComplete: true}
 			},
 		}
-		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
+		ah := mustNewAgent(t, AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
 		ch, err := ah.Run(context.Background(), "Hi")
 		if err != nil {
 			t.Fatal(err)
@@ -232,7 +232,7 @@ func TestAgentHarness_Run(t *testing.T) {
 				events <- LLMResponseChunk{Type: StreamEventMessage, Content: "after progress", IsComplete: true}
 			},
 		}
-		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{progress}})
+		ah := mustNewAgent(t, AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{progress}})
 		ch, err := ah.Run(context.Background(), "progress")
 		if err != nil {
 			t.Fatal(err)
@@ -274,7 +274,7 @@ func TestAgentHarness_Run(t *testing.T) {
 				events <- LLMResponseChunk{Type: StreamEventMessage, Content: "Done!", IsComplete: true}
 			},
 		}
-		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
+		ah := mustNewAgent(t, AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
 		ch, err := ah.Run(context.Background(), "Say hello")
 		if err != nil {
 			t.Fatal(err)
@@ -350,7 +350,7 @@ func TestAgentHarness_Run(t *testing.T) {
 				events <- LLMResponseChunk{Type: StreamEventMessage, Content: "done", IsComplete: true}
 			},
 		}
-		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store})
+		ah := mustNewAgent(t, AgentOptions{Config: Config{}, Model: strategy, Store: store})
 		ch, err := ah.Run(context.Background(), "test")
 		if err != nil {
 			t.Fatal(err)
@@ -383,7 +383,7 @@ func TestAgentHarness_Run(t *testing.T) {
 				events <- LLMResponseChunk{Type: StreamEventMessage, Content: "gave up", IsComplete: true}
 			},
 		}
-		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
+		ah := mustNewAgent(t, AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
 		ch, err := ah.Run(context.Background(), "test")
 		if err != nil {
 			t.Fatal(err)
@@ -437,7 +437,7 @@ func TestAgentHarness_Run(t *testing.T) {
 				events <- LLMResponseChunk{Type: StreamEventMessage, Content: "done", IsComplete: true}
 			},
 		}
-		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{brokenTool}})
+		ah := mustNewAgent(t, AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{brokenTool}})
 		ch, err := ah.Run(context.Background(), "test")
 		if err != nil {
 			t.Fatal(err)
@@ -459,7 +459,7 @@ func TestAgentHarness_Run(t *testing.T) {
 		strategy := &mockStrategy{
 			invokeErr: fmt.Errorf("network error"),
 		}
-		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store})
+		ah := mustNewAgent(t, AgentOptions{Config: Config{}, Model: strategy, Store: store})
 		ch, err := ah.Run(context.Background(), "test")
 		if err != nil {
 			t.Fatal(err)
@@ -493,7 +493,7 @@ func TestAgentHarness_Run(t *testing.T) {
 			},
 		}
 
-		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{interruptTool}})
+		ah := mustNewAgent(t, AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{interruptTool}})
 
 		ch, err := ah.Run(context.Background(), "start")
 		if err != nil {
@@ -630,7 +630,7 @@ func TestAgentHarness_Run(t *testing.T) {
 			},
 		}
 
-		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
+		ah := mustNewAgent(t, AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
 		ah.session.Plan().Set([]Todo{
 			{Title: "Task 1", Status: streaming.TodoStatusInProgress},
 			{Title: "Task 2", Status: streaming.TodoStatusPending},
@@ -730,7 +730,7 @@ func TestAgentHarness_Run(t *testing.T) {
 			},
 		}
 
-		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{interruptTool}})
+		ah := mustNewAgent(t, AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{interruptTool}})
 		ah.session.Plan().Set([]Todo{
 			{Title: "Task 1", Status: streaming.TodoStatusInProgress},
 		})
@@ -811,7 +811,7 @@ func TestAgentHarness_Run(t *testing.T) {
 			},
 		}
 
-		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
+		ah := mustNewAgent(t, AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
 
 		ch, err := ah.Run(context.Background(), "Greet the world")
 		if err != nil {
@@ -896,7 +896,7 @@ func TestAgentHarness_Run(t *testing.T) {
 			},
 		}
 
-		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
+		ah := mustNewAgent(t, AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
 		ah.session.Plan().Set([]Todo{
 			{Title: "Only", Status: streaming.TodoStatusInProgress},
 		})
@@ -959,7 +959,7 @@ func TestAgentHarness_Run(t *testing.T) {
 			},
 		}
 
-		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
+		ah := mustNewAgent(t, AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
 		ah.session.Plan().Set([]Todo{
 			{Title: "Task 1", Status: streaming.TodoStatusInProgress},
 			{Title: "Task 2", Status: streaming.TodoStatusPending},
@@ -1008,7 +1008,7 @@ func TestNewAgent(t *testing.T) {
 	mockModel := &mockStrategy{}
 	wd := &recordingWatchdog{}
 
-	h := mustNewAgent(t, context.Background(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config: Config{
 			MaxWindowSize: 4096,
 			SystemPrompt:  "test prompt",
@@ -1061,7 +1061,7 @@ func TestRun_cancelMidStream_endsTurn(t *testing.T) {
 			}
 		},
 	}
-	h := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{MaxWindowSize: 8192}, Model: strategy})
+	h := mustNewAgent(t, AgentOptions{Config: Config{MaxWindowSize: 8192}, Model: strategy})
 	ctx, cancel := context.WithCancel(context.Background())
 	events, err := h.Run(ctx, "stream please")
 	if err != nil {
@@ -1118,7 +1118,7 @@ func TestRun_reasoningCapturedInContextWindow(t *testing.T) {
 			ch <- LLMResponseChunk{IsComplete: true}
 		},
 	}
-	h := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{MaxWindowSize: 8192}, Model: mock})
+	h := mustNewAgent(t, AgentOptions{Config: Config{MaxWindowSize: 8192}, Model: mock})
 
 	events, err := h.Run(context.Background(), "what is the answer?")
 	if err != nil {
@@ -1187,7 +1187,7 @@ func TestRun_windowPressure_summarizesAndPreservesUser(t *testing.T) {
 		},
 	}
 
-	ah := mustNewAgent(t, context.Background(), AgentOptions{
+	ah := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: maxWindow},
 		Model:  strategy,
 		Store:  store,
@@ -1276,7 +1276,7 @@ func TestRun_windowPressure_onToolResult_summarizes(t *testing.T) {
 	}
 
 	// Seed a near-full window so the large tool result tips pressure.
-	ah := mustNewAgent(t, context.Background(), AgentOptions{
+	ah := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: maxWindow},
 		Model:  strategy,
 		Store:  store,
@@ -1320,7 +1320,7 @@ func TestRun_countTokensError_emitsErrorEvent(t *testing.T) {
 			events <- LLMResponseChunk{Type: StreamEventMessage, Content: "should not run", IsComplete: true}
 		},
 	}
-	ah := mustNewAgent(t, context.Background(), AgentOptions{
+	ah := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Store:  testStore(t),
@@ -1370,7 +1370,7 @@ func TestRun_readSkill_returnsInstructions(t *testing.T) {
 		},
 	}
 
-	ah := mustNewAgent(t, context.Background(), AgentOptions{
+	ah := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192, SkillDirectories: []string{skillsRoot}},
 		Model:  strategy,
 		Store:  testStore(t),
@@ -1428,7 +1428,7 @@ func TestNewAgentFromSession_resumesPendingToolInterrupt(t *testing.T) {
 		},
 	}
 
-	ah := mustNewAgent(t, context.Background(), AgentOptions{
+	ah := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Store:  store,

--- a/tacklr_test.go
+++ b/tacklr_test.go
@@ -38,11 +38,6 @@ func (m *mockStrategy) ModelTelemetryIdentity() telemetry.ModelIdentity {
 	return telemetry.ModelIdentity{Provider: "unknown", Model: "mock"}
 }
 
-func (m *mockStrategy) WithApiKey(string) InferenceStrategy         { return m }
-func (m *mockStrategy) WithModel(string) InferenceStrategy          { return m }
-func (m *mockStrategy) WithURL(string) InferenceStrategy            { return m }
-func (m *mockStrategy) WithReasoningLevel(string) InferenceStrategy { return m }
-func (m *mockStrategy) WithStructuredOutput(any) InferenceStrategy  { return m }
 func (m *mockStrategy) SupportsMIME(mimeType string) bool {
 	if m.supportsMIMEFn != nil {
 		return m.supportsMIMEFn(mimeType)
@@ -50,13 +45,6 @@ func (m *mockStrategy) SupportsMIME(mimeType string) bool {
 	// Tests default to text-only models.
 	return streaming.IsTextMIME(mimeType)
 }
-func (m *mockStrategy) SetSystemPrompt(p string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.systemPrompts = append(m.systemPrompts, p)
-}
-func (m *mockStrategy) Reset()                       {}
-func (m *mockStrategy) CompressContextWindow() error { return nil }
 func (m *mockStrategy) MaxContextWindow() (int, error) {
 	return 0, nil
 }
@@ -67,7 +55,7 @@ func (m *mockStrategy) CountTokens(ctx context.Context, msgs []*Message, tools [
 	// Default 0 keeps existing tests under the window-pressure threshold.
 	return 0, nil
 }
-func (m *mockStrategy) Invoke(ctx context.Context, msgs []*Message, tools []*Tool) (chan LLMResponseChunk, error) {
+func (m *mockStrategy) Invoke(ctx context.Context, msgs []*Message, tools []*Tool, systemPrompt string) (chan LLMResponseChunk, error) {
 	if m.invokeErr != nil {
 		return nil, m.invokeErr
 	}
@@ -80,6 +68,9 @@ func (m *mockStrategy) Invoke(ctx context.Context, msgs []*Message, tools []*Too
 	m.mu.Lock()
 	m.lastInvokeMsgs = msgs
 	m.lastInvokeTools = tools
+	if systemPrompt != "" {
+		m.systemPrompts = append(m.systemPrompts, systemPrompt)
+	}
 	m.mu.Unlock()
 	ch := make(chan LLMResponseChunk)
 	go func() {
@@ -175,7 +166,7 @@ func TestAgentHarness_Run(t *testing.T) {
 
 	interruptTool := NewTool(ToolConfig{
 		Name: "ask_user",
-		Handler: func(ctx context.Context, _ struct{}, runtime *HarnessRuntime) (string, error) {
+		Handler: func(ctx context.Context, _ struct{}, runtime HarnessRuntime) (string, error) {
 			intr, err := runtime.RaiseInterrupt("user_selection_choice", []byte(optionsJSON))
 			if err != nil {
 				return "", err
@@ -192,7 +183,7 @@ func TestAgentHarness_Run(t *testing.T) {
 				events <- LLMResponseChunk{Type: StreamEventMessage, Content: "Hello!", IsComplete: true}
 			},
 		}
-		ah := NewAgent(context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
+		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
 		ch, err := ah.Run(context.Background(), "Hi")
 		if err != nil {
 			t.Fatal(err)
@@ -221,7 +212,7 @@ func TestAgentHarness_Run(t *testing.T) {
 		store := testStore(t)
 		progress := NewTool(ToolConfig{
 			Name: "progress_demo",
-			Handler: func(ctx context.Context, _ struct{}, runtime *HarnessRuntime) (string, error) {
+			Handler: func(ctx context.Context, _ struct{}, runtime HarnessRuntime) (string, error) {
 				runtime.EmitUpdate("starting")
 				runtime.EmitUpdate("halfway")
 				return "done-progress", nil
@@ -241,7 +232,7 @@ func TestAgentHarness_Run(t *testing.T) {
 				events <- LLMResponseChunk{Type: StreamEventMessage, Content: "after progress", IsComplete: true}
 			},
 		}
-		ah := NewAgent(context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{progress}})
+		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{progress}})
 		ch, err := ah.Run(context.Background(), "progress")
 		if err != nil {
 			t.Fatal(err)
@@ -283,7 +274,7 @@ func TestAgentHarness_Run(t *testing.T) {
 				events <- LLMResponseChunk{Type: StreamEventMessage, Content: "Done!", IsComplete: true}
 			},
 		}
-		ah := NewAgent(context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
+		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
 		ch, err := ah.Run(context.Background(), "Say hello")
 		if err != nil {
 			t.Fatal(err)
@@ -359,7 +350,7 @@ func TestAgentHarness_Run(t *testing.T) {
 				events <- LLMResponseChunk{Type: StreamEventMessage, Content: "done", IsComplete: true}
 			},
 		}
-		ah := NewAgent(context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store})
+		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store})
 		ch, err := ah.Run(context.Background(), "test")
 		if err != nil {
 			t.Fatal(err)
@@ -392,7 +383,7 @@ func TestAgentHarness_Run(t *testing.T) {
 				events <- LLMResponseChunk{Type: StreamEventMessage, Content: "gave up", IsComplete: true}
 			},
 		}
-		ah := NewAgent(context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
+		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
 		ch, err := ah.Run(context.Background(), "test")
 		if err != nil {
 			t.Fatal(err)
@@ -446,7 +437,7 @@ func TestAgentHarness_Run(t *testing.T) {
 				events <- LLMResponseChunk{Type: StreamEventMessage, Content: "done", IsComplete: true}
 			},
 		}
-		ah := NewAgent(context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{brokenTool}})
+		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{brokenTool}})
 		ch, err := ah.Run(context.Background(), "test")
 		if err != nil {
 			t.Fatal(err)
@@ -468,7 +459,7 @@ func TestAgentHarness_Run(t *testing.T) {
 		strategy := &mockStrategy{
 			invokeErr: fmt.Errorf("network error"),
 		}
-		ah := NewAgent(context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store})
+		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store})
 		ch, err := ah.Run(context.Background(), "test")
 		if err != nil {
 			t.Fatal(err)
@@ -502,7 +493,7 @@ func TestAgentHarness_Run(t *testing.T) {
 			},
 		}
 
-		ah := NewAgent(context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{interruptTool}})
+		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{}, Model: strategy, Store: store, Tools: []*Tool{interruptTool}})
 
 		ch, err := ah.Run(context.Background(), "start")
 		if err != nil {
@@ -639,7 +630,7 @@ func TestAgentHarness_Run(t *testing.T) {
 			},
 		}
 
-		ah := NewAgent(context.Background(), AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
+		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
 		ah.session.Plan().Set([]Todo{
 			{Title: "Task 1", Status: streaming.TodoStatusInProgress},
 			{Title: "Task 2", Status: streaming.TodoStatusPending},
@@ -739,7 +730,7 @@ func TestAgentHarness_Run(t *testing.T) {
 			},
 		}
 
-		ah := NewAgent(context.Background(), AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{interruptTool}})
+		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{interruptTool}})
 		ah.session.Plan().Set([]Todo{
 			{Title: "Task 1", Status: streaming.TodoStatusInProgress},
 		})
@@ -820,7 +811,7 @@ func TestAgentHarness_Run(t *testing.T) {
 			},
 		}
 
-		ah := NewAgent(context.Background(), AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
+		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
 
 		ch, err := ah.Run(context.Background(), "Greet the world")
 		if err != nil {
@@ -905,7 +896,7 @@ func TestAgentHarness_Run(t *testing.T) {
 			},
 		}
 
-		ah := NewAgent(context.Background(), AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
+		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
 		ah.session.Plan().Set([]Todo{
 			{Title: "Only", Status: streaming.TodoStatusInProgress},
 		})
@@ -968,7 +959,7 @@ func TestAgentHarness_Run(t *testing.T) {
 			},
 		}
 
-		ah := NewAgent(context.Background(), AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
+		ah := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{MaxWindowSize: 65536}, Model: strategy, Store: store, Tools: []*Tool{validTool}})
 		ah.session.Plan().Set([]Todo{
 			{Title: "Task 1", Status: streaming.TodoStatusInProgress},
 			{Title: "Task 2", Status: streaming.TodoStatusPending},
@@ -1006,12 +997,18 @@ func TestAgentHarness_Run(t *testing.T) {
 	})
 }
 
+func TestNewAgent_nilModel_error(t *testing.T) {
+	if _, err := NewAgent(context.Background(), AgentOptions{}); err == nil {
+		t.Fatal("expected constructor error")
+	}
+}
+
 func TestNewAgent(t *testing.T) {
 	store := testStore(t)
 	mockModel := &mockStrategy{}
 	wd := &recordingWatchdog{}
 
-	h := NewAgent(context.Background(), AgentOptions{
+	h := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{
 			MaxWindowSize: 4096,
 			SystemPrompt:  "test prompt",
@@ -1064,7 +1061,7 @@ func TestRun_cancelMidStream_endsTurn(t *testing.T) {
 			}
 		},
 	}
-	h := NewAgent(context.Background(), AgentOptions{Config: Config{MaxWindowSize: 8192}, Model: strategy})
+	h := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{MaxWindowSize: 8192}, Model: strategy})
 	ctx, cancel := context.WithCancel(context.Background())
 	events, err := h.Run(ctx, "stream please")
 	if err != nil {
@@ -1121,7 +1118,7 @@ func TestRun_reasoningCapturedInContextWindow(t *testing.T) {
 			ch <- LLMResponseChunk{IsComplete: true}
 		},
 	}
-	h := NewAgent(context.Background(), AgentOptions{Config: Config{MaxWindowSize: 8192}, Model: mock})
+	h := mustNewAgent(t, context.Background(), AgentOptions{Config: Config{MaxWindowSize: 8192}, Model: mock})
 
 	events, err := h.Run(context.Background(), "what is the answer?")
 	if err != nil {
@@ -1190,7 +1187,7 @@ func TestRun_windowPressure_summarizesAndPreservesUser(t *testing.T) {
 		},
 	}
 
-	ah := NewAgent(context.Background(), AgentOptions{
+	ah := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: maxWindow},
 		Model:  strategy,
 		Store:  store,
@@ -1279,7 +1276,7 @@ func TestRun_windowPressure_onToolResult_summarizes(t *testing.T) {
 	}
 
 	// Seed a near-full window so the large tool result tips pressure.
-	ah := NewAgent(context.Background(), AgentOptions{
+	ah := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: maxWindow},
 		Model:  strategy,
 		Store:  store,
@@ -1323,7 +1320,7 @@ func TestRun_countTokensError_emitsErrorEvent(t *testing.T) {
 			events <- LLMResponseChunk{Type: StreamEventMessage, Content: "should not run", IsComplete: true}
 		},
 	}
-	ah := NewAgent(context.Background(), AgentOptions{
+	ah := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Store:  testStore(t),
@@ -1373,7 +1370,7 @@ func TestRun_readSkill_returnsInstructions(t *testing.T) {
 		},
 	}
 
-	ah := NewAgent(context.Background(), AgentOptions{
+	ah := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192, SkillDirectories: []string{skillsRoot}},
 		Model:  strategy,
 		Store:  testStore(t),
@@ -1404,7 +1401,7 @@ func TestNewAgentFromSession_resumesPendingToolInterrupt(t *testing.T) {
 	store := testStore(t)
 	interruptTool := NewTool(ToolConfig{
 		Name: "ask_user",
-		Handler: func(ctx context.Context, _ struct{}, runtime *HarnessRuntime) (string, error) {
+		Handler: func(ctx context.Context, _ struct{}, runtime HarnessRuntime) (string, error) {
 			intr, err := runtime.RaiseInterrupt("user_selection_choice", []byte(
 				`[{"title":"Yes","description":"","isRecommended":true},{"title":"No","description":"","isRecommended":false}]`,
 			))
@@ -1431,7 +1428,7 @@ func TestNewAgentFromSession_resumesPendingToolInterrupt(t *testing.T) {
 		},
 	}
 
-	ah := NewAgent(context.Background(), AgentOptions{
+	ah := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Store:  store,

--- a/tool_runner.go
+++ b/tool_runner.go
@@ -19,8 +19,8 @@ type ToolInvocation struct {
 type ToolCallFunc func(ctx context.Context, inv ToolInvocation) (string, error)
 
 // ToolInterceptor wraps a tool call. Call next to continue, or return early to
-// short-circuit. Nil ToolInterceptors uses the built-in planning lock and
-// permission gate; a non-nil slice replaces that chain.
+// short-circuit. Host interceptors on AgentOptions wrap outside the built-in
+// planning lock and permission gate; they never replace that chain.
 type ToolInterceptor func(ctx context.Context, inv ToolInvocation, next ToolCallFunc) (string, error)
 
 type toolRunner struct {
@@ -66,10 +66,10 @@ func toolPermissionGate(ctx context.Context, inv ToolInvocation, next ToolCallFu
 	}
 
 	name := inv.Tool.Name
-	if permissionSetHas(inv.Runtime, permissionAlwaysDenyKey, name) {
+	if inv.Runtime != nil && inv.Runtime.PermissionAlwaysDenied(name) {
 		return "", fmt.Errorf("%w: tool %q is always rejected for this session", ErrToolPermissionDenied, name)
 	}
-	if permissionSetHas(inv.Runtime, permissionAlwaysAllowKey, name) {
+	if inv.Runtime != nil && inv.Runtime.PermissionAlwaysAllowed(name) {
 		return next(ctx, inv)
 	}
 
@@ -89,44 +89,17 @@ func toolPermissionGate(ctx context.Context, inv ToolInvocation, next ToolCallFu
 
 	switch perm.SelectedKind {
 	case interrupt.PermissionAllowAlways:
-		permissionRemember(inv.Runtime, permissionAlwaysAllowKey, name)
+		if inv.Runtime != nil {
+			inv.Runtime.RememberPermissionAllow(name)
+		}
 	case interrupt.PermissionRejectAlways:
-		permissionRemember(inv.Runtime, permissionAlwaysDenyKey, name)
+		if inv.Runtime != nil {
+			inv.Runtime.RememberPermissionDeny(name)
+		}
 	}
 
 	if !perm.Allowed {
 		return "", fmt.Errorf("%w: user rejected tool %q", ErrToolPermissionDenied, name)
 	}
 	return next(ctx, inv)
-}
-
-const (
-	permissionAlwaysAllowKey = "_permission_always_allow"
-	permissionAlwaysDenyKey  = "_permission_always_deny"
-)
-
-func permissionSet(rt HarnessRuntime, key string) map[string]bool {
-	v, ok := rt.StateGet(key)
-	if !ok || v == nil {
-		return map[string]bool{}
-	}
-	m, ok := v.(map[string]bool)
-	if !ok {
-		return map[string]bool{}
-	}
-	out := make(map[string]bool, len(m))
-	for k, b := range m {
-		out[k] = b
-	}
-	return out
-}
-
-func permissionSetHas(rt HarnessRuntime, key, toolName string) bool {
-	return permissionSet(rt, key)[toolName]
-}
-
-func permissionRemember(rt HarnessRuntime, key, toolName string) {
-	set := permissionSet(rt, key)
-	set[toolName] = true
-	rt.StateSet(key, set)
 }

--- a/tool_runner_test.go
+++ b/tool_runner_test.go
@@ -78,55 +78,6 @@ func TestHarness_planningWriteLock_thenUnlockAfterCreatePlan(t *testing.T) {
 	}
 }
 
-// TestHarness_disablePlanningLock_writeSucceedsWithoutPlan is the public
-// opt-out: write tools run before create_plan when DisablePlanningLock is set.
-func TestHarness_disablePlanningLock_writeSucceedsWithoutPlan(t *testing.T) {
-	writeTool := NewTool(ToolConfig{
-		Name:   "mutate",
-		Access: ToolWriteAccess,
-		Handler: func(ctx context.Context) (string, error) {
-			return "mutated", nil
-		},
-	})
-	var invokeCount int
-	strategy := &mockStrategy{
-		invokeFn: func(ctx context.Context, msgs []*Message, tools []*Tool, events chan<- LLMResponseChunk) {
-			invokeCount++
-			if invokeCount == 1 {
-				events <- LLMResponseChunk{Type: StreamEventFunctionCall, ToolCalls: []ToolCall{
-					{ID: "w1", CallID: "w1", Name: "mutate", Arguments: `{}`},
-				}, IsComplete: true}
-				events <- LLMResponseChunk{IsComplete: true}
-				return
-			}
-			events <- LLMResponseChunk{Type: StreamEventMessage, Content: "done", IsComplete: true}
-		},
-	}
-	ah := mustNewAgent(t, context.Background(), AgentOptions{
-		Config:              Config{MaxWindowSize: 8192},
-		Model:               strategy,
-		Tools:               []*Tool{writeTool},
-		DisablePlanningLock: true,
-	})
-
-	ch, err := ah.Run(context.Background(), "write now")
-	if err != nil {
-		t.Fatal(err)
-	}
-	var mutated bool
-	for ev := range ch {
-		if ev.Type == StreamEventToolResult && ev.Content == "mutated" {
-			mutated = true
-		}
-		if ev.Type == StreamEventToolResult && (strings.Contains(ev.Content, "locked") || strings.Contains(ev.Content, "permission denied")) {
-			t.Fatalf("write locked despite DisablePlanningLock: %q", ev.Content)
-		}
-	}
-	if !mutated {
-		t.Fatal("expected mutate success without create_plan")
-	}
-}
-
 // TestHarness_toolPermission_allowAlwaysRemembers: first call parks for
 // permission; allow-always resumes and runs the tool. After Close +
 // NewAgentFromSession the grant still skips the interrupt.

--- a/tool_runner_test.go
+++ b/tool_runner_test.go
@@ -47,7 +47,7 @@ func TestHarness_planningWriteLock_thenUnlockAfterCreatePlan(t *testing.T) {
 			}
 		},
 	}
-	ah := mustNewAgent(t, context.Background(), AgentOptions{
+	ah := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Tools:  []*Tool{writeTool},
@@ -114,7 +114,7 @@ func TestHarness_toolPermission_allowAlwaysRemembers(t *testing.T) {
 		Store:     store,
 		Tools:     []*Tool{tool},
 	}
-	ah := mustNewAgent(t, context.Background(), opts)
+	ah := mustNewAgent(t, opts)
 
 	ch1, err := ah.Run(context.Background(), "need secret")
 	if err != nil {
@@ -201,7 +201,7 @@ func TestHarness_toolPermission_rejectAlwaysRemembers(t *testing.T) {
 			}
 		},
 	}
-	ah := mustNewAgent(t, context.Background(), AgentOptions{
+	ah := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Tools:  []*Tool{tool},
@@ -298,7 +298,7 @@ func TestHarness_toolTimeout_surfacesAsToolResult(t *testing.T) {
 			events <- LLMResponseChunk{Type: StreamEventMessage, Content: "after timeout", IsComplete: true}
 		},
 	}
-	ah := mustNewAgent(t, context.Background(), AgentOptions{
+	ah := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Tools:  []*Tool{tool},
@@ -357,7 +357,7 @@ func TestHarness_hostInterceptor_keepsPermissionGate(t *testing.T) {
 			events <- LLMResponseChunk{Type: StreamEventMessage, Content: "done", IsComplete: true}
 		},
 	}
-	ah := mustNewAgent(t, context.Background(), AgentOptions{
+	ah := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Tools:  []*Tool{tool},

--- a/tool_runner_test.go
+++ b/tool_runner_test.go
@@ -47,7 +47,7 @@ func TestHarness_planningWriteLock_thenUnlockAfterCreatePlan(t *testing.T) {
 			}
 		},
 	}
-	ah := NewAgent(context.Background(), AgentOptions{
+	ah := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Tools:  []*Tool{writeTool},
@@ -114,7 +114,7 @@ func TestHarness_toolPermission_allowAlwaysRemembers(t *testing.T) {
 		Store:     store,
 		Tools:     []*Tool{tool},
 	}
-	ah := NewAgent(context.Background(), opts)
+	ah := mustNewAgent(t, context.Background(), opts)
 
 	ch1, err := ah.Run(context.Background(), "need secret")
 	if err != nil {
@@ -201,7 +201,7 @@ func TestHarness_toolPermission_rejectAlwaysRemembers(t *testing.T) {
 			}
 		},
 	}
-	ah := NewAgent(context.Background(), AgentOptions{
+	ah := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Tools:  []*Tool{tool},
@@ -298,7 +298,7 @@ func TestHarness_toolTimeout_surfacesAsToolResult(t *testing.T) {
 			events <- LLMResponseChunk{Type: StreamEventMessage, Content: "after timeout", IsComplete: true}
 		},
 	}
-	ah := NewAgent(context.Background(), AgentOptions{
+	ah := mustNewAgent(t, context.Background(), AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  strategy,
 		Tools:  []*Tool{tool},
@@ -329,5 +329,63 @@ func TestHarness_toolTimeout_surfacesAsToolResult(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("timeout tool result missing from context window")
+	}
+}
+
+// TestHarness_hostInterceptor_keepsPermissionGate: a host interceptor wraps
+// outside the built-in gates and cannot disable the permission interrupt.
+func TestHarness_hostInterceptor_keepsPermissionGate(t *testing.T) {
+	var hostSaw string
+	tool := NewTool(ToolConfig{
+		Name:               "crm_write",
+		PermissionRequired: true,
+		Handler: func(ctx context.Context) (string, error) {
+			return "should-not-run", nil
+		},
+	})
+	var invokeCount int
+	strategy := &mockStrategy{
+		invokeFn: func(ctx context.Context, msgs []*Message, tools []*Tool, events chan<- LLMResponseChunk) {
+			invokeCount++
+			if invokeCount == 1 {
+				events <- LLMResponseChunk{Type: StreamEventFunctionCall, ToolCalls: []ToolCall{
+					{ID: "c1", CallID: "c1", Name: "crm_write", Arguments: `{}`},
+				}, IsComplete: true}
+				events <- LLMResponseChunk{IsComplete: true}
+				return
+			}
+			events <- LLMResponseChunk{Type: StreamEventMessage, Content: "done", IsComplete: true}
+		},
+	}
+	ah := mustNewAgent(t, context.Background(), AgentOptions{
+		Config: Config{MaxWindowSize: 8192},
+		Model:  strategy,
+		Tools:  []*Tool{tool},
+		ToolInterceptors: []ToolInterceptor{
+			func(ctx context.Context, inv ToolInvocation, next ToolCallFunc) (string, error) {
+				hostSaw = inv.Tool.Name
+				return next(ctx, inv)
+			},
+		},
+	})
+	ch, err := ah.Run(context.Background(), "write crm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var interruptType string
+	for ev := range ch {
+		if ev.Type == StreamEventInterrupt {
+			var payload struct {
+				Type string `json:"type"`
+			}
+			_ = json.Unmarshal(ev.Data, &payload)
+			interruptType = payload.Type
+		}
+	}
+	if hostSaw != "crm_write" {
+		t.Fatalf("host interceptor saw %q", hostSaw)
+	}
+	if interruptType != "tool_permission" {
+		t.Fatalf("permission gate type = %q", interruptType)
 	}
 }

--- a/tool_runner_test.go
+++ b/tool_runner_test.go
@@ -78,6 +78,55 @@ func TestHarness_planningWriteLock_thenUnlockAfterCreatePlan(t *testing.T) {
 	}
 }
 
+// TestHarness_disablePlanningLock_writeSucceedsWithoutPlan is the public
+// opt-out: write tools run before create_plan when DisablePlanningLock is set.
+func TestHarness_disablePlanningLock_writeSucceedsWithoutPlan(t *testing.T) {
+	writeTool := NewTool(ToolConfig{
+		Name:   "mutate",
+		Access: ToolWriteAccess,
+		Handler: func(ctx context.Context) (string, error) {
+			return "mutated", nil
+		},
+	})
+	var invokeCount int
+	strategy := &mockStrategy{
+		invokeFn: func(ctx context.Context, msgs []*Message, tools []*Tool, events chan<- LLMResponseChunk) {
+			invokeCount++
+			if invokeCount == 1 {
+				events <- LLMResponseChunk{Type: StreamEventFunctionCall, ToolCalls: []ToolCall{
+					{ID: "w1", CallID: "w1", Name: "mutate", Arguments: `{}`},
+				}, IsComplete: true}
+				events <- LLMResponseChunk{IsComplete: true}
+				return
+			}
+			events <- LLMResponseChunk{Type: StreamEventMessage, Content: "done", IsComplete: true}
+		},
+	}
+	ah := mustNewAgent(t, context.Background(), AgentOptions{
+		Config:              Config{MaxWindowSize: 8192},
+		Model:               strategy,
+		Tools:               []*Tool{writeTool},
+		DisablePlanningLock: true,
+	})
+
+	ch, err := ah.Run(context.Background(), "write now")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mutated bool
+	for ev := range ch {
+		if ev.Type == StreamEventToolResult && ev.Content == "mutated" {
+			mutated = true
+		}
+		if ev.Type == StreamEventToolResult && (strings.Contains(ev.Content, "locked") || strings.Contains(ev.Content, "permission denied")) {
+			t.Fatalf("write locked despite DisablePlanningLock: %q", ev.Content)
+		}
+	}
+	if !mutated {
+		t.Fatal("expected mutate success without create_plan")
+	}
+}
+
 // TestHarness_toolPermission_allowAlwaysRemembers: first call parks for
 // permission; allow-always resumes and runs the tool. After Close +
 // NewAgentFromSession the grant still skips the interrupt.

--- a/tools.go
+++ b/tools.go
@@ -83,7 +83,7 @@ type mcpToolConfig struct {
 }
 
 var timeType = reflect.TypeOf(time.Time{})
-var harnessRuntimeType = reflect.TypeOf(HarnessRuntime{})
+var harnessRuntimeType = reflect.TypeOf((*HarnessRuntime)(nil)).Elem()
 var ctxType = reflect.TypeOf((*context.Context)(nil)).Elem()
 
 func NewTool(cfg ToolConfig) *Tool {
@@ -117,37 +117,30 @@ func NewTool(cfg ToolConfig) *Tool {
 	var argsType reflect.Type
 	var argsIsPtr bool
 	var hasRuntime bool
-	var runtimeIsPtr bool
 
 	if idx < numIn {
 		pType := fnType.In(idx)
-		baseType := pType
-		if baseType.Kind() == reflect.Ptr {
-			baseType = baseType.Elem()
-		}
-
-		if baseType == harnessRuntimeType {
+		if pType == harnessRuntimeType {
 			hasRuntime = true
-			runtimeIsPtr = pType.Kind() == reflect.Ptr
-		} else if baseType.Kind() == reflect.Struct {
-			argsType = baseType
-			argsIsPtr = pType.Kind() == reflect.Ptr
-			idx++
-			if idx < numIn {
-				rType := fnType.In(idx)
-				rBase := rType
-				if rBase.Kind() == reflect.Ptr {
-					rBase = rBase.Elem()
-				}
-				if rBase == harnessRuntimeType {
-					hasRuntime = true
-					runtimeIsPtr = rType.Kind() == reflect.Ptr
-				} else {
-					panic(fmt.Sprintf("tool %q: unexpected parameter type %v", cfg.Name, rType))
-				}
-			}
 		} else {
-			panic(fmt.Sprintf("tool %q: handler parameter must be a struct or HarnessRuntime, got %v", cfg.Name, pType))
+			baseType := pType
+			if baseType.Kind() == reflect.Ptr {
+				baseType = baseType.Elem()
+			}
+			if baseType.Kind() == reflect.Struct {
+				argsType = baseType
+				argsIsPtr = pType.Kind() == reflect.Ptr
+				idx++
+				if idx < numIn {
+					rType := fnType.In(idx)
+					if rType != harnessRuntimeType {
+						panic(fmt.Sprintf("tool %q: unexpected parameter type %v (want HarnessRuntime)", cfg.Name, rType))
+					}
+					hasRuntime = true
+				}
+			} else {
+				panic(fmt.Sprintf("tool %q: handler parameter must be a struct or HarnessRuntime, got %v", cfg.Name, pType))
+			}
 		}
 	}
 
@@ -199,8 +192,8 @@ func NewTool(cfg ToolConfig) *Tool {
 		}
 
 		if hasRuntime {
-			if runtimeIsPtr {
-				callArgs = append(callArgs, reflect.ValueOf(&runtime))
+			if runtime == nil {
+				callArgs = append(callArgs, reflect.Zero(harnessRuntimeType))
 			} else {
 				callArgs = append(callArgs, reflect.ValueOf(runtime))
 			}

--- a/tools_brain_test.go
+++ b/tools_brain_test.go
@@ -27,7 +27,7 @@ func TestBrainTools_saveDiscoveryAndLink(t *testing.T) {
 		t.Fatal(err)
 	}
 	ns := uuid.New()
-	h := mustNewAgent(t, ctx, AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 1024},
 		Model:  &mockStrategy{},
 		Brain:  eng,
@@ -167,7 +167,7 @@ func TestBrainTools_hostNamespaceScopedRead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := mustNewAgent(t, ctx, AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config:          Config{MaxWindowSize: 1024},
 		Model:           &mockStrategy{},
 		Brain:           eng,
@@ -261,7 +261,7 @@ func TestBrainTools_searchFindExactContinueAndCheckpoint(t *testing.T) {
 		t.Fatal(err)
 	}
 	sessStore := stores.NewInMemoryStore()
-	h := mustNewAgent(t, ctx, AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config:          Config{MaxWindowSize: 1024},
 		Model:           &mockStrategy{},
 		Brain:           eng,
@@ -374,7 +374,7 @@ func TestBrainTools_expandChildren(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := mustNewAgent(t, ctx, AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 1024}, Model: &mockStrategy{},
 		Brain: eng, SearchNamespace: &ns,
 	})
@@ -429,7 +429,7 @@ func TestBrainTools_expandMultiHopAndFindLinks(t *testing.T) {
 	if !eng.HasEdgeSearch() {
 		t.Fatal("MemoryGraph must enable edge search")
 	}
-	h := mustNewAgent(t, ctx, AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 1024}, Model: &mockStrategy{},
 		Brain: eng, SearchNamespace: &ns,
 	})
@@ -492,7 +492,7 @@ func TestBrainTools_searchNamespaceIsolation(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Agent scoped to nsB only.
-	h := mustNewAgent(t, ctx, AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Config: Config{MaxWindowSize: 1024}, Model: &mockStrategy{},
 		Brain: eng, SearchNamespace: &nsB,
 	})
@@ -545,7 +545,7 @@ func TestWorkerInheritsBrainAndNamespace(t *testing.T) {
 			ch <- LLMResponseChunk{Type: StreamEventMessage, Content: "ok", IsComplete: true}
 		},
 	}
-	parentH := mustNewAgent(t, ctx, AgentOptions{
+	parentH := mustNewAgent(t, AgentOptions{
 		Config:          Config{MaxWindowSize: 1024},
 		Model:           &mockStrategy{},
 		Brain:           eng,
@@ -620,7 +620,7 @@ func TestBrainTools_engramPathGraph(t *testing.T) {
 	}
 	ns := uuid.New()
 	mustMountBrain(ctx, t, reg, ms, eng, ns, vfs.MountSpec{})
-	h := mustNewAgent(t, ctx, AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		SessionID: "engram-graph", Store: stores.NewInMemoryStore(),
 		MountSession: ms, Model: &mockStrategy{},
 		Brain: eng, SearchNamespace: &ns,

--- a/tools_brain_test.go
+++ b/tools_brain_test.go
@@ -27,7 +27,7 @@ func TestBrainTools_saveDiscoveryAndLink(t *testing.T) {
 		t.Fatal(err)
 	}
 	ns := uuid.New()
-	h := NewAgent(ctx, AgentOptions{
+	h := mustNewAgent(t, ctx, AgentOptions{
 		Config: Config{MaxWindowSize: 1024},
 		Model:  &mockStrategy{},
 		Brain:  eng,
@@ -167,7 +167,7 @@ func TestBrainTools_hostNamespaceScopedRead(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := NewAgent(ctx, AgentOptions{
+	h := mustNewAgent(t, ctx, AgentOptions{
 		Config:          Config{MaxWindowSize: 1024},
 		Model:           &mockStrategy{},
 		Brain:           eng,
@@ -261,7 +261,7 @@ func TestBrainTools_searchFindExactContinueAndCheckpoint(t *testing.T) {
 		t.Fatal(err)
 	}
 	sessStore := stores.NewInMemoryStore()
-	h := NewAgent(ctx, AgentOptions{
+	h := mustNewAgent(t, ctx, AgentOptions{
 		Config:          Config{MaxWindowSize: 1024},
 		Model:           &mockStrategy{},
 		Brain:           eng,
@@ -374,7 +374,7 @@ func TestBrainTools_expandChildren(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := NewAgent(ctx, AgentOptions{
+	h := mustNewAgent(t, ctx, AgentOptions{
 		Config: Config{MaxWindowSize: 1024}, Model: &mockStrategy{},
 		Brain: eng, SearchNamespace: &ns,
 	})
@@ -429,7 +429,7 @@ func TestBrainTools_expandMultiHopAndFindLinks(t *testing.T) {
 	if !eng.HasEdgeSearch() {
 		t.Fatal("MemoryGraph must enable edge search")
 	}
-	h := NewAgent(ctx, AgentOptions{
+	h := mustNewAgent(t, ctx, AgentOptions{
 		Config: Config{MaxWindowSize: 1024}, Model: &mockStrategy{},
 		Brain: eng, SearchNamespace: &ns,
 	})
@@ -492,7 +492,7 @@ func TestBrainTools_searchNamespaceIsolation(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Agent scoped to nsB only.
-	h := NewAgent(ctx, AgentOptions{
+	h := mustNewAgent(t, ctx, AgentOptions{
 		Config: Config{MaxWindowSize: 1024}, Model: &mockStrategy{},
 		Brain: eng, SearchNamespace: &nsB,
 	})
@@ -545,7 +545,7 @@ func TestWorkerInheritsBrainAndNamespace(t *testing.T) {
 			ch <- LLMResponseChunk{Type: StreamEventMessage, Content: "ok", IsComplete: true}
 		},
 	}
-	parentH := NewAgent(ctx, AgentOptions{
+	parentH := mustNewAgent(t, ctx, AgentOptions{
 		Config:          Config{MaxWindowSize: 1024},
 		Model:           &mockStrategy{},
 		Brain:           eng,
@@ -555,7 +555,10 @@ func TestWorkerInheritsBrainAndNamespace(t *testing.T) {
 		},
 	})
 
-	worker := parentH.newWorkerHarness(ctx, "researcher", "spawn_tc1", parentH.subagents["researcher"])
+	worker, err := parentH.newWorkerHarness(ctx, "researcher", "spawn_tc1", parentH.subagents["researcher"])
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	gotNS, ok := worker.SearchNamespace()
 	if !ok || gotNS != ns {
@@ -597,7 +600,7 @@ func TestBrainTools_engramPathGraph(t *testing.T) {
 	if err := reg.Register(vfs.LocalFactory{ID: "scratch", Base: t.TempDir()}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("engram-graph", reg)
+	ms := vfs.MustNewMountSession("engram-graph", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
@@ -617,7 +620,7 @@ func TestBrainTools_engramPathGraph(t *testing.T) {
 	}
 	ns := uuid.New()
 	mustMountBrain(ctx, t, reg, ms, eng, ns, vfs.MountSpec{})
-	h := NewAgent(ctx, AgentOptions{
+	h := mustNewAgent(t, ctx, AgentOptions{
 		SessionID: "engram-graph", Store: stores.NewInMemoryStore(),
 		MountSession: ms, Model: &mockStrategy{},
 		Brain: eng, SearchNamespace: &ns,

--- a/tools_command_test.go
+++ b/tools_command_test.go
@@ -134,7 +134,7 @@ func newRunCommandSession(t *testing.T) (*vfs.MountSession, HarnessRuntime) {
 	if err := ms.Mount(t.Context(), vfs.MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
-	h := mustNewAgent(t, t.Context(), AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		SessionID:    t.Name(),
 		Store:        stores.NewInMemoryStore(),
 		MountSession: ms,

--- a/tools_command_test.go
+++ b/tools_command_test.go
@@ -130,11 +130,11 @@ func newRunCommandSession(t *testing.T) (*vfs.MountSession, HarnessRuntime) {
 	if err := reg.Register(vfs.LocalFactory{ID: "scratch", Base: t.TempDir()}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession(t.Name(), reg)
+	ms := vfs.MustNewMountSession(t.Name(), reg)
 	if err := ms.Mount(t.Context(), vfs.MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
-	h := NewAgent(t.Context(), AgentOptions{
+	h := mustNewAgent(t, t.Context(), AgentOptions{
 		SessionID:    t.Name(),
 		Store:        stores.NewInMemoryStore(),
 		MountSession: ms,

--- a/tools_test.go
+++ b/tools_test.go
@@ -59,7 +59,7 @@ func errHandler(ctx context.Context, args BasicArgs) (string, error) {
 func TestInvoke(t *testing.T) {
 	t.Run("returns raw string", func(t *testing.T) {
 		tool := NewTool(ToolConfig{Name: "zero", Handler: zeroArgsStringHandler})
-		res, err := tool.invoke(context.Background(), "", HarnessRuntime{})
+		res, err := tool.invoke(context.Background(), "", nil)
 		got := res.output
 		if err != nil {
 			t.Fatal(err)
@@ -71,7 +71,7 @@ func TestInvoke(t *testing.T) {
 
 	t.Run("marshals non-string return", func(t *testing.T) {
 		tool := NewTool(ToolConfig{Name: "zero_int", Handler: zeroArgsIntHandler})
-		res, err := tool.invoke(context.Background(), "", HarnessRuntime{})
+		res, err := tool.invoke(context.Background(), "", nil)
 		got := res.output
 		if err != nil {
 			t.Fatal(err)
@@ -89,7 +89,7 @@ func TestInvoke(t *testing.T) {
 			return "result", nil
 		}
 		tool := NewTool(ToolConfig{Name: "handler", Handler: h})
-		res, err := tool.invoke(context.Background(), `{"name":"test","age":10}`, HarnessRuntime{})
+		res, err := tool.invoke(context.Background(), `{"name":"test","age":10}`, nil)
 		got := res.output
 		if err != nil {
 			t.Fatal(err)
@@ -101,7 +101,7 @@ func TestInvoke(t *testing.T) {
 
 	t.Run("propagates handler error", func(t *testing.T) {
 		tool := NewTool(ToolConfig{Name: "err", Handler: errHandler})
-		_, err := tool.invoke(context.Background(), `{"name":"x","age":1}`, HarnessRuntime{})
+		_, err := tool.invoke(context.Background(), `{"name":"x","age":1}`, nil)
 		if err == nil || err.Error() != "boom" {
 			t.Fatalf("got %v, want boom", err)
 		}
@@ -109,7 +109,7 @@ func TestInvoke(t *testing.T) {
 
 	t.Run("bad json args errors", func(t *testing.T) {
 		tool := NewTool(ToolConfig{Name: "basic", Handler: basicHandler})
-		_, err := tool.invoke(context.Background(), `{bad`, HarnessRuntime{})
+		_, err := tool.invoke(context.Background(), `{bad`, nil)
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -128,7 +128,7 @@ func TestInvoke(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		_, err := tool.invoke(ctx, "", HarnessRuntime{})
+		_, err := tool.invoke(ctx, "", nil)
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -361,13 +361,13 @@ func TestNewTool_pointerArgsAndNonStringResultAndBadArgs(t *testing.T) {
 			return a.Name, nil
 		},
 	})
-	res, err := tool.invoke(context.Background(), `{"name":"x"}`, HarnessRuntime{})
+	res, err := tool.invoke(context.Background(), `{"name":"x"}`, nil)
 	got := res.output
 	if err != nil || got != "x" {
 		t.Fatalf("got %q %v", got, err)
 	}
 	// Type mismatch in JSON → invoke error.
-	_, err = tool.invoke(context.Background(), `{"name":123}`, HarnessRuntime{})
+	_, err = tool.invoke(context.Background(), `{"name":123}`, nil)
 	if err == nil {
 		t.Fatal("want unmarshal error")
 	}
@@ -383,7 +383,7 @@ func TestNewTool_pointerArgsAndNonStringResultAndBadArgs(t *testing.T) {
 			}{N: 7}, nil
 		},
 	})
-	res, err = tool2.invoke(context.Background(), "", HarnessRuntime{})
+	res, err = tool2.invoke(context.Background(), "", nil)
 	got = res.output
 	if err != nil || !strings.Contains(got, "7") {
 		t.Fatalf("got %q %v", got, err)
@@ -396,7 +396,7 @@ func TestNewTool_pointerArgsAndNonStringResultAndBadArgs(t *testing.T) {
 			return make(chan int), nil
 		},
 	})
-	_, err = tool3.invoke(context.Background(), "", HarnessRuntime{})
+	_, err = tool3.invoke(context.Background(), "", nil)
 	if err == nil {
 		t.Fatal("want marshal result error")
 	}

--- a/tools_test.go
+++ b/tools_test.go
@@ -296,10 +296,7 @@ func TestTypeToJSONSchema_structuredOutput(t *testing.T) {
 	if len(req) != 2 || req[0] != "title" || req[1] != "count" {
 		t.Fatalf("required = %v, want title and count only", req)
 	}
-}
-
-func TestTypeToJSONSchema_nilValue(t *testing.T) {
-	_, err := TypeToJSONSchema(nil)
+	_, err = TypeToJSONSchema(nil)
 	if err == nil || !strings.Contains(err.Error(), "nil value") {
 		t.Fatalf("want nil-value error, got %v", err)
 	}

--- a/tools_test.go
+++ b/tools_test.go
@@ -268,6 +268,43 @@ func TestAsJson(t *testing.T) {
 
 // TestMakeSchemaNullable_outcomes covers each rewrite branch of makeSchemaNullable
 // (used for strict optional fields). Cheap pure paths that lift library total cover.
+// TestTypeToJSONSchema_structuredOutput is the public structured-output
+// helper: omitempty fields stay optional (non-strict).
+func TestTypeToJSONSchema_structuredOutput(t *testing.T) {
+	type hostOut struct {
+		Title string  `json:"title" desc:"Headline"`
+		Note  *string `json:"note,omitempty" desc:"Optional note"`
+		Count int     `json:"count"`
+	}
+	schema, err := TypeToJSONSchema(hostOut{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if schema["type"] != "object" {
+		t.Fatalf("type = %v", schema["type"])
+	}
+	props, _ := schema["properties"].(map[string]any)
+	title, _ := props["title"].(map[string]any)
+	if title["type"] != "string" || title["description"] != "Headline" {
+		t.Fatalf("title = %#v", title)
+	}
+	note, _ := props["note"].(map[string]any)
+	if note["type"] != "string" || note["description"] != "Optional note" {
+		t.Fatalf("note must stay a plain string (non-strict), got %#v", note)
+	}
+	req, _ := schema["required"].([]string)
+	if len(req) != 2 || req[0] != "title" || req[1] != "count" {
+		t.Fatalf("required = %v, want title and count only", req)
+	}
+}
+
+func TestTypeToJSONSchema_nilValue(t *testing.T) {
+	_, err := TypeToJSONSchema(nil)
+	if err == nil || !strings.Contains(err.Error(), "nil value") {
+		t.Fatalf("want nil-value error, got %v", err)
+	}
+}
+
 func TestToolsAsJson(t *testing.T) {
 	tools := []*Tool{
 		NewTool(ToolConfig{Name: "a", Handler: zeroArgsStringHandler}),

--- a/tools_vfs_test.go
+++ b/tools_vfs_test.go
@@ -20,7 +20,7 @@ func TestVFSTools_readWriteRev(t *testing.T) {
 	if err := reg.Register(vfs.LocalFactory{ID: "scratch", Base: base}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("tools-vfs", reg)
+	ms := vfs.MustNewMountSession("tools-vfs", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +28,7 @@ func TestVFSTools_readWriteRev(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := NewAgent(ctx, AgentOptions{
+	h := mustNewAgent(t, ctx, AgentOptions{
 		SessionID:    "tools-vfs",
 		Store:        stores.NewInMemoryStore(),
 		MountSession: ms,
@@ -431,7 +431,7 @@ func TestVFSTools_runCommandLiveNames(t *testing.T) {
 	if err := reg.Register(vfs.LocalFactory{ID: "scratch", Base: base}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("live-names", reg)
+	ms := vfs.MustNewMountSession("live-names", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
@@ -452,7 +452,7 @@ func TestVFSTools_runCommandLiveNames(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = ms.Close() })
 
-	h := NewAgent(ctx, AgentOptions{
+	h := mustNewAgent(t, ctx, AgentOptions{
 		SessionID: "live-names", Store: stores.NewInMemoryStore(),
 		MountSession: ms, Model: &mockStrategy{},
 	})

--- a/tools_vfs_test.go
+++ b/tools_vfs_test.go
@@ -28,7 +28,7 @@ func TestVFSTools_readWriteRev(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := mustNewAgent(t, ctx, AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		SessionID:    "tools-vfs",
 		Store:        stores.NewInMemoryStore(),
 		MountSession: ms,
@@ -452,7 +452,7 @@ func TestVFSTools_runCommandLiveNames(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = ms.Close() })
 
-	h := mustNewAgent(t, ctx, AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		SessionID: "live-names", Store: stores.NewInMemoryStore(),
 		MountSession: ms, Model: &mockStrategy{},
 	})

--- a/tools_vfsindex_test.go
+++ b/tools_vfsindex_test.go
@@ -47,7 +47,7 @@ func vfsIndexHarness(t *testing.T, withNS bool) (*AgentHarness, *vfs.MountSessio
 	if withNS {
 		opts.SearchNamespace = &ns
 	}
-	h := mustNewAgent(t, ctx, opts)
+	h := mustNewAgent(t, opts)
 	t.Cleanup(h.Close)
 	return h, ms, eng, ns
 }
@@ -285,7 +285,7 @@ func TestVFSIndexTools_prefixAutoIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 	ns := uuid.New()
-	h := mustNewAgent(t, ctx, AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		SessionID: "policy-prefix", Store: stores.NewInMemoryStore(),
 		MountSession: ms, Model: &mockStrategy{},
 		Brain: eng, SearchNamespace: &ns,
@@ -327,7 +327,7 @@ func TestKnowledgeSaveSearchRead(t *testing.T) {
 	}
 	ns := uuid.New()
 	mustMountBrain(ctx, t, reg, ms, eng, ns, vfs.MountSpec{})
-	h := mustNewAgent(t, ctx, AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		SessionID: "save-mem", Store: stores.NewInMemoryStore(),
 		MountSession: ms, Model: &mockStrategy{},
 		Brain: eng, SearchNamespace: &ns,
@@ -455,7 +455,7 @@ func TestKnowledgeSave_rootsMount(t *testing.T) {
 		Point: "/discovery", Profile: brain.DefaultProfile,
 		Params: map[string]string{"mode": brain.ModeRoots, "kind": "Discovery"},
 	})
-	h := mustNewAgent(t, ctx, AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		SessionID: "save-roots", Store: stores.NewInMemoryStore(),
 		MountSession: ms, Model: &mockStrategy{},
 		Brain: eng, SearchNamespace: &ns,
@@ -594,7 +594,7 @@ func TestRun_workspaceResearchTurn(t *testing.T) {
 		}
 	}
 
-	h := mustNewAgent(t, ctx, AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		SessionID: "research-turn",
 		Store:     stores.NewInMemoryStore(),
 		Config: Config{
@@ -691,7 +691,7 @@ func TestPathNativeGraphLinkExpand(t *testing.T) {
 		t.Fatal(err)
 	}
 	ns := uuid.New()
-	h := mustNewAgent(t, ctx, AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		SessionID: "path-graph", Store: stores.NewInMemoryStore(),
 		MountSession: ms, Model: &mockStrategy{},
 		Brain: eng, SearchNamespace: &ns,

--- a/tools_vfsindex_test.go
+++ b/tools_vfsindex_test.go
@@ -24,7 +24,7 @@ func vfsIndexHarness(t *testing.T, withNS bool) (*AgentHarness, *vfs.MountSessio
 	if err := reg.Register(vfs.LocalFactory{ID: "scratch", Base: base}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("vfs-idx-tools", reg)
+	ms := vfs.MustNewMountSession("vfs-idx-tools", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func vfsIndexHarness(t *testing.T, withNS bool) (*AgentHarness, *vfs.MountSessio
 	if withNS {
 		opts.SearchNamespace = &ns
 	}
-	h := NewAgent(ctx, opts)
+	h := mustNewAgent(t, ctx, opts)
 	t.Cleanup(h.Close)
 	return h, ms, eng, ns
 }
@@ -271,7 +271,7 @@ func TestVFSIndexTools_prefixAutoIndex(t *testing.T) {
 	if err := reg.Register(vfs.LocalFactory{ID: "scratch", Base: base}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("policy-prefix", reg)
+	ms := vfs.MustNewMountSession("policy-prefix", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{
 		Point: "/work", Profile: "scratch", IndexPolicy: "  Prefix  ",
 	}); err != nil {
@@ -285,7 +285,7 @@ func TestVFSIndexTools_prefixAutoIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 	ns := uuid.New()
-	h := NewAgent(ctx, AgentOptions{
+	h := mustNewAgent(t, ctx, AgentOptions{
 		SessionID: "policy-prefix", Store: stores.NewInMemoryStore(),
 		MountSession: ms, Model: &mockStrategy{},
 		Brain: eng, SearchNamespace: &ns,
@@ -307,7 +307,7 @@ func TestKnowledgeSaveSearchRead(t *testing.T) {
 	if err := reg.Register(vfs.LocalFactory{ID: "scratch", Base: base}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("save-mem", reg)
+	ms := vfs.MustNewMountSession("save-mem", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
@@ -327,7 +327,7 @@ func TestKnowledgeSaveSearchRead(t *testing.T) {
 	}
 	ns := uuid.New()
 	mustMountBrain(ctx, t, reg, ms, eng, ns, vfs.MountSpec{})
-	h := NewAgent(ctx, AgentOptions{
+	h := mustNewAgent(t, ctx, AgentOptions{
 		SessionID: "save-mem", Store: stores.NewInMemoryStore(),
 		MountSession: ms, Model: &mockStrategy{},
 		Brain: eng, SearchNamespace: &ns,
@@ -434,7 +434,7 @@ func TestKnowledgeSave_rootsMount(t *testing.T) {
 	if err := reg.Register(vfs.LocalFactory{ID: "scratch", Base: base}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("save-roots", reg)
+	ms := vfs.MustNewMountSession("save-roots", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
@@ -455,7 +455,7 @@ func TestKnowledgeSave_rootsMount(t *testing.T) {
 		Point: "/discovery", Profile: brain.DefaultProfile,
 		Params: map[string]string{"mode": brain.ModeRoots, "kind": "Discovery"},
 	})
-	h := NewAgent(ctx, AgentOptions{
+	h := mustNewAgent(t, ctx, AgentOptions{
 		SessionID: "save-roots", Store: stores.NewInMemoryStore(),
 		MountSession: ms, Model: &mockStrategy{},
 		Brain: eng, SearchNamespace: &ns,
@@ -505,7 +505,7 @@ func TestRun_workspaceResearchTurn(t *testing.T) {
 	if err := reg.Register(vfs.LocalFactory{ID: "scratch", Base: base}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("research-turn", reg)
+	ms := vfs.MustNewMountSession("research-turn", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
@@ -594,7 +594,7 @@ func TestRun_workspaceResearchTurn(t *testing.T) {
 		}
 	}
 
-	h := NewAgent(ctx, AgentOptions{
+	h := mustNewAgent(t, ctx, AgentOptions{
 		SessionID: "research-turn",
 		Store:     stores.NewInMemoryStore(),
 		Config: Config{
@@ -677,7 +677,7 @@ func TestPathNativeGraphLinkExpand(t *testing.T) {
 	if err := reg.Register(vfs.LocalFactory{ID: "scratch", Base: base}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("path-graph", reg)
+	ms := vfs.MustNewMountSession("path-graph", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
@@ -691,7 +691,7 @@ func TestPathNativeGraphLinkExpand(t *testing.T) {
 		t.Fatal(err)
 	}
 	ns := uuid.New()
-	h := NewAgent(ctx, AgentOptions{
+	h := mustNewAgent(t, ctx, AgentOptions{
 		SessionID: "path-graph", Store: stores.NewInMemoryStore(),
 		MountSession: ms, Model: &mockStrategy{},
 		Brain: eng, SearchNamespace: &ns,

--- a/types.go
+++ b/types.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ryanaldo34/tacklr/internal/session"
 	"github.com/ryanaldo34/tacklr/interrupt"
 	"github.com/ryanaldo34/tacklr/streaming"
 )
@@ -106,16 +105,11 @@ type ProviderStatus interface {
 }
 
 // InferenceStrategy is the model provider interface used by the harness.
+// Fluent With* builders and SetSystemPrompt live on concrete providers
+// (for example *inference.OpenAIInferenceStrategy), not this interface.
 type InferenceStrategy interface {
-	WithApiKey(string) InferenceStrategy
-	WithModel(string) InferenceStrategy
-	WithURL(string) InferenceStrategy
-	WithReasoningLevel(string) InferenceStrategy
-	WithStructuredOutput(any) InferenceStrategy
-	SetSystemPrompt(string)
-	Invoke(context.Context, []*Message, []*Tool) (chan LLMResponseChunk, error)
+	Invoke(ctx context.Context, messages []*Message, tools []*Tool, systemPrompt string) (chan LLMResponseChunk, error)
 	CountTokens(context.Context, []*Message, []*Tool) (int, error)
-	CompressContextWindow() error
 	MaxContextWindow() (int, error)
 	// SupportsMIME reports whether the currently selected model accepts the
 	// given MIME type as user input. Empty and text/* are always true.
@@ -153,10 +147,27 @@ type AgentWatchDog interface {
 	RecordToolResult(*Message) error
 }
 
-// HarnessRuntime is the tool-facing API for handlers and interceptors:
-// EmitUpdate, StateGet, StateSet, StateDelete, RaiseInterrupt, Store,
-// and CurrentToolCallID. Turn lifecycle helpers live in internal/session.
-type HarnessRuntime = session.Runtime
+// HarnessRuntime is the tool-facing API for handlers and interceptors.
+// Hosts implement CRM write and approval tools against this interface only.
+// Store and SessionManager are not part of the contract.
+type HarnessRuntime interface {
+	EmitUpdate(message string)
+	EmitPlanUpdate(plan []Todo)
+	StateGet(key string) (any, bool)
+	StateSet(key string, value any) error
+	StateDelete(key string)
+	RaiseInterrupt(kind string, payload []byte) (Interrupt, error)
+	AdoptInterrupt(intr Interrupt) (Interrupt, error)
+	TakeResolvedInterrupt(id string) (Interrupt, bool)
+	PendingInterrupt(id string) (Interrupt, bool)
+	ReturnInterrupt(id string, result []byte) (Interrupt, error)
+	HasPendingInterrupt() bool
+	CurrentToolCallID() string
+	PermissionAlwaysAllowed(toolName string) bool
+	PermissionAlwaysDenied(toolName string) bool
+	RememberPermissionAllow(toolName string)
+	RememberPermissionDeny(toolName string)
+}
 
 // Todo is one plan list item (also used in plan_update stream payloads).
 type Todo = streaming.Todo

--- a/vfs/fuse_test.go
+++ b/vfs/fuse_test.go
@@ -20,7 +20,7 @@ func TestFuseMount_hostSeesDirtyText(t *testing.T) {
 	if err := reg.Register(LocalFactory{ID: "scratch", Base: t.TempDir()}); err != nil {
 		t.Fatal(err)
 	}
-	ms := NewMountSession(t.Name(), reg)
+	ms := MustNewMountSession(t.Name(), reg)
 	if err := ms.Mount(ctx, MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestFuseMount_plaintextWritableProjectedEROFS(t *testing.T) {
 	if err := reg.Register(LocalFactory{ID: "scratch", Base: t.TempDir()}); err != nil {
 		t.Fatal(err)
 	}
-	ms := NewMountSession(t.Name(), reg)
+	ms := MustNewMountSession(t.Name(), reg)
 	if err := ms.Mount(ctx, MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
@@ -284,7 +284,7 @@ func TestFuseMount_projectedTextualReadOnly(t *testing.T) {
 	if err := reg.Register(LocalFactory{ID: "scratch", Base: t.TempDir()}); err != nil {
 		t.Fatal(err)
 	}
-	ms := NewMountSession(t.Name(), reg)
+	ms := MustNewMountSession(t.Name(), reg)
 	if err := ms.Mount(ctx, MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
@@ -354,7 +354,7 @@ func TestFuseMount_rejectsMultiSegmentPoint(t *testing.T) {
 	if err := reg.Register(LocalFactory{ID: "scratch", Base: t.TempDir()}); err != nil {
 		t.Fatal(err)
 	}
-	ms := NewMountSession(t.Name(), reg)
+	ms := MustNewMountSession(t.Name(), reg)
 	if err := ms.Mount(ctx, MountSpec{Point: "/tmp/tacklr", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
@@ -366,7 +366,7 @@ func TestFuseMount_rejectsMultiSegmentPoint(t *testing.T) {
 		t.Fatal("empty FuseMount dir")
 	}
 	if FuseAvailable() {
-		empty := NewMountSession("empty-tree", reg)
+		empty := MustNewMountSession("empty-tree", reg)
 		dir := t.TempDir()
 		if err := empty.FuseMount(dir); err != nil {
 			t.Fatalf("empty specs FuseMount: %v", err)

--- a/vfs/s3_fake_test.go
+++ b/vfs/s3_fake_test.go
@@ -143,7 +143,7 @@ func TestMountSession_s3MemAPI(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("s3-mem", reg)
+	ms := vfs.MustNewMountSession("s3-mem", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{
 		Point: "/data", Profile: "s3",
 		Params: map[string]string{"prefix": "runs/1"},
@@ -377,7 +377,7 @@ func TestS3Provider_openWriteClose(t *testing.T) {
 	if err := reg.Register(factory); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("s3w", reg)
+	ms := vfs.MustNewMountSession("s3w", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/w", Profile: "s3w"}); err != nil {
 		t.Fatal(err)
 	}
@@ -560,7 +560,7 @@ func TestOpenDocument_providerMediaType(t *testing.T) {
 	if err := reg.Register(vfs.S3Factory{ID: "s3", Client: api, DefaultBucket: "bkt"}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("s3-ctype", reg)
+	ms := vfs.MustNewMountSession("s3-ctype", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/data", Profile: "s3"}); err != nil {
 		t.Fatal(err)
 	}

--- a/vfs/s3_integration_test.go
+++ b/vfs/s3_integration_test.go
@@ -35,7 +35,7 @@ func TestMountSession_s3MinIO(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ms := vfs.NewMountSession("sess-s3", reg)
+	ms := vfs.MustNewMountSession("sess-s3", reg)
 	if err := ms.Materialize(ctx, []vfs.MountSpec{
 		{Point: "/data", Profile: "s3", Params: map[string]string{"prefix": "runs/1"}},
 		{Point: "/ro", Profile: "s3", ReadOnly: true, Params: map[string]string{"prefix": "readonly"}},

--- a/vfs/session.go
+++ b/vfs/session.go
@@ -77,8 +77,23 @@ func (m *MountSession) fireAfterPersist(ctx context.Context, virtualPath string)
 
 // NewMountSession binds a session id to a process registry.
 // Hosts that want a kernel tree call FuseMount.
-func NewMountSession(sessionID string, reg *BackendRegistry) *MountSession {
-	return &MountSession{id: sessionID, reg: reg, tab: newMountTable()}
+func NewMountSession(sessionID string, reg *BackendRegistry) (*MountSession, error) {
+	if strings.TrimSpace(sessionID) == "" {
+		return nil, fmt.Errorf("%w: session id is required", ErrInvalidPath)
+	}
+	if reg == nil {
+		return nil, errRegistryRequired
+	}
+	return &MountSession{id: sessionID, reg: reg, tab: newMountTable()}, nil
+}
+
+// MustNewMountSession is for tests. It panics if NewMountSession fails.
+func MustNewMountSession(sessionID string, reg *BackendRegistry) *MountSession {
+	ms, err := NewMountSession(sessionID, reg)
+	if err != nil {
+		panic(err)
+	}
+	return ms
 }
 
 // HostDir is the directory last passed to FuseMount, or "".

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -493,6 +493,16 @@ func TestDocument_session(t *testing.T) {
 	if err := ms.WriteDocument(ctx, huge); !errors.Is(err, vfs.ErrTooLarge) {
 		t.Fatalf("oversize write: %v", err)
 	}
+	note, err := ms.ReadText(ctx, "/work/note.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b, err := vfs.EncodeTextual(note); err != nil || string(b) != "A\nB\nC\nD\n" {
+		t.Fatalf("EncodeTextual = %q err=%v", b, err)
+	}
+	if _, err := vfs.EncodeTextual(huge); !errors.Is(err, vfs.ErrTooLarge) {
+		t.Fatalf("oversize encode: %v", err)
+	}
 
 	if mt, err := ms.Classify(ctx, "/work/note.txt", nil); err != nil || mt != "text/plain" {
 		t.Fatalf("Classify: %q err=%v", mt, err)
@@ -700,22 +710,6 @@ func TestKernelWritable(t *testing.T) {
 	if !vfs.KernelCreateOK("README") || !vfs.KernelCreateOK("note.txt") {
 		t.Fatal("KernelCreateOK plaintext")
 	}
-}
-
-// TestEncodeTextual_roundTripAndCap is the public encode helper backends use
-// when persisting a Textual document as bytes.
-func TestEncodeTextual_roundTripAndCap(t *testing.T) {
-	doc := vfs.NewTextDocument("/work/a.md", "text/markdown", "utf-8", "hello\n")
-	b, err := vfs.EncodeTextual(doc)
-	if err != nil || string(b) != "hello\n" {
-		t.Fatalf("EncodeTextual = %q err=%v", b, err)
-	}
-	huge := vfs.NewTextDocument("/work/huge.txt", "text/plain", "utf-8", strings.Repeat("x", vfs.MaxReadFileBytes+1))
-	if _, err := vfs.EncodeTextual(huge); !errors.Is(err, vfs.ErrTooLarge) {
-		t.Fatalf("oversize encode: %v", err)
-	}
-	var id vfs.IdentityCodec = vfs.TextCodec{}
-	id.Identity()
 }
 
 type projectedCodec struct{}

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -26,7 +26,7 @@ func TestMountSession_localSession(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ms := vfs.NewMountSession("sess-1", reg)
+	ms := vfs.MustNewMountSession("sess-1", reg)
 	if err := ms.Materialize(ctx, []vfs.MountSpec{
 		{Point: "/work", Profile: "scratch"},
 		{Point: "/work/nested", Profile: "scratch", ReadOnly: true, Params: map[string]string{"subpath": "nested"}},
@@ -139,7 +139,7 @@ func TestMountSession_localSession(t *testing.T) {
 
 	// Rematerialize from Specs (restart shape)
 	specs := ms.Specs()
-	ms2 := vfs.NewMountSession("sess-2", reg)
+	ms2 := vfs.MustNewMountSession("sess-2", reg)
 	if err := ms2.Materialize(ctx, specs); err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +171,7 @@ func TestMountSession_byteProviderWriteAndLimits(t *testing.T) {
 	if err := reg.Register(memFactory{id: "mem", store: store}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("mem-sess", reg)
+	ms := vfs.MustNewMountSession("mem-sess", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/mem", Profile: "mem"}); err != nil {
 		t.Fatal(err)
 	}
@@ -274,7 +274,7 @@ func TestDocument_session(t *testing.T) {
 	if err := reg.Register(vfs.LocalFactory{ID: "scratch", Base: base}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("doc-sess", reg)
+	ms := vfs.MustNewMountSession("doc-sess", reg)
 	if err := ms.Materialize(ctx, []vfs.MountSpec{
 		{Point: "/work", Profile: "scratch"},
 		{Point: "/ro", Profile: "scratch", ReadOnly: true, Params: map[string]string{"subpath": "ro"}},
@@ -593,7 +593,7 @@ func TestMountSession_configErrors(t *testing.T) {
 	if !reg.HasProfile("scratch") || reg.HasProfile("nope") {
 		t.Fatal("HasProfile")
 	}
-	ms := vfs.NewMountSession("s", reg)
+	ms := vfs.MustNewMountSession("s", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/x", Profile: "nope"}); !errors.Is(err, vfs.ErrUnknownProfile) {
 		t.Fatalf("unknown profile: %v", err)
 	}
@@ -622,13 +622,12 @@ func TestMountSession_configErrors(t *testing.T) {
 	if err := ms.Unmount("/missing"); !errors.Is(err, vfs.ErrNotMounted) {
 		t.Fatalf("unmount missing: %v", err)
 	}
-	// nil registry session
-	ms2 := vfs.NewMountSession("s2", nil)
-	if err := ms2.Mount(ctx, vfs.MountSpec{Point: "/x", Profile: "scratch"}); err == nil {
-		t.Fatal("nil registry mount")
+	// nil registry session is rejected at construct
+	if _, err := vfs.NewMountSession("s2", nil); err == nil {
+		t.Fatal("nil registry construct")
 	}
-	if err := ms2.Materialize(ctx, []vfs.MountSpec{{Point: "/x", Profile: "scratch"}}); err == nil {
-		t.Fatal("nil registry materialize")
+	if _, err := vfs.NewMountSession("", reg); err == nil {
+		t.Fatal("empty session id construct")
 	}
 	creg := vfs.NewContentRegistry()
 	if err := creg.Register(nil); err == nil {
@@ -651,7 +650,7 @@ func TestMountSession_configErrors(t *testing.T) {
 		t.Fatalf("codec cancel: %v", err)
 	}
 	// materialize duplicate points
-	ms3 := vfs.NewMountSession("s3", reg)
+	ms3 := vfs.MustNewMountSession("s3", reg)
 	if err := ms3.Materialize(ctx, []vfs.MountSpec{
 		{Point: "/d", Profile: "scratch"},
 		{Point: "/d", Profile: "scratch"},

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -702,6 +702,22 @@ func TestKernelWritable(t *testing.T) {
 	}
 }
 
+// TestEncodeTextual_roundTripAndCap is the public encode helper backends use
+// when persisting a Textual document as bytes.
+func TestEncodeTextual_roundTripAndCap(t *testing.T) {
+	doc := vfs.NewTextDocument("/work/a.md", "text/markdown", "utf-8", "hello\n")
+	b, err := vfs.EncodeTextual(doc)
+	if err != nil || string(b) != "hello\n" {
+		t.Fatalf("EncodeTextual = %q err=%v", b, err)
+	}
+	huge := vfs.NewTextDocument("/work/huge.txt", "text/plain", "utf-8", strings.Repeat("x", vfs.MaxReadFileBytes+1))
+	if _, err := vfs.EncodeTextual(huge); !errors.Is(err, vfs.ErrTooLarge) {
+		t.Fatalf("oversize encode: %v", err)
+	}
+	var id vfs.IdentityCodec = vfs.TextCodec{}
+	id.Identity()
+}
+
 type projectedCodec struct{}
 
 func (projectedCodec) MediaTypes() []string { return []string{"application/x-test-projected"} }

--- a/vfsindex/indexer_test.go
+++ b/vfsindex/indexer_test.go
@@ -24,7 +24,7 @@ func TestMountIndexer_indexSearchAndNotify(t *testing.T) {
 	if err := reg.Register(vfs.LocalFactory{ID: "scratch", Base: base}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("idx", reg)
+	ms := vfs.MustNewMountSession("idx", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
@@ -182,7 +182,7 @@ func TestMountIndexer_markdownBlocksChunks(t *testing.T) {
 	if err := reg.Register(vfs.LocalFactory{ID: "scratch", Base: base}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("idx-md", reg)
+	ms := vfs.MustNewMountSession("idx-md", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
@@ -307,7 +307,7 @@ func TestMountIndexer_emptyMarkdownLineChunks(t *testing.T) {
 	if err := reg.Register(vfs.LocalFactory{ID: "scratch", Base: base}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("idx-md-empty", reg)
+	ms := vfs.MustNewMountSession("idx-md-empty", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
@@ -392,7 +392,7 @@ func TestMountIndexer_IndexFileResultAndDefaults(t *testing.T) {
 	if err := reg.Register(vfs.LocalFactory{ID: "scratch", Base: base}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("idx-file-result", reg)
+	ms := vfs.MustNewMountSession("idx-file-result", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
@@ -551,7 +551,7 @@ func TestMountIndexer_IndexFileResultAndDefaults(t *testing.T) {
 	}}); err != nil {
 		t.Fatal(err)
 	}
-	ms2 := vfs.NewMountSession("idx-stream", bytesReg)
+	ms2 := vfs.MustNewMountSession("idx-stream", bytesReg)
 	if err := ms2.Mount(ctx, vfs.MountSpec{Point: "/raw", Profile: "bytes"}); err != nil {
 		t.Fatal(err)
 	}

--- a/vfsindex/policy_test.go
+++ b/vfsindex/policy_test.go
@@ -19,7 +19,7 @@ func TestBridge_policyAndTrack(t *testing.T) {
 	if err := reg.Register(vfs.LocalFactory{ID: "scratch", Base: t.TempDir()}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("br", reg)
+	ms := vfs.MustNewMountSession("br", reg)
 	var composed []string
 	ms.SetAfterPersist(func(_ context.Context, path string) error {
 		composed = append(composed, path)

--- a/vfsindex/scheduler_test.go
+++ b/vfsindex/scheduler_test.go
@@ -22,7 +22,7 @@ func TestAsyncScheduler_notifyCoalesceAndEventualIndex(t *testing.T) {
 	if err := reg.Register(vfs.LocalFactory{ID: "scratch", Base: base}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("async-sched", reg)
+	ms := vfs.MustNewMountSession("async-sched", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func TestIndexPathResult_andUnindex(t *testing.T) {
 	if err := reg.Register(vfs.LocalFactory{ID: "scratch", Base: base}); err != nil {
 		t.Fatal(err)
 	}
-	ms := vfs.NewMountSession("result-unindex", reg)
+	ms := vfs.MustNewMountSession("result-unindex", reg)
 	if err := ms.Mount(ctx, vfs.MountSpec{Point: "/work", Profile: "scratch"}); err != nil {
 		t.Fatal(err)
 	}

--- a/web_test.go
+++ b/web_test.go
@@ -96,7 +96,7 @@ func TestWebSearchTool_invokeAgainstServer(t *testing.T) {
 		t.Fatalf("text mode: %q err=%v", res.output, err)
 	}
 
-	h := mustNewAgent(t, ctx, AgentOptions{
+	h := mustNewAgent(t, AgentOptions{
 		Store: stores.NewInMemoryStore(), Model: &mockStrategy{}, ExaAPIKey: "from-opts",
 	})
 	t.Cleanup(h.Close)

--- a/web_test.go
+++ b/web_test.go
@@ -53,7 +53,7 @@ func TestWebSearchTool_invokeAgainstServer(t *testing.T) {
 		"user_location":"US",
 		"system_prompt":"prefer primary sources",
 		"max_age_hours":24
-	}`, nil)
+	}`, nopRuntime())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,11 +61,11 @@ func TestWebSearchTool_invokeAgainstServer(t *testing.T) {
 		t.Fatal(res.output)
 	}
 
-	res, err = tool.invoke(ctx, `{"query":"empty-results"}`, nil)
+	res, err = tool.invoke(ctx, `{"query":"empty-results"}`, nopRuntime())
 	if err != nil || !strings.Contains(res.output, "No results found") {
 		t.Fatalf("empty: %q err=%v", res.output, err)
 	}
-	res, err = tool.invoke(ctx, `{"query":"untitled","content_mode":"highlights"}`, nil)
+	res, err = tool.invoke(ctx, `{"query":"untitled","content_mode":"highlights"}`, nopRuntime())
 	if err != nil || !strings.Contains(res.output, "(untitled)") || !strings.Contains(res.output, `"answer"`) {
 		t.Fatalf("untitled/synth: %q err=%v", res.output, err)
 	}
@@ -87,11 +87,11 @@ func TestWebSearchTool_invokeAgainstServer(t *testing.T) {
 	if _, err := tool.invoke(ctx, `{"query":"q","content_mode":"raw"}`, nil); err == nil {
 		t.Fatal("invalid mode")
 	}
-	res, err = tool.invoke(ctx, `{"query":"q","type":"text","content_mode":"text","category":"news"}`, nil)
+	res, err = tool.invoke(ctx, `{"query":"q","type":"text","content_mode":"text","category":"news"}`, nopRuntime())
 	if err == nil && !strings.Contains(res.output, "Hit") {
 		// type "text" is invalid — already covered; news+text mode
 	}
-	res, err = tool.invoke(ctx, `{"query":"news-q","type":"auto","content_mode":"text","category":"news"}`, nil)
+	res, err = tool.invoke(ctx, `{"query":"news-q","type":"auto","content_mode":"text","category":"news"}`, nopRuntime())
 	if err != nil || !strings.Contains(res.output, "Hit") {
 		t.Fatalf("text mode: %q err=%v", res.output, err)
 	}
@@ -128,7 +128,7 @@ func TestRunWebFetch_endToEnd(t *testing.T) {
 	})
 	ctx := context.Background()
 
-	got, err := runWebFetch(ctx, client, webFetchArgs{URLs: []string{"https://example.gov/code"}}, nil)
+	got, err := runWebFetch(ctx, client, webFetchArgs{URLs: []string{"https://example.gov/code"}}, nopRuntime())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,14 +138,14 @@ func TestRunWebFetch_endToEnd(t *testing.T) {
 
 	got, err = runWebFetch(ctx, client, webFetchArgs{
 		URLs: []string{"  ", "ftp://x", "example.gov/code", "https://example.gov/code", "not a host"},
-	}, nil)
+	}, nopRuntime())
 	if err != nil || !strings.Contains(got, "City Code") {
 		t.Fatalf("normalize: %q err=%v", got, err)
 	}
 
 	got, err = runWebFetch(ctx, client, webFetchArgs{
 		URLs: []string{"https://example.gov/missing"}, ContentMode: "highlights", HighlightQuery: "setbacks",
-	}, nil)
+	}, nopRuntime())
 	if err != nil || !strings.Contains(got, "error") || !strings.Contains(got, "not_found") {
 		t.Fatalf("status: %q err=%v", got, err)
 	}
@@ -155,17 +155,17 @@ func TestRunWebFetch_endToEnd(t *testing.T) {
 	}
 	if _, err := runWebFetch(ctx, client, webFetchArgs{
 		URLs: []string{"https://a", "https://b", "https://c", "https://d", "https://e", "https://f"},
-	}, nil); err == nil {
+	}, nopRuntime()); err == nil {
 		t.Fatal("too many urls")
 	}
 	if _, err := runWebFetch(ctx, client, webFetchArgs{
 		URLs: []string{"https://example.gov/code"}, ContentMode: "raw",
-	}, nil); err == nil {
+	}, nopRuntime()); err == nil {
 		t.Fatal("invalid mode")
 	}
 	got, err = runWebFetch(ctx, client, webFetchArgs{
 		URLs: []string{"https://example.gov/code"}, ContentMode: "both", MaxTextCharacters: 20000,
-	}, nil)
+	}, nopRuntime())
 	if err != nil || !strings.Contains(got, "City Code") {
 		t.Fatalf("both: %q err=%v", got, err)
 	}

--- a/web_test.go
+++ b/web_test.go
@@ -53,7 +53,7 @@ func TestWebSearchTool_invokeAgainstServer(t *testing.T) {
 		"user_location":"US",
 		"system_prompt":"prefer primary sources",
 		"max_age_hours":24
-	}`, HarnessRuntime{})
+	}`, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,42 +61,42 @@ func TestWebSearchTool_invokeAgainstServer(t *testing.T) {
 		t.Fatal(res.output)
 	}
 
-	res, err = tool.invoke(ctx, `{"query":"empty-results"}`, HarnessRuntime{})
+	res, err = tool.invoke(ctx, `{"query":"empty-results"}`, nil)
 	if err != nil || !strings.Contains(res.output, "No results found") {
 		t.Fatalf("empty: %q err=%v", res.output, err)
 	}
-	res, err = tool.invoke(ctx, `{"query":"untitled","content_mode":"highlights"}`, HarnessRuntime{})
+	res, err = tool.invoke(ctx, `{"query":"untitled","content_mode":"highlights"}`, nil)
 	if err != nil || !strings.Contains(res.output, "(untitled)") || !strings.Contains(res.output, `"answer"`) {
 		t.Fatalf("untitled/synth: %q err=%v", res.output, err)
 	}
-	if _, err := tool.invoke(ctx, `{"query":"  "}`, HarnessRuntime{}); err == nil || !strings.Contains(err.Error(), "query is required") {
+	if _, err := tool.invoke(ctx, `{"query":"  "}`, nil); err == nil || !strings.Contains(err.Error(), "query is required") {
 		t.Fatalf("empty query: %v", err)
 	}
-	if _, err := tool.invoke(ctx, `{"query":"q","type":"nope"}`, HarnessRuntime{}); err == nil {
+	if _, err := tool.invoke(ctx, `{"query":"q","type":"nope"}`, nil); err == nil {
 		t.Fatal("invalid type")
 	}
-	if _, err := tool.invoke(ctx, `{"query":"q","category":"nope"}`, HarnessRuntime{}); err == nil {
+	if _, err := tool.invoke(ctx, `{"query":"q","category":"nope"}`, nil); err == nil {
 		t.Fatal("invalid category")
 	}
-	if _, err := tool.invoke(ctx, `{"query":"q","category":"company","exclude_domains":["x.com"]}`, HarnessRuntime{}); err == nil {
+	if _, err := tool.invoke(ctx, `{"query":"q","category":"company","exclude_domains":["x.com"]}`, nil); err == nil {
 		t.Fatal("company exclude")
 	}
-	if _, err := tool.invoke(ctx, `{"query":"q","category":"people","start_published_date":"2024-01-01T00:00:00Z"}`, HarnessRuntime{}); err == nil {
+	if _, err := tool.invoke(ctx, `{"query":"q","category":"people","start_published_date":"2024-01-01T00:00:00Z"}`, nil); err == nil {
 		t.Fatal("people dates")
 	}
-	if _, err := tool.invoke(ctx, `{"query":"q","content_mode":"raw"}`, HarnessRuntime{}); err == nil {
+	if _, err := tool.invoke(ctx, `{"query":"q","content_mode":"raw"}`, nil); err == nil {
 		t.Fatal("invalid mode")
 	}
-	res, err = tool.invoke(ctx, `{"query":"q","type":"text","content_mode":"text","category":"news"}`, HarnessRuntime{})
+	res, err = tool.invoke(ctx, `{"query":"q","type":"text","content_mode":"text","category":"news"}`, nil)
 	if err == nil && !strings.Contains(res.output, "Hit") {
 		// type "text" is invalid — already covered; news+text mode
 	}
-	res, err = tool.invoke(ctx, `{"query":"news-q","type":"auto","content_mode":"text","category":"news"}`, HarnessRuntime{})
+	res, err = tool.invoke(ctx, `{"query":"news-q","type":"auto","content_mode":"text","category":"news"}`, nil)
 	if err != nil || !strings.Contains(res.output, "Hit") {
 		t.Fatalf("text mode: %q err=%v", res.output, err)
 	}
 
-	h := NewAgent(ctx, AgentOptions{
+	h := mustNewAgent(t, ctx, AgentOptions{
 		Store: stores.NewInMemoryStore(), Model: &mockStrategy{}, ExaAPIKey: "from-opts",
 	})
 	t.Cleanup(h.Close)
@@ -128,7 +128,7 @@ func TestRunWebFetch_endToEnd(t *testing.T) {
 	})
 	ctx := context.Background()
 
-	got, err := runWebFetch(ctx, client, webFetchArgs{URLs: []string{"https://example.gov/code"}}, HarnessRuntime{})
+	got, err := runWebFetch(ctx, client, webFetchArgs{URLs: []string{"https://example.gov/code"}}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,34 +138,34 @@ func TestRunWebFetch_endToEnd(t *testing.T) {
 
 	got, err = runWebFetch(ctx, client, webFetchArgs{
 		URLs: []string{"  ", "ftp://x", "example.gov/code", "https://example.gov/code", "not a host"},
-	}, HarnessRuntime{})
+	}, nil)
 	if err != nil || !strings.Contains(got, "City Code") {
 		t.Fatalf("normalize: %q err=%v", got, err)
 	}
 
 	got, err = runWebFetch(ctx, client, webFetchArgs{
 		URLs: []string{"https://example.gov/missing"}, ContentMode: "highlights", HighlightQuery: "setbacks",
-	}, HarnessRuntime{})
+	}, nil)
 	if err != nil || !strings.Contains(got, "error") || !strings.Contains(got, "not_found") {
 		t.Fatalf("status: %q err=%v", got, err)
 	}
 
-	if _, err := runWebFetch(ctx, client, webFetchArgs{}, HarnessRuntime{}); err == nil {
+	if _, err := runWebFetch(ctx, client, webFetchArgs{}, nil); err == nil {
 		t.Fatal("no urls")
 	}
 	if _, err := runWebFetch(ctx, client, webFetchArgs{
 		URLs: []string{"https://a", "https://b", "https://c", "https://d", "https://e", "https://f"},
-	}, HarnessRuntime{}); err == nil {
+	}, nil); err == nil {
 		t.Fatal("too many urls")
 	}
 	if _, err := runWebFetch(ctx, client, webFetchArgs{
 		URLs: []string{"https://example.gov/code"}, ContentMode: "raw",
-	}, HarnessRuntime{}); err == nil {
+	}, nil); err == nil {
 		t.Fatal("invalid mode")
 	}
 	got, err = runWebFetch(ctx, client, webFetchArgs{
 		URLs: []string{"https://example.gov/code"}, ContentMode: "both", MaxTextCharacters: 20000,
-	}, HarnessRuntime{})
+	}, nil)
 	if err != nil || !strings.Contains(got, "City Code") {
 		t.Fatalf("both: %q err=%v", got, err)
 	}


### PR DESCRIPTION
## Why

Product hosts (RPC tools, language guests, registry-as-daemon) freeze today’s public types. This change locks the harness surface so a host can implement gated writes and human approval without reaching into `stores.BaseStore`, `SessionManager`, or a replaceable ACM path.

## What changed

1. **`HarnessRuntime` is a public interface** — emit, state, interrupt, current call id, and typed permission memory. No `Store`. Reserved `StateSet` keys return an error. Permission and parked-worker bags live on `SessionManager`.
2. **Constructors fail closed** — `NewAgent` and `NewMountSession` return `(*T, error)`. Skill and vfsindex init errors surface. `ensure()` and `PlanStore` nil-receivers are gone.
3. **`InferenceStrategy` is invoke-only** — `Invoke`, `CountTokens`, `MaxContextWindow`, `SupportsMIME`. System prompt is an `Invoke` argument. `With*` / `SetSystemPrompt` stay on `*OpenAIInferenceStrategy`. `CompressContextWindow` is deleted.
4. **Interceptors compose** — host interceptors wrap outside the planning lock and permission gate. `DisablePlanningLock` is the explicit opt-out; the permission gate always stays.
5. **ACM stays harness-owned** — `ContextManager` / `ModelTasks` are no longer `AgentOptions` replacements. `Messages` is the single window snapshot.
6. **Session aggregate** — `SearchContext` moves onto `SessionManager`. `EventStream.Harness` is unexported; resume/cancel/close and `SessionID` / `AskUserQuestion` / `VFS` stay on the stream. Harness store and wire store remain separate.
7. **VFS catalog** — Phases 3–5 of the FUSE tool collapse are documented as shipped (`read` / `write` / `run_command`).

## Test plan

- [x] `go test ./...` — all packages passed
- [x] `go fmt` / `go vet` on touched packages
- [x] CI Lint (`revive` `context-as-argument`) — `mustNewAgent` now takes `(t, opts)` and constructs with `t.Context()`
- [x] CI Testcontainers image build — retry `pg_textsearch` download and `docker build` after GitHub connection resets
- Integration outcomes: permission deny/allow-always, planning lock, construct errors, host interceptor still gates, handoff after `complete_todo`, checkpoint round-trip of plan + permissions + search
- golangci-lint could not run locally (linter binary is Go 1.25; module targets 1.26.3)
