### PR TITLE
refactor: lock interrupt, VFS, and ACP invariants

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -37,10 +37,11 @@ type AgentHarness struct {
 	maxTurnRequests int // 0 = unlimited; from Config.MaxTurnRequests
 	session         *session.SessionManager
 	subagents       map[string]*SubAgent
-	// interruptToRequester maps interrupt id → tool call id for resume.
-	interruptToRequester map[string]string
-	pendingToolCalls     map[string]stores.PendingToolCall
-	pendingMu            sync.Mutex
+	// pendingToolCalls is keyed by tool call id, which is also the wire interrupt id.
+	pendingToolCalls map[string]stores.PendingToolCall
+	pendingMu        sync.Mutex
+	// legacyInterruptIDs maps old checkpoint wire ids → tool call ids. Not saved.
+	legacyInterruptIDs map[string]string
 	// interruptPayloads maps parent tool call id → resume payload for workers.
 	interruptPayloads map[string][]byte
 	// parkedWorkersLive maps spawn_worker tool call id → live child harness.
@@ -102,7 +103,6 @@ func (a *AgentHarness) AskUserQuestion(toolCallID string) string {
 	}
 	s, ok := v.(string)
 	if !ok {
-		// Wrong type means a bug in ask_user_choice stash; surface empty, not a silent cast.
 		slog.Error("ask_user_question state is not a string",
 			"session_id", a.sessionId,
 			"tool_call_id", toolCallID,
@@ -111,6 +111,26 @@ func (a *AgentHarness) AskUserQuestion(toolCallID string) string {
 		return ""
 	}
 	return s
+}
+
+func (a *AgentHarness) pendingSnapshot() map[string]stores.PendingToolCall {
+	a.pendingMu.Lock()
+	defer a.pendingMu.Unlock()
+	ptc := make(map[string]stores.PendingToolCall, len(a.pendingToolCalls))
+	for k, v := range a.pendingToolCalls {
+		ptc[k] = v
+	}
+	return ptc
+}
+
+func (a *AgentHarness) lookupToolCallID(id string) (string, bool) {
+	if _, ok := a.pendingToolCalls[id]; ok {
+		return id, true
+	}
+	if tc, ok := a.legacyInterruptIDs[id]; ok {
+		return tc, true
+	}
+	return "", false
 }
 
 func (a *AgentHarness) restoreMessages(window []*Message) {
@@ -161,18 +181,9 @@ func (a *AgentHarness) checkpointSession(ctx context.Context) error {
 		return nil
 	}
 
-	a.pendingMu.Lock()
-	ptc := make(map[string]stores.PendingToolCall, len(a.pendingToolCalls))
-	for k, v := range a.pendingToolCalls {
-		ptc[k] = v
-	}
-	itr := make(map[string]string, len(a.interruptToRequester))
-	for k, v := range a.interruptToRequester {
-		itr[k] = v
-	}
-	a.pendingMu.Unlock()
+	ptc := a.pendingSnapshot()
 
-	cp, err := session.NewCheckpointer().Capture(a.context.Messages(), a.session, ptc, itr)
+	cp, err := session.NewCheckpointer().Capture(a.context.Messages(), a.session, ptc)
 	if err != nil {
 		telemetry.InstrumentsFromContext(ctx).RecordCheckpointSave(ctx, telemetry.OutcomeError)
 		return err
@@ -435,118 +446,15 @@ func (a *AgentHarness) withToolPresentation(tc ToolCall) ToolCall {
 	return tc
 }
 
-// stripUnpairedToolCallsAfterInferenceError removes unpaired function_call /
-// tool-result messages so the next prompt has valid Responses pairing.
-// Keeps pending interrupt tool calls. Call only on inference-error exits.
-func (a *AgentHarness) stripUnpairedToolCallsAfterInferenceError() {
-	a.pendingMu.Lock()
-	keep := make(map[string]struct{}, len(a.pendingToolCalls))
-	for _, p := range a.pendingToolCalls {
-		if p.ToolCall == nil {
-			continue
-		}
-		if id := p.ToolCall.WireID(); id != "" {
-			keep[id] = struct{}{}
-		}
-		if id := p.ToolCall.Key(); id != "" {
-			keep[id] = struct{}{}
-		}
-	}
-	a.pendingMu.Unlock()
-
-	before := a.Messages()
-	after := stripUnpairedToolTurns(before, keep)
-	if len(before) == len(after) {
-		same := true
-		for i := range before {
-			if before[i] != after[i] {
-				same = false
-				break
-			}
-		}
-		if same {
-			return
-		}
-	}
-	a.context.Replace(after)
-	slog.Info("stripped unpaired tool turns after inference error",
-		"session_id", a.sessionId,
-		"before", len(before),
-		"after", len(after),
-	)
-}
-
-// stripUnpairedToolTurns drops unpaired tool turns. keepCallIDs may lack results
-// (active interrupts).
-func stripUnpairedToolTurns(window []*Message, keepCallIDs map[string]struct{}) []*Message {
-	if len(window) == 0 {
-		return window
-	}
+// toolOutputIDs returns RoleTool call ids present in the window.
+func toolOutputIDs(window []*Message) map[string]struct{} {
 	hasOutput := make(map[string]struct{})
-	hasCall := make(map[string]struct{})
 	for _, m := range window {
-		if m == nil {
-			continue
-		}
-		if m.Role == RoleTool && m.ToolCallID != "" {
+		if m != nil && m.Role == RoleTool && m.ToolCallID != "" {
 			hasOutput[m.ToolCallID] = struct{}{}
 		}
-		if m.Role == RoleAssistant {
-			for _, tc := range m.ToolCalls {
-				if id := tc.WireID(); id != "" {
-					hasCall[id] = struct{}{}
-				}
-			}
-		}
 	}
-	keepID := func(id string) bool {
-		if id == "" {
-			return false
-		}
-		if _, ok := keepCallIDs[id]; ok {
-			return true
-		}
-		_, call := hasCall[id]
-		_, out := hasOutput[id]
-		return call && out
-	}
-
-	out := make([]*Message, 0, len(window))
-	for _, m := range window {
-		if m == nil {
-			continue
-		}
-		switch m.Role {
-		case RoleTool:
-			if keepID(m.ToolCallID) {
-				out = append(out, m)
-			}
-		case RoleAssistant:
-			if len(m.ToolCalls) == 0 {
-				out = append(out, m)
-				continue
-			}
-			kept := make([]ToolCall, 0, len(m.ToolCalls))
-			for _, tc := range m.ToolCalls {
-				if keepID(tc.WireID()) {
-					kept = append(kept, tc)
-				}
-			}
-			if len(kept) == 0 && strings.TrimSpace(m.Content) == "" {
-				continue
-			}
-			if len(kept) == len(m.ToolCalls) {
-				out = append(out, m)
-				continue
-			}
-			cp := *m
-			cp.ToolCalls = kept
-			out = append(out, &cp)
-		default:
-			out = append(out, m)
-		}
-	}
-	return out
+	return hasOutput
 }
 
 func (a *AgentHarness) recordWatchdog(msg *Message) {
@@ -620,18 +528,17 @@ func (a *AgentHarness) HasOpenToolWork() bool {
 // FinalizeCancelledWork pairs open tools as cancelled into the window only,
 // clears interrupt park, checkpoints. Parked/steer path (no live turn stream).
 func (a *AgentHarness) FinalizeCancelledWork(ctx context.Context) {
-	a.pairCancelledToolResults(nil)
+	a.finalizeCancelledWork(nil)
+}
+
+func (a *AgentHarness) finalizeCancelledWork(out chan<- StreamEvent) {
+	a.pairCancelledToolResults(out)
 	a.clearInterruptParkState()
 }
 
 // openToolCalls returns assistant/pending tool_calls that have no RoleTool result yet.
 func (a *AgentHarness) openToolCalls() []ToolCall {
-	hasOutput := make(map[string]struct{})
-	for _, m := range a.Messages() {
-		if m != nil && m.Role == RoleTool && m.ToolCallID != "" {
-			hasOutput[m.ToolCallID] = struct{}{}
-		}
-	}
+	hasOutput := toolOutputIDs(a.Messages())
 	seen := make(map[string]struct{})
 	var open []ToolCall
 	add := func(tc ToolCall) {
@@ -682,7 +589,7 @@ func (a *AgentHarness) pairCancelledToolResults(out chan<- StreamEvent) {
 func (a *AgentHarness) clearInterruptParkState() {
 	a.pendingMu.Lock()
 	a.pendingToolCalls = make(map[string]stores.PendingToolCall)
-	a.interruptToRequester = make(map[string]string)
+	a.legacyInterruptIDs = make(map[string]string)
 	a.interruptPayloads = make(map[string][]byte)
 	a.pendingMu.Unlock()
 	a.session.ClearInterrupts()

--- a/agent_construct.go
+++ b/agent_construct.go
@@ -113,6 +113,9 @@ func newHarnessBase(opts AgentOptions, sm *session.SessionManager) (*AgentHarnes
 	if opts.Model == nil {
 		return nil, fmt.Errorf("tacklr: AgentOptions.Model is required")
 	}
+	if sm == nil {
+		return nil, fmt.Errorf("tacklr: session manager is required")
+	}
 	h := &AgentHarness{
 		model:                opts.Model,
 		maxWindowSize:        opts.Config.MaxWindowSize,
@@ -130,8 +133,8 @@ func newHarnessBase(opts AgentOptions, sm *session.SessionManager) (*AgentHarnes
 		brainWriteKinds:      opts.BrainWriteKinds,
 		sessionId:            "",
 		subagents:            make(map[string]*SubAgent),
-		interruptToRequester: make(map[string]string),
 		pendingToolCalls:     make(map[string]stores.PendingToolCall),
+		legacyInterruptIDs:   make(map[string]string),
 		interruptPayloads:    make(map[string][]byte),
 		parkedWorkersLive:    make(map[string]*AgentHarness),
 		context:              NewModelContextManager(),
@@ -165,10 +168,10 @@ func newHarnessBase(opts AgentOptions, sm *session.SessionManager) (*AgentHarnes
 }
 
 func (h *AgentHarness) finishInit(ctx context.Context, subAgents []*SubAgent) error {
-	h.initMCP(ctx)
 	if err := h.initSkills(ctx); err != nil {
 		return fmt.Errorf("initialize skills: %w", err)
 	}
+	h.initMCP(ctx)
 	if err := h.initSubAgentWorkers(subAgents); err != nil {
 		return err
 	}
@@ -178,6 +181,15 @@ func (h *AgentHarness) finishInit(ctx context.Context, subAgents []*SubAgent) er
 		}
 	}
 	h.injectBuiltinTools()
+	return nil
+}
+
+func (a *AgentHarness) ensureReady(ctx context.Context) error {
+	if err := a.initSkills(ctx); err != nil {
+		return fmt.Errorf("load skills: %w", err)
+	}
+	a.initMCP(ctx)
+	a.injectBuiltinTools()
 	return nil
 }
 
@@ -333,7 +345,7 @@ func NewAgentFromSession(ctx context.Context, sessionId string, opts AgentOption
 	}
 	h.sessionId = sessionId
 	h.context.Restore(applied.Window)
-	h.interruptToRequester = applied.InterruptToRequester
+	h.legacyInterruptIDs = applied.LegacyInterruptIDs
 	h.pendingToolCalls = applied.PendingToolCalls
 	if err := h.finishInit(ctx, opts.SubAgents); err != nil {
 		return nil, err

--- a/agent_run.go
+++ b/agent_run.go
@@ -10,8 +10,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/google/uuid"
-
 	"github.com/ryanaldo34/tacklr/internal/session"
 	"github.com/ryanaldo34/tacklr/interrupt"
 	"github.com/ryanaldo34/tacklr/stores"
@@ -34,378 +32,368 @@ func (a *AgentHarness) RunMessage(ctx context.Context, user *Message) (<-chan St
 	if bad := UnsupportedMIMEs(a.model, user.MIMETypes()); len(bad) > 0 {
 		return nil, fmt.Errorf("unsupported content type(s): %s", strings.Join(bad, ", "))
 	}
-	if err := a.initSkills(ctx); err != nil {
-		return nil, fmt.Errorf("load skills: %w", err)
+	return a.startTurn(ctx, user)
+}
+
+// ReturnFromInterrupt applies host resolutions and resumes the parked tool batch.
+// Keys are tool call ids (also the wire interrupt ids). Old checkpoints that
+// stored a separate wire id are resolved through legacyInterruptIDs.
+func (a *AgentHarness) ReturnFromInterrupt(ctx context.Context, finishedInterrupts map[string][]byte) (<-chan StreamEvent, error) {
+	if err := a.applyInterruptResolutions(finishedInterrupts); err != nil {
+		return nil, err
 	}
-	a.initMCP(ctx)
-	a.injectBuiltinTools()
+	return a.startTurn(ctx, nil)
+}
+
+func (a *AgentHarness) applyInterruptResolutions(finishedInterrupts map[string][]byte) error {
+	a.pendingMu.Lock()
+	defer a.pendingMu.Unlock()
+	if a.interruptPayloads == nil {
+		a.interruptPayloads = make(map[string][]byte)
+	}
+	for id, payload := range finishedInterrupts {
+		toolCallID, ok := a.lookupToolCallID(id)
+		if !ok {
+			return fmt.Errorf("no tool call id found for interrupt %s: %w", id, interrupt.ErrInterruptNotFound)
+		}
+		a.interruptPayloads[toolCallID] = payload
+		if _, err := a.session.ReturnInterrupt(toolCallID, payload); err != nil {
+			return fmt.Errorf("return from interrupt %q: %w", id, err)
+		}
+		delete(a.legacyInterruptIDs, id)
+		tc, ok := a.pendingToolCalls[toolCallID]
+		if !ok {
+			return fmt.Errorf("no pending tool call found for tool call id %s", toolCallID)
+		}
+		a.pendingToolCalls[toolCallID] = stores.PendingToolCall{ToolCall: tc.ToolCall, InterruptActive: false}
+	}
+	return nil
+}
+
+func (a *AgentHarness) startTurn(ctx context.Context, user *Message) (<-chan StreamEvent, error) {
+	if err := a.ensureReady(ctx); err != nil {
+		return nil, err
+	}
 	out := make(chan StreamEvent, streamEventBuffer)
-	// Turn-scoped Runtime: event bus for this Run only; durable state is on a.session.
 	turnRT := session.NewRuntime(out, a.session)
 
-	emitCancelled := func() {
-		// Pair open tools into the window before the cancel error event so the
-		// checkpoint (and any client still draining) sees consistent tool results.
-		a.pairCancelledToolResults(out)
-		a.clearInterruptParkState()
-		out <- StreamEvent{Type: StreamEventError, Error: fmt.Errorf("run: context cancelled: %w", ctx.Err())}
-	}
-
-	// Run work is async so the caller can drain out. Dump on every exit so
-	// callers that never Close (tests, mid-turn interrupt) still persist.
-	// Close dumps again, then releases FUSE/MCP. runMu ensures
-	// ReturnFromInterrupt's follow-on Run cannot overlap this loop.
 	go func() {
 		a.runMu.Lock()
 		defer a.runMu.Unlock()
 		defer close(out)
 		defer a.persistSession(ctx)
-		if err := a.addToContext(ctx, user, out); err != nil {
-			if ctx.Err() != nil {
-				emitCancelled()
-				return
-			}
-			a.stripUnpairedToolCallsAfterInferenceError()
-			out <- StreamEvent{Type: StreamEventError, Error: fmt.Errorf("run: %w", err)}
-			return
+
+		emitCancelled := func() {
+			a.finalizeCancelledWork(out)
+			out <- StreamEvent{Type: StreamEventError, Error: fmt.Errorf("run: context cancelled: %w", ctx.Err())}
 		}
-		turnModelRequests := 0
-		// hadToolRound: true after a tool batch so model errors are not treated as tool failures.
-		hadToolRound := false
-		for {
-			if ctx.Err() != nil {
-				emitCancelled()
-				return
-			}
-			var toolResults []*Message
-			var toolCalls []ToolCall
-			if len(a.pendingToolCalls) == 0 {
-				if a.maxTurnRequests > 0 && turnModelRequests >= a.maxTurnRequests {
-					out <- StreamEvent{
-						Type:  StreamEventError,
-						Error: WrapStopReason(ErrMaxTurnRequests, fmt.Errorf("limit %d", a.maxTurnRequests)),
-					}
-					return
-				}
-				turnCtx := ctx
-				if hadToolRound {
-					turnCtx = telemetry.ContextWithAfterTools(ctx)
-				}
-				events, err := a.tasks.Turn(turnCtx, a.tools, a.constructSystemPrompt())
-				if err != nil {
-					if ctx.Err() != nil {
-						emitCancelled()
-						return
-					}
-					var outErr error
-					if hadToolRound {
-						outErr = fmt.Errorf("%w: %w", ErrModelAfterTools, err)
-					} else {
-						outErr = fmt.Errorf("model request failed: %w", err)
-					}
-					a.stripUnpairedToolCallsAfterInferenceError()
-					out <- StreamEvent{Type: StreamEventError, Error: outErr}
-					return
-				}
-				turnModelRequests++
-				asm := newStreamAssembler()
-				// Track announced function_calls so incomplete ones get a failed result
-				// (clients otherwise stay in_progress).
-				announced := make(map[string]ToolCall)
-				announceOrder := make([]string, 0)
-				failAnnounced := func(reason string) {
-					for _, id := range announceOrder {
-						tc := a.withToolPresentation(announced[id])
-						tc.Status = "error"
-						out <- StreamEvent{
-							Type:      StreamEventToolResult,
-							MessageID: tc.Key(),
-							Content:   reason,
-							ToolCalls: []ToolCall{tc},
-						}
-					}
-					announceOrder = nil
-					announced = make(map[string]ToolCall)
-				}
-				// Select on cancel: bare range would ignore ctx if the model keeps the channel open.
-				modelFailed := false
-				for {
-					var chunk LLMResponseChunk
-					var ok bool
-					select {
-					case <-ctx.Done():
-						// Announced-only tools never entered the window; stream cancel
-						// status for clients. Window pairing is handled by emitCancelled.
-						failAnnounced("tool call cancelled")
-						emitCancelled()
-						return
-					case chunk, ok = <-events:
-					}
-					if !ok {
-						break
-					}
-					if hadToolRound && (chunk.Type == StreamEventError || chunk.Error != nil) {
-						chunk = tagModelAfterToolsError(chunk)
-					}
-					if !a.streamChunk(ctx, chunk, out) {
-						failAnnounced("tool call cancelled")
-						emitCancelled()
-						return
-					}
-					if chunk.Type == StreamEventError || chunk.Error != nil {
-						failAnnounced("model error")
-						modelFailed = true
-						break
-					}
-					if chunk.Type == StreamEventFunctionCall {
-						for _, tc := range chunk.ToolCalls {
-							key := tc.Key()
-							if key == "" {
-								continue
-							}
-							if _, seen := announced[key]; !seen {
-								announceOrder = append(announceOrder, key)
-							}
-							announced[key] = tc
-						}
-					}
-					asm.AddDelta(chunk)
-					if chunk.IsComplete {
-						toolCalls = append(toolCalls, chunk.ToolCalls...)
-						if chunk.Type == StreamEventMessage || chunk.Type == StreamEventReasoning {
-							msg := asm.MessageFromComplete(chunk)
-							a.context.Add(msg)
-							a.recordWatchdog(msg)
-						}
-					}
-				}
-				if modelFailed {
-					a.stripUnpairedToolCallsAfterInferenceError()
-					return
-				}
+
+		if user != nil {
+			if err := a.addToContext(ctx, user, out); err != nil {
 				if ctx.Err() != nil {
-					failAnnounced("tool call cancelled")
 					emitCancelled()
 					return
 				}
-				executable := make(map[string]struct{}, len(toolCalls))
-				for _, tc := range toolCalls {
-					if key := tc.Key(); key != "" {
-						executable[key] = struct{}{}
-					}
+				out <- StreamEvent{Type: StreamEventError, Error: fmt.Errorf("run: %w", err)}
+				return
+			}
+		}
+		a.runTurnLoop(ctx, out, turnRT, emitCancelled)
+	}()
+	return out, nil
+}
+
+func (a *AgentHarness) runTurnLoop(ctx context.Context, out chan StreamEvent, turnRT session.Runtime, emitCancelled func()) {
+	turnModelRequests := 0
+	hadToolRound := false
+	for {
+		if ctx.Err() != nil {
+			emitCancelled()
+			return
+		}
+		var toolResults []*Message
+		var toolCalls []ToolCall
+		pending := a.pendingSnapshot()
+		if len(pending) == 0 {
+			if a.maxTurnRequests > 0 && turnModelRequests >= a.maxTurnRequests {
+				out <- StreamEvent{
+					Type:  StreamEventError,
+					Error: WrapStopReason(ErrMaxTurnRequests, fmt.Errorf("limit %d", a.maxTurnRequests)),
 				}
+				return
+			}
+			turnCtx := ctx
+			if hadToolRound {
+				turnCtx = telemetry.ContextWithAfterTools(ctx)
+			}
+			events, err := a.tasks.Turn(turnCtx, a.tools, a.constructSystemPrompt())
+			if err != nil {
+				if ctx.Err() != nil {
+					emitCancelled()
+					return
+				}
+				var outErr error
+				if hadToolRound {
+					outErr = fmt.Errorf("%w: %w", ErrModelAfterTools, err)
+				} else {
+					outErr = fmt.Errorf("model request failed: %w", err)
+				}
+				out <- StreamEvent{Type: StreamEventError, Error: outErr}
+				return
+			}
+			turnModelRequests++
+			asm := newStreamAssembler()
+			announced := make(map[string]ToolCall)
+			announceOrder := make([]string, 0)
+			failAnnounced := func(reason string) {
 				for _, id := range announceOrder {
-					if _, ok := executable[id]; ok {
-						continue
-					}
 					tc := a.withToolPresentation(announced[id])
 					tc.Status = "error"
 					out <- StreamEvent{
 						Type:      StreamEventToolResult,
 						MessageID: tc.Key(),
-						Content:   "tool call incomplete",
+						Content:   reason,
 						ToolCalls: []ToolCall{tc},
 					}
-					if ctx.Err() != nil {
-						emitCancelled()
-						return
-					}
 				}
-				if len(toolCalls) == 0 {
-					out <- StreamEvent{Type: StreamEventComplete}
-					if ctx.Err() != nil {
-						emitCancelled()
-						return
-					}
+				announceOrder = nil
+				announced = make(map[string]ToolCall)
+			}
+			modelFailed := false
+			for {
+				var chunk LLMResponseChunk
+				var ok bool
+				select {
+				case <-ctx.Done():
+					failAnnounced("tool call cancelled")
+					emitCancelled()
+					return
+				case chunk, ok = <-events:
+				}
+				if !ok {
+					break
+				}
+				if hadToolRound && (chunk.Type == StreamEventError || chunk.Error != nil) {
+					chunk = tagModelAfterToolsError(chunk)
+				}
+				if !a.streamChunk(ctx, chunk, out) {
+					failAnnounced("tool call cancelled")
+					emitCancelled()
 					return
 				}
-				// Record the assistant tool-call turn before tool results (Responses pairing).
-				a.context.Add(&Message{
-					Role:      RoleAssistant,
-					ToolCalls: append([]ToolCall(nil), toolCalls...),
-				})
-				toolResults = make([]*Message, len(toolCalls))
-			} else {
-				toolResults = make([]*Message, len(a.pendingToolCalls))
-				toolCalls = make([]ToolCall, 0, len(a.pendingToolCalls))
-				for _, tc := range a.pendingToolCalls {
-					if !tc.InterruptActive {
-						toolCalls = append(toolCalls, *tc.ToolCall)
+				if chunk.Type == StreamEventError || chunk.Error != nil {
+					failAnnounced("model error")
+					modelFailed = true
+					break
+				}
+				if chunk.Type == StreamEventFunctionCall {
+					for _, tc := range chunk.ToolCalls {
+						key := tc.Key()
+						if key == "" {
+							continue
+						}
+						if _, seen := announced[key]; !seen {
+							announceOrder = append(announceOrder, key)
+						}
+						announced[key] = tc
+					}
+				}
+				asm.AddDelta(chunk)
+				if chunk.IsComplete {
+					toolCalls = append(toolCalls, chunk.ToolCalls...)
+					if chunk.Type == StreamEventMessage || chunk.Type == StreamEventReasoning {
+						msg := asm.MessageFromComplete(chunk)
+						a.context.Add(msg)
+						a.recordWatchdog(msg)
 					}
 				}
 			}
-
+			if modelFailed {
+				return
+			}
 			if ctx.Err() != nil {
+				failAnnounced("tool call cancelled")
 				emitCancelled()
 				return
 			}
+			executable := make(map[string]struct{}, len(toolCalls))
+			for _, tc := range toolCalls {
+				if key := tc.Key(); key != "" {
+					executable[key] = struct{}{}
+				}
+			}
+			for _, id := range announceOrder {
+				if _, ok := executable[id]; ok {
+					continue
+				}
+				tc := a.withToolPresentation(announced[id])
+				tc.Status = "error"
+				out <- StreamEvent{
+					Type:      StreamEventToolResult,
+					MessageID: tc.Key(),
+					Content:   "tool call incomplete",
+					ToolCalls: []ToolCall{tc},
+				}
+				if ctx.Err() != nil {
+					emitCancelled()
+					return
+				}
+			}
+			if len(toolCalls) == 0 {
+				out <- StreamEvent{Type: StreamEventComplete}
+				if ctx.Err() != nil {
+					emitCancelled()
+					return
+				}
+				return
+			}
+			a.context.Add(&Message{
+				Role:      RoleAssistant,
+				ToolCalls: append([]ToolCall(nil), toolCalls...),
+			})
+			toolResults = make([]*Message, len(toolCalls))
+		} else {
+			toolResults = make([]*Message, len(pending))
+			toolCalls = make([]ToolCall, 0, len(pending))
+			for _, tc := range pending {
+				if !tc.InterruptActive && tc.ToolCall != nil {
+					toolCalls = append(toolCalls, *tc.ToolCall)
+				}
+			}
+		}
 
-			var runningTools sync.WaitGroup
-			var batchEffects batchToolResultEffects
-			suppressWindow := make([]atomic.Bool, len(toolCalls))
-			for i, tc := range toolCalls {
-				runningTools.Add(1)
-				go func(i int, tc ToolCall) {
-					defer runningTools.Done()
-					if ctx.Err() != nil {
-						return
-					}
-					tcKey := tc.Key()
-					toolCtx, toolSpan := telemetry.StartToolSpan(ctx, tc.Name, tc.Namespace)
+		if ctx.Err() != nil {
+			emitCancelled()
+			return
+		}
 
-					tool := a.findTool(tc.Name, tc.Namespace)
-					if tool == nil {
-						toolErr := fmt.Errorf("tool %q: %w", tc.Name, ErrToolNotFound)
-						toolSpan.Finish("error", toolErr)
-						toolResults[i] = a.emitToolResult(out, tc, toolErr.Error(), "error")
-						return
-					}
-					runtimeCopy := turnRT.WithToolCallID(tcKey)
-					output, toolDisp, err := a.toolRunner.Run(toolCtx, ToolInvocation{
-						Tool:     tool,
-						ArgsJSON: tc.Arguments,
-						Runtime:  runtimeCopy,
-					})
-					var interrupt interrupt.Interrupt
-					if errors.As(err, &interrupt) {
-						intrId := uuid.New().String()
-						serialized, err := interrupt.Serialize()
-						if err != nil {
-							toolSpan.Finish("error", err)
-							out <- StreamEvent{Type: StreamEventError, Error: fmt.Errorf("serialize interrupt: %w", err)}
-							return
-						}
-						// Use json.RawMessage so interrupt data is nested JSON, not base64.
-						payload := map[string]any{
-							"interruptId": intrId,
-							"type":        interrupt.TypeName(),
-							"data":        json.RawMessage(serialized),
-						}
-						data, err := json.Marshal(payload)
-						if err != nil {
-							toolSpan.Finish("error", err)
-							out <- StreamEvent{Type: StreamEventError, Error: fmt.Errorf("marshal interrupt: %w", err)}
-							return
-						}
-						telemetry.InstrumentsFromContext(ctx).RecordInterrupt(
-							toolCtx, telemetry.AgentIDFromContext(ctx), interrupt.TypeName(),
-						)
-						toolSpan.Finish("interrupt", nil)
-						// Register resume maps before yielding the interrupt event so a
-						// synchronous consumer (ACP mid-turn resolve) never races an empty map.
-						a.pendingMu.Lock()
-						a.pendingToolCalls[tcKey] = stores.PendingToolCall{ToolCall: &tc, InterruptActive: true}
-						a.interruptToRequester[intrId] = tcKey
-						a.pendingMu.Unlock()
-						out <- StreamEvent{Type: StreamEventInterrupt, MessageID: tcKey, Data: data}
-						a.persistSession(toolCtx)
-						return
-					}
-					a.pendingMu.Lock()
-					delete(a.pendingToolCalls, tcKey)
-					a.pendingMu.Unlock()
+		var runningTools sync.WaitGroup
+		var batchEffects batchToolResultEffects
+		suppressWindow := make([]atomic.Bool, len(toolCalls))
+		for i, tc := range toolCalls {
+			runningTools.Add(1)
+			go func(i int, tc ToolCall) {
+				defer runningTools.Done()
+				if ctx.Err() != nil {
+					return
+				}
+				tcKey := tc.Key()
+				toolCtx, toolSpan := telemetry.StartToolSpan(ctx, tc.Name, tc.Namespace)
+
+				tool := a.findTool(tc.Name, tc.Namespace)
+				if tool == nil {
+					toolErr := fmt.Errorf("tool %q: %w", tc.Name, ErrToolNotFound)
+					toolSpan.Finish("error", toolErr)
+					toolResults[i] = a.emitToolResult(out, tc, toolErr.Error(), "error")
+					return
+				}
+				runtimeCopy := turnRT.WithToolCallID(tcKey)
+				output, toolDisp, err := a.toolRunner.Run(toolCtx, ToolInvocation{
+					Tool:     tool,
+					ArgsJSON: tc.Arguments,
+					Runtime:  runtimeCopy,
+				})
+				var parked interrupt.Interrupt
+				if errors.As(err, &parked) {
+					serialized, err := parked.Serialize()
 					if err != nil {
 						toolSpan.Finish("error", err)
-						content := err.Error()
-						if toolCtx.Err() != nil {
-							content = CancelledToolResultContent
-						}
-						toolResults[i] = a.emitToolResult(out, tc, content, "error")
+						out <- StreamEvent{Type: StreamEventError, Error: fmt.Errorf("serialize interrupt: %w", err)}
 						return
 					}
-					batchEffects.merge(toolDisp)
-					if toolDisp.SuppressWindowMessage {
-						suppressWindow[i].Store(true)
+					payload := map[string]any{
+						"interruptId": tcKey,
+						"type":        parked.TypeName(),
+						"data":        json.RawMessage(serialized),
 					}
-					hookDisp := a.toolResultHooks.observe(toolCtx, ToolResultObservation{
-						Name:     tc.Name,
-						ArgsJSON: tc.Arguments,
-						Output:   output,
-						Runtime:  runtimeCopy,
-					})
-					batchEffects.merge(hookDisp)
-					if hookDisp.SuppressWindowMessage {
-						suppressWindow[i].Store(true)
+					data, err := json.Marshal(payload)
+					if err != nil {
+						toolSpan.Finish("error", err)
+						out <- StreamEvent{Type: StreamEventError, Error: fmt.Errorf("marshal interrupt: %w", err)}
+						return
 					}
-					toolSpan.Finish("success", nil)
-					a.emitPlanUpdate(out)
-					toolResults[i] = a.emitToolResult(out, tc, output, "success")
-				}(i, tc)
-			}
-			runningTools.Wait()
-			if ctx.Err() != nil {
-				// Keep results that finished before cancel; open slots get cancelled pairing.
-				for i, r := range toolResults {
-					if r == nil || suppressWindow[i].Load() {
-						continue
-					}
-					a.context.Add(r)
+					telemetry.InstrumentsFromContext(ctx).RecordInterrupt(
+						toolCtx, telemetry.AgentIDFromContext(ctx), parked.TypeName(),
+					)
+					toolSpan.Finish("interrupt", nil)
+					a.pendingMu.Lock()
+					a.pendingToolCalls[tcKey] = stores.PendingToolCall{ToolCall: &tc, InterruptActive: true}
+					a.pendingMu.Unlock()
+					out <- StreamEvent{Type: StreamEventInterrupt, MessageID: tcKey, Data: data}
+					a.persistSession(toolCtx)
+					return
 				}
-				emitCancelled()
-				return
-			}
-			if len(toolCalls) > 0 {
-				hadToolRound = true
-			}
+				a.pendingMu.Lock()
+				delete(a.pendingToolCalls, tcKey)
+				a.pendingMu.Unlock()
+				if err != nil {
+					toolSpan.Finish("error", err)
+					content := err.Error()
+					if toolCtx.Err() != nil {
+						content = CancelledToolResultContent
+					}
+					toolResults[i] = a.emitToolResult(out, tc, content, "error")
+					return
+				}
+				batchEffects.merge(toolDisp)
+				if toolDisp.SuppressWindowMessage {
+					suppressWindow[i].Store(true)
+				}
+				hookDisp := a.toolResultHooks.observe(toolCtx, ToolResultObservation{
+					Name:     tc.Name,
+					ArgsJSON: tc.Arguments,
+					Output:   output,
+					Runtime:  runtimeCopy,
+				})
+				batchEffects.merge(hookDisp)
+				if hookDisp.SuppressWindowMessage {
+					suppressWindow[i].Store(true)
+				}
+				toolSpan.Finish("success", nil)
+				a.emitPlanUpdate(out)
+				toolResults[i] = a.emitToolResult(out, tc, output, "success")
+			}(i, tc)
+		}
+		runningTools.Wait()
+		if ctx.Err() != nil {
 			for i, r := range toolResults {
 				if r == nil || suppressWindow[i].Load() {
 					continue
 				}
-				if err := a.addToContext(ctx, r, out); err != nil {
-					if ctx.Err() != nil {
-						emitCancelled()
-						return
-					}
-					a.stripUnpairedToolCallsAfterInferenceError()
-					out <- StreamEvent{Type: StreamEventError, Error: fmt.Errorf("run: %w", err)}
+				a.context.Add(r)
+			}
+			emitCancelled()
+			return
+		}
+		if len(toolCalls) > 0 {
+			hadToolRound = true
+		}
+		for i, r := range toolResults {
+			if r == nil || suppressWindow[i].Load() {
+				continue
+			}
+			if err := a.addToContext(ctx, r, out); err != nil {
+				if ctx.Err() != nil {
+					emitCancelled()
 					return
 				}
-			}
-			a.pendingMu.Lock()
-			hasPending := len(a.pendingToolCalls) > 0
-			a.pendingMu.Unlock()
-			if hasPending {
-				a.persistSession(ctx)
+				a.pairCancelledToolResults(out)
+				out <- StreamEvent{Type: StreamEventError, Error: fmt.Errorf("run: %w", err)}
 				return
 			}
-			if effect := batchEffects.resolved(); effect != EffectNone {
-				if err := a.applyBatchToolResultEffect(ctx, effect); err != nil {
-					slog.ErrorContext(ctx, "failed to apply tool result context effect", "session_id", a.sessionId, "effect", effect, "error", err)
-					out <- StreamEvent{Type: StreamEventError, Error: err, Content: err.Error()}
-					return
-				}
+		}
+		if len(a.pendingSnapshot()) > 0 {
+			a.persistSession(ctx)
+			return
+		}
+		if effect := batchEffects.resolved(); effect != EffectNone {
+			if err := a.applyBatchToolResultEffect(ctx, effect); err != nil {
+				slog.ErrorContext(ctx, "failed to apply tool result context effect", "session_id", a.sessionId, "effect", effect, "error", err)
+				out <- StreamEvent{Type: StreamEventError, Error: err, Content: err.Error()}
+				return
 			}
 		}
-	}()
-	return out, nil
-}
-
-func (a *AgentHarness) ReturnFromInterrupt(ctx context.Context, finishedInterrupts map[string][]byte) (<-chan StreamEvent, error) {
-	a.pendingMu.Lock()
-	if a.interruptPayloads == nil {
-		a.interruptPayloads = make(map[string][]byte)
 	}
-	for interruptId, payload := range finishedInterrupts {
-		toolCallId, ok := a.interruptToRequester[interruptId]
-		if !ok {
-			a.pendingMu.Unlock()
-			return nil, fmt.Errorf("no tool call id found for interrupt %s: %w", interruptId, interrupt.ErrInterruptNotFound)
-		}
-		a.interruptPayloads[toolCallId] = payload
-		if _, err := a.session.ReturnInterrupt(toolCallId, payload); err != nil {
-			a.pendingMu.Unlock()
-			return nil, fmt.Errorf("return from interrupt %q: %w", interruptId, err)
-		}
-		delete(a.interruptToRequester, interruptId)
-		if tc, ok := a.pendingToolCalls[toolCallId]; ok {
-			a.pendingToolCalls[toolCallId] = stores.PendingToolCall{ToolCall: tc.ToolCall, InterruptActive: false}
-		} else {
-			a.pendingMu.Unlock()
-			return nil, fmt.Errorf("no pending tool call found for tool call id %s", toolCallId)
-		}
-	}
-	a.pendingMu.Unlock()
-	return a.Run(ctx, "")
 }
 
 // tagModelAfterToolsError wraps a stream error with ErrModelAfterTools.

--- a/agent_run.go
+++ b/agent_run.go
@@ -88,6 +88,7 @@ func (a *AgentHarness) startTurn(ctx context.Context, user *Message) (<-chan Str
 			out <- StreamEvent{Type: StreamEventError, Error: fmt.Errorf("run: context cancelled: %w", ctx.Err())}
 		}
 
+		a.pairOpenToolCalls("unpaired tool call")
 		if user != nil {
 			if err := a.addToContext(ctx, user, out); err != nil {
 				if ctx.Err() != nil {
@@ -397,6 +398,38 @@ func (a *AgentHarness) runTurnLoop(ctx context.Context, out chan StreamEvent, tu
 }
 
 // tagModelAfterToolsError wraps a stream error with ErrModelAfterTools.
+// pairOpenToolCalls appends error tool results for assistant tool_calls that
+// have no matching tool message. Restored dirty windows become valid before
+// the next model turn; new turns never commit unpaired calls.
+func (a *AgentHarness) pairOpenToolCalls(reason string) {
+	if a.context == nil {
+		return
+	}
+	msgs := a.context.Messages()
+	haveResult := make(map[string]struct{})
+	for _, m := range msgs {
+		if m != nil && m.Role == RoleTool && m.ToolCallID != "" {
+			haveResult[m.ToolCallID] = struct{}{}
+		}
+	}
+	for _, m := range msgs {
+		if m == nil || m.Role != RoleAssistant {
+			continue
+		}
+		for _, tc := range m.ToolCalls {
+			key := tc.Key()
+			if key == "" {
+				continue
+			}
+			if _, ok := haveResult[key]; ok {
+				continue
+			}
+			a.context.Add(&Message{Role: RoleTool, ToolCallID: key, Content: reason})
+			haveResult[key] = struct{}{}
+		}
+	}
+}
+
 func tagModelAfterToolsError(chunk LLMResponseChunk) LLMResponseChunk {
 	if chunk.Error != nil {
 		if !errors.Is(chunk.Error, ErrModelAfterTools) {

--- a/agent_run_test.go
+++ b/agent_run_test.go
@@ -454,9 +454,9 @@ func TestRun_modelErrorAfterTools_tagsAndCheckpointsPairs(t *testing.T) {
 	}
 }
 
-// TestRun_modelError_stripsUnpairedFromCheckpoint: on inference failure, unpaired
-// function_calls/results are dropped while complete tool pairs remain.
-func TestRun_modelError_stripsUnpairedFromCheckpoint(t *testing.T) {
+// TestRun_pairsOpenToolCallsBeforeTurn: a restored open function_call is paired
+// with an error tool result so the next model turn sees a valid window.
+func TestRun_pairsOpenToolCallsBeforeTurn(t *testing.T) {
 	store := stores.NewInMemoryStore()
 	strategy := &mockStrategy{
 		invokeFn: func(ctx context.Context, msgs []*Message, tools []*Tool, ch chan<- LLMResponseChunk) {
@@ -472,8 +472,7 @@ func TestRun_modelError_stripsUnpairedFromCheckpoint(t *testing.T) {
 		Model:  strategy,
 		Store:  store,
 	})
-	h.sessionId = "sess-strip-orphan"
-	// Leave pendingToolCalls empty so Run takes the model-turn path (not resume).
+	h.sessionId = "sess-pair-open"
 	h.restoreMessages([]*Message{
 		{Role: RoleUser, Content: "goal"},
 		{Role: RoleAssistant, ToolCalls: []ToolCall{
@@ -483,7 +482,6 @@ func TestRun_modelError_stripsUnpairedFromCheckpoint(t *testing.T) {
 			{CallID: "good", Name: "echo", Arguments: `{}`},
 		}},
 		{Role: RoleTool, ToolCallID: "good", Content: "done"},
-		{Role: RoleTool, ToolCallID: "orphan_out", Content: "no-call"},
 	})
 
 	events, err := h.Run(context.Background(), "continue")
@@ -492,7 +490,7 @@ func TestRun_modelError_stripsUnpairedFromCheckpoint(t *testing.T) {
 	}
 	_ = drainEvents(events)
 
-	loaded, err := NewAgentFromSession(context.Background(), "sess-strip-orphan", AgentOptions{
+	loaded, err := NewAgentFromSession(context.Background(), "sess-pair-open", AgentOptions{
 		Config: Config{MaxWindowSize: 8192},
 		Model:  &mockStrategy{},
 		Store:  store,
@@ -500,7 +498,7 @@ func TestRun_modelError_stripsUnpairedFromCheckpoint(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var sawGood, sawOrphan bool
+	var sawGood, sawOrphanCall, sawOrphanResult bool
 	for _, m := range loaded.Messages() {
 		if m == nil {
 			continue
@@ -508,7 +506,7 @@ func TestRun_modelError_stripsUnpairedFromCheckpoint(t *testing.T) {
 		if m.Role == RoleAssistant {
 			for _, tc := range m.ToolCalls {
 				if tc.CallID == "orphan" {
-					sawOrphan = true
+					sawOrphanCall = true
 				}
 			}
 		}
@@ -516,13 +514,14 @@ func TestRun_modelError_stripsUnpairedFromCheckpoint(t *testing.T) {
 			if m.ToolCallID == "good" && m.Content == "done" {
 				sawGood = true
 			}
-			if m.ToolCallID == "orphan_out" {
-				t.Fatalf("orphan tool output survived: %+v", loaded.Messages())
+			if m.ToolCallID == "orphan" {
+				sawOrphanResult = true
 			}
 		}
 	}
-	if sawOrphan {
-		t.Fatalf("orphan function_call survived: %+v", loaded.Messages())
+	if !sawOrphanCall || !sawOrphanResult {
+		t.Fatalf("open tool call must be paired: call=%v result=%v window=%+v",
+			sawOrphanCall, sawOrphanResult, loaded.Messages())
 	}
 	if !sawGood {
 		t.Fatalf("paired tool result missing: %+v", loaded.Messages())

--- a/builtins.go
+++ b/builtins.go
@@ -43,11 +43,6 @@ type askUserChoiceArgs struct {
 	Choices  []askUserChoiceOption `json:"choices" desc:"2 or more mutually exclusive options"`
 }
 
-// setPlanTodos persists the plan. The harness streams plan_update after Set.
-func setPlanTodos(sm *session.SessionManager, todos []Todo) {
-	sm.Plan.Set(todos)
-}
-
 var askUserChoiceTool = NewTool(ToolConfig{
 	Name:        "ask_user_choice",
 	DisplayName: "Ask: {question}",
@@ -82,7 +77,9 @@ var askUserChoiceTool = NewTool(ToolConfig{
 			return "", fmt.Errorf("marshal choices: %w", err)
 		}
 		if runtime.CurrentToolCallID() != "" {
-			_ = runtime.StateSet(askUserQuestionStateKey(runtime.CurrentToolCallID()), args.Question)
+			if err := runtime.StateSet(askUserQuestionStateKey(runtime.CurrentToolCallID()), args.Question); err != nil {
+				return "", err
+			}
 		}
 
 		intr, err := runtime.RaiseInterrupt("user_selection_choice", optionsJSON)
@@ -136,7 +133,7 @@ func newCreatePlanTool(sm *session.SessionManager) *Tool {
 				}
 			}
 			sm.Plan.SetDocument(args.Plan)
-			setPlanTodos(sm, todos)
+			sm.Plan.Set(todos)
 			return BuiltinResult{
 				Output:                "Plan created successfully",
 				Effect:                EffectInstallPlanDocument,
@@ -201,19 +198,19 @@ func newCompleteTodoTool(sm *session.SessionManager) *Tool {
 							for j < len(plan) {
 								if plan[j].Status != streaming.TodoStatusCompleted {
 									plan[j].Status = streaming.TodoStatusInProgress
-									setPlanTodos(sm, plan)
+									sm.Plan.Set(plan)
 									return handoff(fmt.Sprintf("Todo completed successfully, now starting %q with description: %q", plan[j].Title, plan[j].Description))
 								}
 								j++
 							}
-							setPlanTodos(sm, plan)
+							sm.Plan.Set(plan)
 							return allDone("All todos completed successfully")
 						}
 						plan[i+1].Status = streaming.TodoStatusInProgress
-						setPlanTodos(sm, plan)
+						sm.Plan.Set(plan)
 						return handoff(fmt.Sprintf("Todo completed successfully, now starting %q with description: %q", plan[i+1].Title, plan[i+1].Description))
 					}
-					setPlanTodos(sm, plan)
+					sm.Plan.Set(plan)
 					return allDone("All todos completed successfully")
 				}
 			}
@@ -265,7 +262,7 @@ func newEditPlanTool(sm *session.SessionManager) *Tool {
 					return BuiltinResult{}, fmt.Errorf("todo %q not found in plan", title)
 				}
 			}
-			setPlanTodos(sm, plan)
+			sm.Plan.Set(plan)
 			if trimmedPlan != "" {
 				sm.Plan.SetDocument(args.Plan)
 			}

--- a/cmd/testserver/main.go
+++ b/cmd/testserver/main.go
@@ -184,7 +184,7 @@ func main() {
 			"addr", addr,
 			"websocket", fmt.Sprintf("ws://localhost:%d/acp", port),
 			"streamable_http", fmt.Sprintf("http://localhost:%d/acp", port),
-			"legacy_unary", "POST /",
+			"sse", "POST /",
 		)
 		if err := srv.ServeHTTP(ctx, addr); err != nil && !errors.Is(err, context.Canceled) {
 			slog.Error("server error", "error", err)

--- a/inference/coverage_test.go
+++ b/inference/coverage_test.go
@@ -496,7 +496,7 @@ func TestCountTokens_tiktokenEncodingError(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 	s := NewOpenAIInferenceStrategy(srv.Client())
-	s.WithApiKey("k").WithModel("m").WithURL(srv.URL)
+	s.WithApiKey("k").WithModel("m").WithURL(srv.URL).WithLocalTokenFallback()
 	if _, err := s.CountTokens(context.Background(), []*tacklr.Message{{Role: tacklr.RoleUser, Content: "x"}}, nil); err == nil || !strings.Contains(err.Error(), "tiktoken") {
 		t.Fatalf("err = %v", err)
 	}

--- a/inference/inference.go
+++ b/inference/inference.go
@@ -38,6 +38,8 @@ type OpenAIInferenceStrategy struct {
 	structuredOutputSchema map[string]any
 	structuredOutputName   string
 	structuredOutputType   reflect.Type
+	// localTokenFallback uses tiktoken when the provider has no input_tokens endpoint.
+	localTokenFallback bool
 }
 
 func (s *OpenAIInferenceStrategy) SetSystemPrompt(prompt string) {
@@ -72,6 +74,13 @@ func (s *OpenAIInferenceStrategy) ModelTelemetryIdentity() telemetry.ModelIdenti
 
 func (s *OpenAIInferenceStrategy) WithURL(url string) *OpenAIInferenceStrategy {
 	s.baseURL = url
+	return s
+}
+
+// WithLocalTokenFallback counts tokens with tiktoken when the provider returns
+// 404/400/422 for /responses/input_tokens. Off by default.
+func (s *OpenAIInferenceStrategy) WithLocalTokenFallback() *OpenAIInferenceStrategy {
+	s.localTokenFallback = true
 	return s
 }
 
@@ -215,8 +224,7 @@ func (s *OpenAIInferenceStrategy) CountTokens(ctx context.Context, messages []*t
 	}
 
 	if httpResp.StatusCode != http.StatusOK {
-		if httpResp.StatusCode == http.StatusNotFound || httpResp.StatusCode == http.StatusBadRequest || httpResp.StatusCode == http.StatusUnprocessableEntity {
-			// Local fallback when the provider has no input_tokens endpoint.
+		if s.localTokenFallback && (httpResp.StatusCode == http.StatusNotFound || httpResp.StatusCode == http.StatusBadRequest || httpResp.StatusCode == http.StatusUnprocessableEntity) {
 			tke, err := getEncoding("o200k_base")
 			if err != nil {
 				return 0, fmt.Errorf("tiktoken count tokens: %w", err)

--- a/inference/invoke_test.go
+++ b/inference/invoke_test.go
@@ -3,6 +3,7 @@ package inference
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -138,7 +139,7 @@ func TestCountTokens_usesAPIWhenAvailable(t *testing.T) {
 	}
 }
 
-func TestCountTokens_fallsBackToTiktokenOn404(t *testing.T) {
+func TestCountTokens_404WithoutLocalFallback_returnsAPIError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = io.WriteString(w, `{"error":"nope"}`)
@@ -149,6 +150,28 @@ func TestCountTokens_fallsBackToTiktokenOn404(t *testing.T) {
 		WithApiKey("k").
 		WithModel("m").
 		WithURL(srv.URL)
+
+	_, err := s.CountTokens(context.Background(), []*tacklr.Message{
+		{Role: tacklr.RoleUser, Content: "count these tokens please"},
+	}, nil)
+	var apiErr *APIStatusError
+	if !errors.As(err, &apiErr) || apiErr.Status != http.StatusNotFound {
+		t.Fatalf("want 404 API error, got %v", err)
+	}
+}
+
+func TestCountTokens_fallsBackToTiktokenOn404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"error":"nope"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	s := NewOpenAIInferenceStrategy(srv.Client()).
+		WithApiKey("k").
+		WithModel("m").
+		WithURL(srv.URL).
+		WithLocalTokenFallback()
 
 	n, err := s.CountTokens(context.Background(), []*tacklr.Message{
 		{Role: tacklr.RoleUser, Content: "count these tokens please"},

--- a/internal/session/checkpointer.go
+++ b/internal/session/checkpointer.go
@@ -26,13 +26,12 @@ func (Checkpointer) Capture(
 	window []*streaming.Message,
 	sm *SessionManager,
 	pendingToolCalls map[string]stores.PendingToolCall,
-	interruptToRequester map[string]string,
 ) (*stores.SessionCheckpoint, error) {
 	if sm == nil {
 		return nil, fmt.Errorf("checkpointer: session manager is nil")
 	}
 	runtimeState, pending, resolved := sm.SnapshotDurable()
-	cp, err := stores.NewCheckpoint(window, pendingToolCalls, interruptToRequester, runtimeState, pending, resolved)
+	cp, err := stores.NewCheckpoint(window, pendingToolCalls, runtimeState, pending, resolved)
 	if err != nil {
 		return nil, err
 	}
@@ -49,9 +48,11 @@ func (Checkpointer) Capture(
 // AppliedCheckpoint is harness-side state restored from a store blob
 // (everything not owned by SessionManager).
 type AppliedCheckpoint struct {
-	Window               []*streaming.Message
-	PendingToolCalls     map[string]stores.PendingToolCall
-	InterruptToRequester map[string]string
+	Window           []*streaming.Message
+	PendingToolCalls map[string]stores.PendingToolCall
+	// LegacyInterruptIDs maps old wire interrupt ids → tool call ids.
+	// Empty for checkpoints written after interrupt identity unification.
+	LegacyInterruptIDs map[string]string
 }
 
 // Apply loads SessionManager state from the checkpoint and returns maps the
@@ -73,13 +74,13 @@ func (Checkpointer) Apply(cp stores.SessionCheckpoint, sm *SessionManager) (Appl
 	if ptc == nil {
 		ptc = make(map[string]stores.PendingToolCall)
 	}
-	itr := cp.State.InterruptToRequester
-	if itr == nil {
-		itr = make(map[string]string)
+	legacy := cp.State.InterruptToRequester
+	if legacy == nil {
+		legacy = make(map[string]string)
 	}
 	return AppliedCheckpoint{
-		Window:               cp.ContextWindow,
-		PendingToolCalls:     ptc,
-		InterruptToRequester: itr,
+		Window:             cp.ContextWindow,
+		PendingToolCalls:   ptc,
+		LegacyInterruptIDs: legacy,
 	}, nil
 }

--- a/internal/session/modules_test.go
+++ b/internal/session/modules_test.go
@@ -85,7 +85,7 @@ func TestSessionModules_surviveCheckpoint(t *testing.T) {
 
 	cp, err := session.NewCheckpointer().Capture(
 		[]*streaming.Message{{Role: streaming.RoleUser, Content: "go"}},
-		sm, nil, nil,
+		sm, nil,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -120,7 +120,7 @@ func TestSessionModules_surviveCheckpoint(t *testing.T) {
 
 	sm2.DeleteParkedWorker("spawn_1")
 	sm2.SetParkedWorker("spawn_2", session.ParkedWorkerMeta{WorkerName: "writer", Task: "draft"})
-	cp2, err := session.NewCheckpointer().Capture(nil, sm2, nil, nil)
+	cp2, err := session.NewCheckpointer().Capture(nil, sm2, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/session/runtime_namespace_test.go
+++ b/internal/session/runtime_namespace_test.go
@@ -20,7 +20,7 @@ func TestSession_legacySearchNamespaceKey_strippedOnLoad(t *testing.T) {
 	if !ok || got != id {
 		t.Fatalf("legacy key must restore Search namespace, got %v ok=%v", got, ok)
 	}
-	cp, err := session.NewCheckpointer().Capture(nil, sm, nil, nil)
+	cp, err := session.NewCheckpointer().Capture(nil, sm, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -3,6 +3,7 @@ package session_test
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/ryanaldo34/tacklr/internal/session"
@@ -31,7 +32,6 @@ func TestCheckpointer_roundTrip(t *testing.T) {
 		[]*streaming.Message{{Role: streaming.RoleUser, Content: "hi"}},
 		sm,
 		map[string]stores.PendingToolCall{},
-		map[string]string{},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -62,7 +62,7 @@ func TestCheckpointer_roundTrip(t *testing.T) {
 
 // TestCheckpointer_nilManager_errors is the Capture/Apply guard outcome.
 func TestCheckpointer_nilManager_errors(t *testing.T) {
-	if _, err := session.NewCheckpointer().Capture(nil, nil, nil, nil); err == nil {
+	if _, err := session.NewCheckpointer().Capture(nil, nil, nil); err == nil {
 		t.Fatal("want capture error")
 	}
 	if _, err := session.NewCheckpointer().Apply(stores.SessionCheckpoint{}, nil); err == nil {
@@ -80,8 +80,39 @@ func TestCheckpointer_applyNilMaps_defaults(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if applied.PendingToolCalls == nil || applied.InterruptToRequester == nil {
+	if applied.PendingToolCalls == nil || applied.LegacyInterruptIDs == nil {
 		t.Fatal("expected non-nil default maps")
+	}
+}
+
+// TestCheckpointer_applyLegacyInterruptIDs restores old wire-id maps without
+// writing them back on Capture.
+func TestCheckpointer_applyLegacyInterruptIDs(t *testing.T) {
+	sm := session.NewSessionManager()
+	var cp stores.SessionCheckpoint
+	if err := json.Unmarshal([]byte(`{
+		"contextWindow":[],
+		"state":{"interruptToRequester":{"old-wire":"call_1"},"pendingToolCalls":{"call_1":{"interruptActive":true}}}
+	}`), &cp); err != nil {
+		t.Fatal(err)
+	}
+	applied, err := session.NewCheckpointer().Apply(cp, sm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if applied.LegacyInterruptIDs["old-wire"] != "call_1" {
+		t.Fatalf("legacy map = %#v", applied.LegacyInterruptIDs)
+	}
+	out, err := session.NewCheckpointer().Capture(applied.Window, sm, applied.PendingToolCalls)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "interruptToRequester") {
+		t.Fatalf("new checkpoint must omit legacy map: %s", raw)
 	}
 }
 
@@ -462,8 +493,7 @@ func TestCheckpointer_withPendingToolMaps_roundTrip(t *testing.T) {
 	ptc := map[string]stores.PendingToolCall{
 		"t1": {ToolCall: &streaming.ToolCall{ID: "t1", Name: "x"}, InterruptActive: true},
 	}
-	itr := map[string]string{"intr1": "t1"}
-	cp, err := session.NewCheckpointer().Capture(nil, sm, ptc, itr)
+	cp, err := session.NewCheckpointer().Capture(nil, sm, ptc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -472,7 +502,7 @@ func TestCheckpointer_withPendingToolMaps_roundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !applied.PendingToolCalls["t1"].InterruptActive || applied.InterruptToRequester["intr1"] != "t1" {
+	if !applied.PendingToolCalls["t1"].InterruptActive {
 		t.Fatalf("%+v", applied)
 	}
 }

--- a/server/acp.go
+++ b/server/acp.go
@@ -39,11 +39,6 @@ func stopReasonFromError(err error) (reason string, ok bool) {
 	case errors.Is(err, tacklr.ErrMaxTurnRequests):
 		return stopReasonMaxTurnRequests, true
 	default:
-		// Harness cancel notices wrap context.Canceled under fmt.Errorf.
-		if strings.Contains(strings.ToLower(err.Error()), "context cancelled") ||
-			strings.Contains(strings.ToLower(err.Error()), "context canceled") {
-			return stopReasonCancelled, true
-		}
 		return "", false
 	}
 }
@@ -409,15 +404,6 @@ func formatResourceLink(b acpContentBlock) (string, error) {
 		bld.WriteString(d)
 	}
 	return bld.String(), nil
-}
-
-// negotiateACPProtocolVersion implements init version negotiation:
-// same version if we support it, else the latest we support.
-func negotiateACPProtocolVersion(clientVersion int) int {
-	if clientVersion == acpProtocolVersion {
-		return acpProtocolVersion
-	}
-	return acpProtocolVersion
 }
 
 func eventToAcpJsonRpc(threadId string, event *streaming.StreamEvent) ([][]byte, error) {

--- a/server/acp_http.go
+++ b/server/acp_http.go
@@ -95,7 +95,6 @@ func (p *acpProtocol) handleACPPost(env ProtocolEnv, w http.ResponseWriter, r *h
 	reqConn := &Conn{
 		Writer: conn.Writer,
 		RPC:    conn.Bridge,
-		Caps:   conn.Bridge.GetCaps(),
 	}
 	reqEnv := ProtocolEnv{
 		Registry:    env.Registry,
@@ -127,27 +126,21 @@ func (p *acpProtocol) handleStreamableInitialize(env ProtocolEnv, w http.Respons
 
 	// Initialize result goes on the HTTP response body (200), not SSE.
 	hw := &httpBufferWriter{}
-	reqConn := &Conn{Writer: hw, RPC: bridge, Caps: ClientCapabilities{}}
+	reqConn := &Conn{Writer: hw, RPC: bridge}
 	reqEnv := ProtocolEnv{Registry: env.Registry, Conn: reqConn, Connections: env.Connections}
 	if err := p.HandleInbound(r.Context(), reqEnv, body); err != nil {
 		slog.Debug("acp streamable initialize", "error", err)
 	}
 
-	// If handler wrote an error, map to HTTP error shape still as JSON-RPC 200 body.
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set(HeaderAcpConnectionID, conn.ID)
 	setAffinityCookie(w, conn.ID)
-	w.WriteHeader(http.StatusOK)
-	if len(hw.buf) > 0 {
-		_, _ = w.Write(hw.buf)
+	if len(hw.buf) == 0 {
+		http.Error(w, "initialize produced no response", http.StatusInternalServerError)
 		return
 	}
-	// Fallback if nothing was written.
-	_ = json.NewEncoder(w).Encode(map[string]any{
-		"jsonrpc": "2.0",
-		"id":      peek.ID,
-		"result":  acpInitializeResult(env.Registry, acpProtocolVersion),
-	})
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(hw.buf)
 }
 
 // handleACPGet dispatches WebSocket upgrade vs Streamable HTTP SSE.

--- a/server/acp_protocol.go
+++ b/server/acp_protocol.go
@@ -54,33 +54,10 @@ func (*acpProtocol) Name() string { return "acp" }
 
 func (p *acpProtocol) HTTPRoutes() []HTTPRoute {
 	return []HTTPRoute{
-		// Legacy unary HTTP: one request owns the whole turn; no mid-turn client RPC.
-		// Prefer GET|POST|DELETE /acp (WebSocket or Streamable HTTP).
-		{Method: http.MethodPost, Pattern: "/", Handler: p.handleHTTP},
 		// ACP remote transport (RFD Streamable HTTP + WebSocket).
 		{Method: http.MethodPost, Pattern: "/acp", Handler: p.handleACPPost},
 		{Method: http.MethodGet, Pattern: "/acp", Handler: p.handleACPGet},
 		{Method: http.MethodDelete, Pattern: "/acp", Handler: p.handleACPDelete},
-	}
-}
-
-func (p *acpProtocol) handleHTTP(env ProtocolEnv, w http.ResponseWriter, r *http.Request) {
-	// Legacy unary ACP: prefer GET|POST|DELETE /acp (WebSocket or Streamable HTTP).
-	w.Header().Set("Deprecation", "true")
-	w.Header().Set("Link", `</acp>; rel="successor-version"`)
-	w.Header().Set("Warning", `299 - "Unary POST / ACP is deprecated; use WebSocket or Streamable HTTP on /acp"`)
-
-	body, err := readHTTPBody(r)
-	if err != nil {
-		mw := &jsonRPCMessageWriter{w: w}
-		_ = mw.WriteError(nil, fmt.Errorf("read body: %w", err))
-		return
-	}
-	conn := &Conn{Writer: &jsonRPCMessageWriter{w: w}}
-	// Unary HTTP has no outbound RPC bridge (no mid-turn elicitation).
-	env.Conn = conn
-	if err := p.HandleInbound(r.Context(), env, body); err != nil {
-		slog.Debug("acp http handler", "error", err)
 	}
 }
 
@@ -128,7 +105,6 @@ func (p *acpProtocol) handleACPWebSocket(env ProtocolEnv, w http.ResponseWriter,
 			reqConn := &Conn{
 				Writer: mw,
 				RPC:    bridge,
-				Caps:   bridge.GetCaps(),
 			}
 			reqEnv := ProtocolEnv{
 				Registry:    env.Registry,
@@ -185,14 +161,11 @@ func (p *acpProtocol) HandleInbound(ctx context.Context, env ProtocolEnv, body [
 	case "session/prompt", "session/resume":
 		return p.handleSessionTurn(ctx, env, pr)
 	case "initialize":
-		if len(pr.ClientCapsRaw) > 0 {
-			caps := ParseClientCapabilities(pr.ClientCapsRaw)
-			if env.Conn != nil {
-				env.Conn.Caps = caps
-				if env.Conn.RPC != nil {
-					env.Conn.RPC.SetCaps(caps)
-				}
+		if env.Conn != nil && env.Conn.RPC != nil {
+			if len(pr.ClientCapsRaw) > 0 {
+				env.Conn.RPC.SetCaps(ParseClientCapabilities(pr.ClientCapsRaw))
 			}
+			env.Conn.RPC.MarkInitialized()
 		}
 		return env.Conn.Writer.WriteResult(pr.ID, acpInitializeResult(env.Registry, pr.ProtocolVersion))
 	case "authenticate":
@@ -229,8 +202,13 @@ func (p *acpProtocol) HandleInbound(ctx context.Context, env ProtocolEnv, body [
 }
 
 func (p *acpProtocol) handleSessionTurn(ctx context.Context, env ProtocolEnv, pr *parsedRequest) error {
-	// Canonical path: Protocol.BindTurn → Registry.RunTurn.
-	req, err := p.BindTurn(ctx, env, pr.ThreadID, pr.Params)
+	if env.Conn != nil && env.Conn.RPC != nil {
+		if err := env.Conn.RPC.WaitInitialized(ctx); err != nil {
+			_ = env.Conn.Writer.WriteError(pr.ID, err)
+			return err
+		}
+	}
+	req, err := p.BindTurn(ctx, env, pr.ThreadID, pr.Method, pr.Params)
 	if err != nil {
 		_ = env.Conn.Writer.WriteError(pr.ID, err)
 		return err
@@ -329,16 +307,12 @@ func resolveInterruptViaACP(ctx context.Context, env ProtocolEnv, threadID strin
 	}
 	kind := envl.Type
 	if kind == "" {
-		// Backward compat: older yields without type are user selections.
-		kind = "user_selection_choice"
+		return nil, fmt.Errorf("interrupt envelope missing type")
 	}
 	switch kind {
 	case "tool_permission":
 		return resolvePermissionViaRequest(ctx, env, threadID, stream, ev)
 	case "user_selection_choice":
-		// Caps are snapshotted per inbound message at dispatch; initialize may
-		// finish SetCaps after session/prompt was already dispatched. Always
-		// prefer live bridge caps so mid-turn elicitation sees form support.
 		if !connElicitationForm(env.Conn) {
 			return nil, nil
 		}
@@ -349,15 +323,12 @@ func resolveInterruptViaACP(ctx context.Context, env ProtocolEnv, threadID strin
 }
 
 // connElicitationForm reports form-mode elicitation support from the live RPC
-// bridge when present, else the Conn snapshot.
+// bridge. No snapshot: initialize writes caps on the bridge.
 func connElicitationForm(c *Conn) bool {
-	if c == nil {
+	if c == nil || c.RPC == nil {
 		return false
 	}
-	if c.RPC != nil {
-		return c.RPC.GetCaps().ElicitationForm
-	}
-	return c.Caps.ElicitationForm
+	return c.RPC.GetCaps().ElicitationForm
 }
 
 func resolvePermissionViaRequest(ctx context.Context, env ProtocolEnv, threadID string, stream *EventStream, ev *streaming.StreamEvent) (<-chan streaming.StreamEvent, error) {
@@ -426,8 +397,9 @@ func acpInitializeResult(r *Registry, clientProtocolVersion int) map[string]any 
 			image = m.SupportsMIME("image/png")
 		}
 	}
+	_ = clientProtocolVersion
 	return map[string]any{
-		"protocolVersion": negotiateACPProtocolVersion(clientProtocolVersion),
+		"protocolVersion": acpProtocolVersion,
 		"agentCapabilities": map[string]any{
 			// Durable session/load against the registry store (survives restarts).
 			"loadSession": true,

--- a/server/acp_test.go
+++ b/server/acp_test.go
@@ -23,11 +23,6 @@ import (
 // helpers
 // ---------------------------------------------------------------------------
 
-func newACPRequest(t *testing.T, body string) *http.Request {
-	t.Helper()
-	return httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(body)))
-}
-
 func parseACPFrames(t *testing.T, body io.Reader) []map[string]any {
 	t.Helper()
 	var frames []map[string]any
@@ -66,10 +61,7 @@ func newACPTestServerWithWire(t *testing.T, r *Registry, wire ProtocolWireStore)
 
 func (s *acpTestServer) rpc(body string) *httptest.ResponseRecorder {
 	s.t.Helper()
-	req := newACPRequest(s.t, body)
-	rec := httptest.NewRecorder()
-	NewServer(s.r, s.proto).serveHTTPRPC(rec, req)
-	return rec
+	return serveACPInbound(s.t, s.r, s.proto, body)
 }
 
 // protocolForRegistry returns a stable ACP protocol per *Registry so multi-step
@@ -88,13 +80,19 @@ func acpProtocolFor(r *Registry) Protocol {
 	return actual.(Protocol)
 }
 
+func serveACPInbound(t *testing.T, r *Registry, proto Protocol, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	mw := &jsonRPCMessageWriter{w: rec}
+	env := ProtocolEnv{Registry: r, Conn: &Conn{Writer: mw}}
+	_ = proto.HandleInbound(t.Context(), env, []byte(body))
+	return rec
+}
+
 // serveACPRaw runs one RPC against a per-Registry isolated ACP protocol (not package ACP).
 func serveACPRaw(t *testing.T, r *Registry, body string) *httptest.ResponseRecorder {
 	t.Helper()
-	req := newACPRequest(t, body)
-	rec := httptest.NewRecorder()
-	NewServer(r, acpProtocolFor(r)).serveHTTPRPC(rec, req)
-	return rec
+	return serveACPInbound(t, r, acpProtocolFor(r), body)
 }
 
 func acpRPCResult(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
@@ -523,13 +521,9 @@ func TestInjectReqID_nonJSONFrame(t *testing.T) {
 	}
 }
 
-func TestACP_handleHTTP_initialize(t *testing.T) {
+func TestACP_handleInbound_initialize(t *testing.T) {
 	r := newTestRegistry(testStore(t), &mockInferenceStrategy{}, nil)
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(
-		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}`,
-	)))
-	NewACPProtocol(nil).(*acpProtocol).handleHTTP(ProtocolEnv{Registry: r, Conn: &Conn{}}, rec, req)
+	rec := serveACPRaw(t, r, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}`)
 	if rec.Code != 200 || !strings.Contains(rec.Body.String(), "protocolVersion") {
 		t.Fatalf("%d %s", rec.Code, rec.Body.String())
 	}

--- a/server/acp_test.go
+++ b/server/acp_test.go
@@ -1307,8 +1307,9 @@ func TestServeStdio_lifecycleAndPrompt(t *testing.T) {
 		t.Fatalf("session/new missing configOptions: %v", newResult)
 	}
 
-	// Second IO pass: set agent + prompt against the live session state.
+	// Second IO pass is a new connection: initialize, then set agent + prompt.
 	in2 := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":1}}`,
 		`{"jsonrpc":"2.0","id":3,"method":"session/set_config_option","params":{"sessionId":"` + sessionID + `","configId":"model","value":"default"}}`,
 		`{"jsonrpc":"2.0","id":4,"method":"session/prompt","params":{"sessionId":"` + sessionID + `","prompt":[{"type":"text","text":"hi"}]}}`,
 	}, "\n") + "\n"
@@ -1334,6 +1335,28 @@ func TestServeStdio_lifecycleAndPrompt(t *testing.T) {
 	}
 	if !hasResult {
 		t.Error("expected prompt result frame with id 4")
+	}
+}
+
+func TestServeStdio_promptBeforeInitialize_unblocksOnEOF(t *testing.T) {
+	r := newTestRegistry(testStore(t), &mockInferenceStrategy{}, nil)
+	in := `{"jsonrpc":"2.0","id":1,"method":"session/new","params":{"cwd":"/tmp"}}` + "\n" +
+		`{"jsonrpc":"2.0","id":2,"method":"session/prompt","params":{"sessionId":"x","prompt":[{"type":"text","text":"hi"}]}}` + "\n"
+	var out bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- NewServer(r, ACP).ServeStdio(context.Background(), strings.NewReader(in), &out)
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ServeStdio: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("prompt before initialize must not hang after stdin EOF")
+	}
+	if !strings.Contains(out.String(), "error") {
+		t.Fatalf("expected initialize-required error, got %s", out.String())
 	}
 }
 

--- a/server/acp_wire_session.go
+++ b/server/acp_wire_session.go
@@ -207,7 +207,7 @@ func (p *acpProtocol) LoadSession(ctx context.Context, env ProtocolEnv, sessionI
 
 // BindTurn implements Protocol: maps ACP session/prompt or session/resume params
 // into a Registry TurnRequest. This is the only turn-binding path for ACP.
-func (p *acpProtocol) BindTurn(ctx context.Context, env ProtocolEnv, sessionID string, turnParams json.RawMessage) (TurnRequest, error) {
+func (p *acpProtocol) BindTurn(ctx context.Context, env ProtocolEnv, sessionID, method string, turnParams json.RawMessage) (TurnRequest, error) {
 	var prompt string
 	var userMsg *tacklr.Message
 	var responses map[string]json.RawMessage
@@ -215,8 +215,27 @@ func (p *acpProtocol) BindTurn(ctx context.Context, env ProtocolEnv, sessionID s
 	var mcpFromClient []mcp.MCPConfig
 
 	if len(turnParams) > 0 {
-		var pp acpPromptParams
-		if err := json.Unmarshal(turnParams, &pp); err == nil {
+		switch method {
+		case "session/resume":
+			var sp acpSessionParams
+			if err := json.Unmarshal(turnParams, &sp); err == nil {
+				if sp.SessionID != "" {
+					sessionID = sp.SessionID
+				}
+				cwd = sp.Cwd
+				mcpFromClient = sp.MCPServers
+			}
+			var withResp struct {
+				Responses map[string]json.RawMessage `json:"responses"`
+			}
+			if err := json.Unmarshal(turnParams, &withResp); err == nil {
+				responses = withResp.Responses
+			}
+		default:
+			var pp acpPromptParams
+			if err := json.Unmarshal(turnParams, &pp); err != nil {
+				return TurnRequest{}, clientErrorf(ErrInvalidRequest, "invalid prompt params: %v", err)
+			}
 			if pp.SessionID != "" {
 				sessionID = pp.SessionID
 			}
@@ -228,20 +247,15 @@ func (p *acpProtocol) BindTurn(ctx context.Context, env ProtocolEnv, sessionID s
 				userMsg = msg
 				prompt = msg.Content
 			}
-		}
-		var sp acpSessionParams
-		if err := json.Unmarshal(turnParams, &sp); err == nil {
-			if sp.SessionID != "" && sessionID == "" {
-				sessionID = sp.SessionID
+			var sp acpSessionParams
+			if err := json.Unmarshal(turnParams, &sp); err == nil {
+				if sp.SessionID != "" && sessionID == "" {
+					sessionID = sp.SessionID
+				}
+				cwd = sp.Cwd
+				mcpFromClient = sp.MCPServers
 			}
-			cwd = sp.Cwd
-			mcpFromClient = sp.MCPServers
 		}
-		var withResp struct {
-			Responses map[string]json.RawMessage `json:"responses"`
-		}
-		_ = json.Unmarshal(turnParams, &withResp)
-		responses = withResp.Responses
 	}
 
 	if sessionID == "" {

--- a/server/client_rpc.go
+++ b/server/client_rpc.go
@@ -52,13 +52,38 @@ type ClientBridge struct {
 	wait map[string]*rpcWaiter
 	// Caps is protected by mu; use GetCaps/SetCaps from concurrent stdio handlers.
 	Caps ClientCapabilities
+	// initialized is closed once initialize has run on this connection.
+	initialized     chan struct{}
+	initializedOnce sync.Once
 }
 
 // NewClientBridge creates a bridge that writes requests through w.
 func NewClientBridge(w MessageWriter) *ClientBridge {
 	return &ClientBridge{
-		w:    w,
-		wait: make(map[string]*rpcWaiter),
+		w:           w,
+		wait:        make(map[string]*rpcWaiter),
+		initialized: make(chan struct{}),
+	}
+}
+
+// MarkInitialized records that initialize completed on this connection.
+func (b *ClientBridge) MarkInitialized() {
+	if b == nil {
+		return
+	}
+	b.initializedOnce.Do(func() { close(b.initialized) })
+}
+
+// WaitInitialized blocks until initialize has run or ctx is done.
+func (b *ClientBridge) WaitInitialized(ctx context.Context) error {
+	if b == nil {
+		return nil
+	}
+	select {
+	case <-b.initialized:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/server/client_rpc.go
+++ b/server/client_rpc.go
@@ -3,10 +3,13 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
 )
+
+var errConnectionNotInitialized = errors.New("connection closed before initialize")
 
 // ClientCapabilities captures client features from initialize.
 type ClientCapabilities struct {
@@ -55,6 +58,9 @@ type ClientBridge struct {
 	// initialized is closed once initialize has run on this connection.
 	initialized     chan struct{}
 	initializedOnce sync.Once
+	// closed is closed when the connection is torn down (stdio EOF, etc.).
+	closed     chan struct{}
+	closedOnce sync.Once
 }
 
 // NewClientBridge creates a bridge that writes requests through w.
@@ -63,6 +69,7 @@ func NewClientBridge(w MessageWriter) *ClientBridge {
 		w:           w,
 		wait:        make(map[string]*rpcWaiter),
 		initialized: make(chan struct{}),
+		closed:      make(chan struct{}),
 	}
 }
 
@@ -74,7 +81,15 @@ func (b *ClientBridge) MarkInitialized() {
 	b.initializedOnce.Do(func() { close(b.initialized) })
 }
 
-// WaitInitialized blocks until initialize has run or ctx is done.
+// Close unblocks WaitInitialized when the connection ends without initialize.
+func (b *ClientBridge) Close() {
+	if b == nil {
+		return
+	}
+	b.closedOnce.Do(func() { close(b.closed) })
+}
+
+// WaitInitialized blocks until initialize has run, the connection closes, or ctx is done.
 func (b *ClientBridge) WaitInitialized(ctx context.Context) error {
 	if b == nil {
 		return nil
@@ -82,6 +97,8 @@ func (b *ClientBridge) WaitInitialized(ctx context.Context) error {
 	select {
 	case <-b.initialized:
 		return nil
+	case <-b.closed:
+		return errConnectionNotInitialized
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/server/client_rpc_test.go
+++ b/server/client_rpc_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -177,6 +178,23 @@ func TestClientBridge_errorResponseAndConcurrent(t *testing.T) {
 		}
 	}
 	wg.Wait()
+}
+
+func TestClientBridge_WaitInitialized(t *testing.T) {
+	b := NewClientBridge(&recordingWriter{})
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := b.WaitInitialized(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("before initialize: %v", err)
+	}
+	b.MarkInitialized()
+	if err := b.WaitInitialized(context.Background()); err != nil {
+		t.Fatalf("after initialize: %v", err)
+	}
+	var nilB *ClientBridge
+	if err := nilB.WaitInitialized(context.Background()); err != nil {
+		t.Fatalf("nil bridge: %v", err)
+	}
 }
 
 func TestParseClientCapabilities(t *testing.T) {

--- a/server/client_rpc_test.go
+++ b/server/client_rpc_test.go
@@ -191,6 +191,11 @@ func TestClientBridge_WaitInitialized(t *testing.T) {
 	if err := b.WaitInitialized(context.Background()); err != nil {
 		t.Fatalf("after initialize: %v", err)
 	}
+	closed := NewClientBridge(&recordingWriter{})
+	closed.Close()
+	if err := closed.WaitInitialized(context.Background()); !errors.Is(err, errConnectionNotInitialized) {
+		t.Fatalf("closed before initialize: %v", err)
+	}
 	var nilB *ClientBridge
 	if err := nilB.WaitInitialized(context.Background()); err != nil {
 		t.Fatalf("nil bridge: %v", err)

--- a/server/connection.go
+++ b/server/connection.go
@@ -276,8 +276,8 @@ func (c *Connection) attachSessionSSE(sessionID string, w http.ResponseWriter, f
 }
 
 // deliver sends one JSON-RPC message to the appropriate SSE stream(s).
-// connLevel or empty sessionID → connection stream; else session stream with
-// fallback to connection stream so messages are not dropped if session SSE is late.
+// connLevel or empty sessionID → connection stream; else the session stream.
+// Late session traffic is dropped unless LateSessionSSEFallback is set.
 func (c *Connection) deliver(sessionID string, data []byte, connLevel bool) error {
 	if c == nil {
 		return fmt.Errorf("nil connection")

--- a/server/connection.go
+++ b/server/connection.go
@@ -41,6 +41,8 @@ type Connection struct {
 	routes   map[string]streamRoute
 	sessions map[string]struct{}
 	closed   bool
+	// lateSessionSSEFallback copies ConnectionRegistry.LateSessionSSEFallback.
+	lateSessionSSEFallback bool
 }
 
 type streamRoute struct {
@@ -95,6 +97,9 @@ func (s *sseSink) close() {
 type ConnectionRegistry struct {
 	mu   sync.Mutex
 	byID map[string]*Connection
+	// LateSessionSSEFallback delivers session traffic on the connection SSE
+	// when the session sink is not open yet. Off by default.
+	LateSessionSSEFallback bool
 }
 
 // NewConnectionRegistry returns an empty registry.
@@ -107,14 +112,15 @@ func NewConnectionRegistry() *ConnectionRegistry {
 func (r *ConnectionRegistry) Create(bridge *ClientBridge, writer MessageWriter) *Connection {
 	ctx, cancel := context.WithCancel(context.Background())
 	c := &Connection{
-		ID:           uuid.NewString(),
-		Bridge:       bridge,
-		Writer:       writer,
-		ctx:          ctx,
-		cancel:       cancel,
-		sessionSinks: make(map[string]*sseSink),
-		routes:       make(map[string]streamRoute),
-		sessions:     make(map[string]struct{}),
+		ID:                     uuid.NewString(),
+		Bridge:                 bridge,
+		Writer:                 writer,
+		ctx:                    ctx,
+		cancel:                 cancel,
+		sessionSinks:           make(map[string]*sseSink),
+		routes:                 make(map[string]streamRoute),
+		sessions:               make(map[string]struct{}),
+		lateSessionSSEFallback: r != nil && r.LateSessionSSEFallback,
 	}
 	if r == nil {
 		return c
@@ -289,7 +295,7 @@ func (c *Connection) deliver(sessionID string, data []byte, connLevel bool) erro
 	} else {
 		if s := c.sessionSinks[sessionID]; s != nil {
 			targets = append(targets, s)
-		} else if c.connSink != nil {
+		} else if c.lateSessionSSEFallback && c.connSink != nil {
 			targets = append(targets, c.connSink)
 		}
 	}

--- a/server/errors.go
+++ b/server/errors.go
@@ -63,7 +63,8 @@ func IsClientError(err error) bool {
 		errors.Is(err, ErrMethodNotFound) ||
 		errors.Is(err, ErrAgentNotFound) ||
 		errors.Is(err, ErrSessionNotFound) ||
-		errors.Is(err, ErrSessionStoreNotConfigured)
+		errors.Is(err, ErrSessionStoreNotConfigured) ||
+		errors.Is(err, errConnectionNotInitialized)
 }
 
 // PublicError returns a wire-safe error: client errors pass through unchanged;

--- a/server/handler_failure_paths_test.go
+++ b/server/handler_failure_paths_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -477,10 +478,12 @@ func TestServeHTTPSSE_resumePath(t *testing.T) {
 }
 
 func TestStopReasonFromError_contextMessage(t *testing.T) {
-	// String-based cancel detection
-	reason, ok := stopReasonFromError(errors.New("run: context cancelled: wrap"))
+	reason, ok := stopReasonFromError(fmt.Errorf("run: %w", context.Canceled))
 	if !ok || reason != stopReasonCancelled {
 		t.Fatalf("%v %v", reason, ok)
+	}
+	if reason, ok := stopReasonFromError(errors.New("run: context cancelled: wrap")); ok {
+		t.Fatalf("string match must not classify cancel: %v", reason)
 	}
 }
 
@@ -930,7 +933,7 @@ func TestRunStdioLoop_channelClosed(t *testing.T) {
 	close(ch)
 	var wg sync.WaitGroup
 	bridge := NewClientBridge(&recordingWriter{})
-	err := runStdioLoop(context.Background(), ch, bridge, func([]byte) {}, &wg)
+	err := runStdioLoop(context.Background(), ch, bridge, func([]byte) {}, &wg, nil)
 	if err != nil {
 		// ctx not cancelled → nil from ctx.Err()
 		t.Fatalf("want nil on closed channel without cancel, got %v", err)
@@ -939,7 +942,7 @@ func TestRunStdioLoop_channelClosed(t *testing.T) {
 	cancel()
 	ch2 := make(chan stdioReadResult)
 	close(ch2)
-	err = runStdioLoop(ctx, ch2, bridge, func([]byte) {}, &wg)
+	err = runStdioLoop(ctx, ch2, bridge, func([]byte) {}, &wg, nil)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("want canceled, got %v", err)
 	}
@@ -986,7 +989,7 @@ func TestHandleWS_acceptFailAndReadFail(t *testing.T) {
 	mux := http.NewServeMux()
 	env := ProtocolEnv{Registry: r, Conn: &Conn{}}
 	for _, route := range SSE.HTTPRoutes() {
-		if route.Method == http.MethodGet && route.Pattern == "/" {
+		if route.Method == http.MethodGet && route.Pattern == "/{$}" {
 			mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
 				route.Handler(env, w, req)
 			})
@@ -1012,7 +1015,7 @@ func TestHandleWS_nonClientRunErrorAndWriteThreadFail(t *testing.T) {
 	mux := http.NewServeMux()
 	env := ProtocolEnv{Registry: r, Conn: &Conn{}}
 	for _, route := range SSE.HTTPRoutes() {
-		if route.Method == http.MethodGet && route.Pattern == "/" {
+		if route.Method == http.MethodGet && route.Pattern == "/{$}" {
 			mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
 				route.Handler(env, w, req)
 			})
@@ -1056,7 +1059,7 @@ func TestHandleWS_nonClientRunErrorAndWriteThreadFail(t *testing.T) {
 	mux2 := http.NewServeMux()
 	env2 := ProtocolEnv{Registry: r2, Conn: &Conn{}}
 	for _, route := range SSE.HTTPRoutes() {
-		if route.Method == http.MethodGet && route.Pattern == "/" {
+		if route.Method == http.MethodGet && route.Pattern == "/{$}" {
 			mux2.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
 				route.Handler(env2, w, req)
 			})
@@ -1086,8 +1089,8 @@ func TestServeHTTPSSE_fallbackPath(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := newSSERequest(t, "/nope", bytes.NewReader([]byte(`{"agent_id":"default","prompt":"x"}`)))
 	serveSSEHTTP(srv, rec, req)
-	if !strings.Contains(rec.Body.String(), "fb2") {
-		t.Fatalf("fallback = %s", rec.Body.String())
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown SSE path status = %d body=%s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/server/handler_failure_paths_test.go
+++ b/server/handler_failure_paths_test.go
@@ -128,13 +128,12 @@ func (f *failAfter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func TestHandleHTTP_bodyReadError(t *testing.T) {
+func TestHandleInbound_invalidJSON(t *testing.T) {
 	r := newTestRegistry(testStore(t), &mockInferenceStrategy{}, nil)
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/", brokenBody{})
-	NewACPProtocol(nil).(*acpProtocol).handleHTTP(ProtocolEnv{Registry: r}, rec, req)
-	if rec.Body.Len() == 0 {
-		t.Fatal("expected error response body")
+	w := &recordingMessageWriter{}
+	err := NewACPProtocol(nil).(*acpProtocol).HandleInbound(context.Background(), ProtocolEnv{Registry: r, Conn: &Conn{Writer: w}}, []byte(`{`))
+	if err == nil && w.FrameCount() == 0 {
+		t.Fatal("expected inbound error for invalid JSON")
 	}
 }
 
@@ -231,7 +230,7 @@ func TestRunTurn_sessionCwdMismatchAndNoAgent(t *testing.T) {
 		"cwd":       "/cwd-b",
 		"prompt":    []map[string]string{{"type": "text", "text": "x"}},
 	})
-	if _, err := p.BindTurn(context.Background(), env, sid, turnParams); err == nil || !strings.Contains(err.Error(), "cwd") {
+	if _, err := p.BindTurn(context.Background(), env, sid, "session/prompt", turnParams); err == nil || !strings.Contains(err.Error(), "cwd") {
 		t.Fatalf("err = %v", err)
 	}
 
@@ -388,7 +387,7 @@ func TestResolveSelectionViaElicitation_withQuestion(t *testing.T) {
 
 	w := &recordingWriter{}
 	bridge := NewClientBridge(w)
-	env := ProtocolEnv{Conn: &Conn{RPC: bridge, Caps: ClientCapabilities{ElicitationForm: true}}}
+	env := ProtocolEnv{Conn: &Conn{RPC: bridge}}
 	stream := &EventStream{harness: h, runCtx: context.Background()}
 
 	type res struct {
@@ -460,7 +459,7 @@ func TestClientBridge_TryCompleteUnknownID(t *testing.T) {
 }
 
 func TestServeHTTPSSE_resumePath(t *testing.T) {
-	// Hit /resume pattern registration via serveHTTPSSE path matching.
+	// Hit /resume pattern registration via serveSSEHTTP path matching.
 	store := testStore(t)
 	strategy := &mockInferenceStrategy{
 		invokeFn: func(ctx context.Context, msgs []*tacklr.Message, tools []*tacklr.Tool, ch chan<- tacklr.LLMResponseChunk) {
@@ -470,11 +469,11 @@ func TestServeHTTPSSE_resumePath(t *testing.T) {
 	srv := NewServer(newTestRegistry(store, strategy, nil), SSE)
 	// First create a session via normal prompt to get thread
 	rec := httptest.NewRecorder()
-	srv.serveHTTPSSE(rec, newSSERequest(t, "/", bytes.NewReader([]byte(`{"agent_id":"default","prompt":"hi"}`))))
+	serveSSEHTTP(srv, rec, newSSERequest(t, "/", bytes.NewReader([]byte(`{"agent_id":"default","prompt":"hi"}`))))
 	// Resume with empty responses still exercises /resume route (may error)
 	rec2 := httptest.NewRecorder()
 	req := newSSERequest(t, "/resume", bytes.NewReader([]byte(`{"agent_id":"default","thread_id":"missing","responses":{"x":{}}}`)))
-	srv.serveHTTPSSE(rec2, req)
+	serveSSEHTTP(srv, rec2, req)
 }
 
 func TestStopReasonFromError_contextMessage(t *testing.T) {
@@ -663,7 +662,7 @@ func TestResolveSelectionViaElicitation_errorPaths(t *testing.T) {
 	}
 	// Call fail — bridge write fails
 	failBridge := NewClientBridge(&failFrameWriter{})
-	env := ProtocolEnv{Conn: &Conn{RPC: failBridge, Caps: ClientCapabilities{ElicitationForm: true}}}
+	env := ProtocolEnv{Conn: &Conn{RPC: failBridge}}
 	if _, err := resolveSelectionViaElicitation(context.Background(), env, "s", &EventStream{}, &streaming.StreamEvent{
 		Data: optsOK, MessageID: "m1",
 	}); err == nil {
@@ -672,7 +671,7 @@ func TestResolveSelectionViaElicitation_errorPaths(t *testing.T) {
 	// Bad elicitation result payload
 	w := &recordingWriter{}
 	bridge := NewClientBridge(w)
-	env2 := ProtocolEnv{Conn: &Conn{RPC: bridge, Caps: ClientCapabilities{ElicitationForm: true}}}
+	env2 := ProtocolEnv{Conn: &Conn{RPC: bridge}}
 	type res struct {
 		err error
 	}
@@ -788,7 +787,7 @@ func (closedErrProtocol) CreateSession(context.Context, ProtocolEnv, json.RawMes
 func (closedErrProtocol) LoadSession(context.Context, ProtocolEnv, string, json.RawMessage) (any, error) {
 	return nil, ErrWireSessionUnsupported
 }
-func (closedErrProtocol) BindTurn(context.Context, ProtocolEnv, string, json.RawMessage) (TurnRequest, error) {
+func (closedErrProtocol) BindTurn(context.Context, ProtocolEnv, string, string, json.RawMessage) (TurnRequest, error) {
 	return TurnRequest{}, ErrWireSessionUnsupported
 }
 func (closedErrProtocol) CloseSession(context.Context, ProtocolEnv, string) error {
@@ -1086,7 +1085,7 @@ func TestServeHTTPSSE_fallbackPath(t *testing.T) {
 	srv := NewServer(newTestRegistry(testStore(t), strategy, nil), SSE)
 	rec := httptest.NewRecorder()
 	req := newSSERequest(t, "/nope", bytes.NewReader([]byte(`{"agent_id":"default","prompt":"x"}`)))
-	srv.serveHTTPSSE(rec, req)
+	serveSSEHTTP(srv, rec, req)
 	if !strings.Contains(rec.Body.String(), "fb2") {
 		t.Fatalf("fallback = %s", rec.Body.String())
 	}

--- a/server/permission_resolve_test.go
+++ b/server/permission_resolve_test.go
@@ -39,27 +39,25 @@ func TestResolveInterruptViaACP_dispatchOutcomes(t *testing.T) {
 		"data":        json.RawMessage(ser),
 	})
 	ch, err := resolveInterruptViaACP(context.Background(), ProtocolEnv{Conn: &Conn{
-		RPC:  NewClientBridge(&recordingWriter{}),
-		Caps: ClientCapabilities{ElicitationForm: false},
+		RPC: NewClientBridge(&recordingWriter{}),
 	}}, "s", &EventStream{}, &streaming.StreamEvent{Data: selData, MessageID: "tc"})
 	if err != nil || ch != nil {
 		t.Fatalf("no-form park: ch=%v err=%v", ch, err)
 	}
 
-	// Empty type defaults to user_selection_choice (same park without form).
+	// Missing type is rejected — no default kind.
 	legacy, _ := json.Marshal(map[string]any{
 		"interruptId": "i3",
 		"data":        json.RawMessage(ser),
 	})
-	ch, err = resolveInterruptViaACP(context.Background(), ProtocolEnv{Conn: &Conn{
+	_, err = resolveInterruptViaACP(context.Background(), ProtocolEnv{Conn: &Conn{
 		RPC: NewClientBridge(&recordingWriter{}),
 	}}, "s", &EventStream{}, &streaming.StreamEvent{Data: legacy})
-	if err != nil || ch != nil {
-		t.Fatalf("legacy type park: ch=%v err=%v", ch, err)
+	if err == nil || !strings.Contains(err.Error(), "missing type") {
+		t.Fatalf("missing type: %v", err)
 	}
 
-	// Stale Conn.Caps snapshot (false) but bridge has form support after initialize.
-	// Mid-turn resolution must use live GetCaps, not the dispatch-time copy.
+	// Live bridge caps after initialize drive elicitation (no Conn snapshot).
 	bridge := NewClientBridge(&recordingWriter{})
 	bridge.SetCaps(ClientCapabilities{ElicitationForm: true})
 	// Without a matching client response Call will block; just assert we do not
@@ -67,8 +65,7 @@ func TestResolveInterruptViaACP_dispatchOutcomes(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
 	_, err = resolveInterruptViaACP(ctx, ProtocolEnv{Conn: &Conn{
-		RPC:  bridge,
-		Caps: ClientCapabilities{ElicitationForm: false}, // stale snapshot
+		RPC: bridge,
 	}}, "s", &EventStream{}, &streaming.StreamEvent{Data: selData, MessageID: "tc"})
 	// Must not park (nil, nil): should attempt elicitation and fail via ctx/call.
 	if err == nil {

--- a/server/protocol.go
+++ b/server/protocol.go
@@ -13,7 +13,6 @@ import (
 type Conn struct {
 	Writer MessageWriter
 	RPC    *ClientBridge
-	Caps   ClientCapabilities
 }
 
 // ProtocolEnv is the domain + connection context passed into protocol handlers.
@@ -78,7 +77,8 @@ type Protocol interface {
 	LoadSession(ctx context.Context, env ProtocolEnv, sessionID string, params json.RawMessage) (result any, err error)
 
 	// BindTurn maps a wire session + turn body into a Registry TurnRequest.
-	BindTurn(ctx context.Context, env ProtocolEnv, sessionID string, turnParams json.RawMessage) (TurnRequest, error)
+	// method is the inbound RPC method (session/prompt, session/resume, …).
+	BindTurn(ctx context.Context, env ProtocolEnv, sessionID, method string, turnParams json.RawMessage) (TurnRequest, error)
 
 	// CloseSession drops live wire binding and may cancel an in-flight turn.
 	CloseSession(ctx context.Context, env ProtocolEnv, sessionID string) error

--- a/server/protocol_test.go
+++ b/server/protocol_test.go
@@ -100,7 +100,7 @@ func (healthProtocol) CreateSession(context.Context, ProtocolEnv, json.RawMessag
 func (healthProtocol) LoadSession(context.Context, ProtocolEnv, string, json.RawMessage) (any, error) {
 	return nil, ErrWireSessionUnsupported
 }
-func (healthProtocol) BindTurn(context.Context, ProtocolEnv, string, json.RawMessage) (TurnRequest, error) {
+func (healthProtocol) BindTurn(context.Context, ProtocolEnv, string, string, json.RawMessage) (TurnRequest, error) {
 	return TurnRequest{}, ErrWireSessionUnsupported
 }
 func (healthProtocol) CloseSession(context.Context, ProtocolEnv, string) error {

--- a/server/sse_protocol.go
+++ b/server/sse_protocol.go
@@ -28,9 +28,9 @@ func (sseProtocol) HandleInbound(ctx context.Context, env ProtocolEnv, body []by
 
 func (p sseProtocol) HTTPRoutes() []HTTPRoute {
 	return []HTTPRoute{
-		{Method: http.MethodPost, Pattern: "/", Handler: p.handleSSE},
+		{Method: http.MethodPost, Pattern: "/{$}", Handler: p.handleSSE},
 		{Method: http.MethodPost, Pattern: "/resume", Handler: p.handleSSE},
-		{Method: http.MethodGet, Pattern: "/", Handler: p.handleWS},
+		{Method: http.MethodGet, Pattern: "/{$}", Handler: p.handleWS},
 		{Method: http.MethodGet, Pattern: "/resume", Handler: p.handleWS},
 	}
 }

--- a/server/sse_protocol.go
+++ b/server/sse_protocol.go
@@ -57,50 +57,21 @@ func (p sseProtocol) handleSSE(env ProtocolEnv, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	threadID, load := resolveThread(pr)
-	req := TurnRequest{
-		AgentID:   pr.AgentID,
-		ThreadID:  threadID,
-		Prompt:    pr.Prompt,
-		Responses: pr.Responses,
-		Load:      load,
-	}
-	stream, err := env.Registry.RunTurn(r.Context(), req)
-	if err != nil {
-		if !IsClientError(err) {
-			logTurnError(err, pr.AgentID, threadID)
-		}
-		// Headers not yet SSE; return JSON-RPC-ish error via SSE writer after headers.
-		w.Header().Set("Content-Type", "text/event-stream")
-		flusher.Flush()
-		mw := &sseMessageWriter{w: w, flusher: flusher}
-		_ = mw.WriteError(nil, err)
-		return
-	}
-	defer func() {
-		stream.Cancel()
-		stream.Close()
-	}()
-	if stream.SessionID() != "" {
-		threadID = stream.SessionID()
-	}
-
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("X-Thread-ID", threadID)
-	flusher.Flush()
-
-	mw := &sseMessageWriter{w: w, flusher: flusher}
-	env.Conn = &Conn{Writer: mw}
-
-	threadData, _ := json.Marshal(threadEvent{ThreadID: threadID})
-	_ = writeSSEEvent(w, flusher, "thread", threadData)
-
-	if err := runTurnStream(r.Context(), env, p, threadID, stream, nil); err != nil {
-		if !IsClientError(err) {
-			slog.Debug("sse turn stream ended", "error", err)
-		}
+	if err := p.runSSEProtocolTurn(r.Context(), env, pr, func(threadID string) MessageWriter {
+		w.Header().Set("X-Thread-ID", threadID)
+		flusher.Flush()
+		threadData, _ := json.Marshal(threadEvent{ThreadID: threadID})
+		_ = writeSSEEvent(w, flusher, "thread", threadData)
+		return &sseMessageWriter{w: w, flusher: flusher}
+	}, func(err error) {
+		flusher.Flush()
+		mw := &sseMessageWriter{w: w, flusher: flusher}
+		_ = mw.WriteError(nil, err)
+	}); err != nil && !IsClientError(err) {
+		slog.Debug("sse turn stream ended", "error", err)
 	}
 }
 
@@ -124,6 +95,21 @@ func (p sseProtocol) handleWS(env ProtocolEnv, w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	_ = p.runSSEProtocolTurn(ctx, env, pr, func(threadID string) MessageWriter {
+		_ = wsWriteJSON(ctx, c, wsServerEvent{Type: "thread", Content: threadID})
+		return &wsMessageWriter{ctx: ctx, c: c}
+	}, func(err error) {
+		_ = wsWriteJSON(ctx, c, wsServerEvent{Type: "error", Content: PublicError(err).Error()})
+	})
+}
+
+func (p sseProtocol) runSSEProtocolTurn(
+	ctx context.Context,
+	env ProtocolEnv,
+	pr *parsedRequest,
+	ready func(threadID string) MessageWriter,
+	onStartError func(error),
+) error {
 	threadID, load := resolveThread(pr)
 	req := TurnRequest{
 		AgentID:   pr.AgentID,
@@ -137,8 +123,10 @@ func (p sseProtocol) handleWS(env ProtocolEnv, w http.ResponseWriter, r *http.Re
 		if !IsClientError(err) {
 			logTurnError(err, pr.AgentID, threadID)
 		}
-		_ = wsWriteJSON(ctx, c, wsServerEvent{Type: "error", Content: PublicError(err).Error()})
-		return
+		if onStartError != nil {
+			onStartError(err)
+		}
+		return err
 	}
 	defer func() {
 		stream.Cancel()
@@ -147,13 +135,8 @@ func (p sseProtocol) handleWS(env ProtocolEnv, w http.ResponseWriter, r *http.Re
 	if stream.SessionID() != "" {
 		threadID = stream.SessionID()
 	}
-	if err := wsWriteJSON(ctx, c, wsServerEvent{Type: "thread", Content: threadID}); err != nil {
-		return
-	}
-
-	mw := &wsMessageWriter{ctx: ctx, c: c}
-	env.Conn = &Conn{Writer: mw}
-	_ = runTurnStream(ctx, env, p, threadID, stream, nil)
+	env.Conn = &Conn{Writer: ready(threadID)}
+	return runTurnStream(ctx, env, p, threadID, stream, nil)
 }
 
 func (p sseProtocol) OnStreamEvent(ctx context.Context, env ProtocolEnv, threadID string, stream *EventStream, ev streaming.StreamEvent, reqID json.RawMessage) StreamControl {
@@ -174,7 +157,7 @@ func (sseProtocol) LoadSession(context.Context, ProtocolEnv, string, json.RawMes
 	return nil, ErrWireSessionUnsupported
 }
 
-func (sseProtocol) BindTurn(context.Context, ProtocolEnv, string, json.RawMessage) (TurnRequest, error) {
+func (sseProtocol) BindTurn(context.Context, ProtocolEnv, string, string, json.RawMessage) (TurnRequest, error) {
 	return TurnRequest{}, ErrWireSessionUnsupported
 }
 

--- a/server/sse_test.go
+++ b/server/sse_test.go
@@ -132,7 +132,7 @@ func TestHandlePrompt_generatesThreadID(t *testing.T) {
 	req := newSSERequest(t, "/", body)
 	rec := httptest.NewRecorder()
 
-	NewServer(r, SSE).serveHTTPSSE(rec, req)
+	NewServer(r, SSE).HTTPMux().ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
@@ -163,7 +163,7 @@ func TestHandlePrompt_missingAcceptHeader_returnsNotAcceptable(t *testing.T) {
 	req.Header.Set("Accept", "application/json")
 	rec := httptest.NewRecorder()
 
-	NewServer(r, SSE).serveHTTPSSE(rec, req)
+	NewServer(r, SSE).HTTPMux().ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusNotAcceptable {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotAcceptable)
@@ -196,7 +196,7 @@ func TestHandleResume_resolvesInterrupt(t *testing.T) {
 	promptBody := bytes.NewReader([]byte(`{"agent_id":"default","prompt":"start"}`))
 	promptReq := newSSERequest(t, "/", promptBody)
 	promptRec := httptest.NewRecorder()
-	NewServer(r, SSE).serveHTTPSSE(promptRec, promptReq)
+	NewServer(r, SSE).HTTPMux().ServeHTTP(promptRec, promptReq)
 
 	events := parseSSEEvents(t, promptRec.Body)
 	var threadID, interruptID string
@@ -225,7 +225,7 @@ func TestHandleResume_resolvesInterrupt(t *testing.T) {
 	resumeBody := fmt.Sprintf(`{"agent_id":"default","thread_id":%q,"responses":{%q:{"interruptId":%q,"selectionIdx":0}}}`, threadID, interruptID, interruptID)
 	resumeReq := newSSERequest(t, "/resume", bytes.NewReader([]byte(resumeBody)))
 	resumeRec := httptest.NewRecorder()
-	NewServer(r, SSE).serveHTTPSSE(resumeRec, resumeReq)
+	NewServer(r, SSE).HTTPMux().ServeHTTP(resumeRec, resumeReq)
 
 	if resumeRec.Code != http.StatusOK {
 		t.Fatalf("resume status = %d, want 200", resumeRec.Code)
@@ -289,7 +289,7 @@ func TestHandleResume_toolPermission_allowAndReject(t *testing.T) {
 			r := newTestRegistry(store, strategy, []*tacklr.Tool{sensitive})
 
 			promptRec := httptest.NewRecorder()
-			NewServer(r, SSE).serveHTTPSSE(promptRec, newSSERequest(t, "/", bytes.NewReader([]byte(`{"agent_id":"default","prompt":"start"}`))))
+			NewServer(r, SSE).HTTPMux().ServeHTTP(promptRec, newSSERequest(t, "/", bytes.NewReader([]byte(`{"agent_id":"default","prompt":"start"}`))))
 
 			events := parseSSEEvents(t, promptRec.Body)
 			var threadID, interruptID string
@@ -316,7 +316,7 @@ func TestHandleResume_toolPermission_allowAndReject(t *testing.T) {
 
 			resumeBody := fmt.Sprintf(`{"agent_id":"default","thread_id":%q,"responses":{%q:{"optionId":%q}}}`, threadID, interruptID, tc.optionID)
 			resumeRec := httptest.NewRecorder()
-			NewServer(r, SSE).serveHTTPSSE(resumeRec, newSSERequest(t, "/resume", bytes.NewReader([]byte(resumeBody))))
+			NewServer(r, SSE).HTTPMux().ServeHTTP(resumeRec, newSSERequest(t, "/resume", bytes.NewReader([]byte(resumeBody))))
 			if resumeRec.Code != http.StatusOK {
 				t.Fatalf("resume status = %d", resumeRec.Code)
 			}
@@ -360,7 +360,7 @@ func TestHandleResume_unknownThread_returnsError(t *testing.T) {
 	body := bytes.NewReader([]byte(`{"agent_id":"default","thread_id":"nonexistent","responses":{"x":{}}}`))
 	req := newSSERequest(t, "/resume", body)
 	rec := httptest.NewRecorder()
-	NewServer(r, SSE).serveHTTPSSE(rec, req)
+	NewServer(r, SSE).HTTPMux().ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
@@ -399,7 +399,7 @@ func TestHandleResume_invalidPayload_returnsError(t *testing.T) {
 
 	// Raise an interrupt first
 	promptRec := httptest.NewRecorder()
-	NewServer(r, SSE).serveHTTPSSE(promptRec, newSSERequest(t, "/", bytes.NewReader([]byte(`{"agent_id":"default","prompt":"start"}`))))
+	NewServer(r, SSE).HTTPMux().ServeHTTP(promptRec, newSSERequest(t, "/", bytes.NewReader([]byte(`{"agent_id":"default","prompt":"start"}`))))
 
 	events := parseSSEEvents(t, promptRec.Body)
 	var threadID, interruptID string
@@ -422,7 +422,7 @@ func TestHandleResume_invalidPayload_returnsError(t *testing.T) {
 	// Resume with out-of-bounds selectionIdx
 	resumeBody := fmt.Sprintf(`{"agent_id":"default","thread_id":%q,"responses":{%q:{"interruptId":%q,"selectionIdx":99}}}`, threadID, interruptID, interruptID)
 	resumeRec := httptest.NewRecorder()
-	NewServer(r, SSE).serveHTTPSSE(resumeRec, newSSERequest(t, "/resume", bytes.NewReader([]byte(resumeBody))))
+	NewServer(r, SSE).HTTPMux().ServeHTTP(resumeRec, newSSERequest(t, "/resume", bytes.NewReader([]byte(resumeBody))))
 
 	resumeEvents := parseSSEEvents(t, resumeRec.Body)
 	var foundError bool

--- a/server/testutil_test.go
+++ b/server/testutil_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"net/http"
 	"sync/atomic"
 	"testing"
 
@@ -52,6 +53,10 @@ func mustAgent(t *testing.T, opts tacklr.AgentOptions) *tacklr.AgentHarness {
 		t.Fatal(err)
 	}
 	return h
+}
+
+func serveSSEHTTP(s *Server, w http.ResponseWriter, req *http.Request) {
+	s.HTTPMux().ServeHTTP(w, req)
 }
 
 func testStore(t *testing.T) *stores.InMemoryStore {

--- a/server/transport.go
+++ b/server/transport.go
@@ -82,7 +82,6 @@ func (s *Server) ServeStdio(ctx context.Context, in io.Reader, out io.Writer) er
 			reqConn := &Conn{
 				Writer: w,
 				RPC:    bridge,
-				Caps:   bridge.GetCaps(),
 			}
 			reqEnv := ProtocolEnv{Registry: s.Registry, Conn: reqConn}
 			if err := proto.HandleInbound(ctx, reqEnv, body); err != nil {
@@ -191,61 +190,8 @@ func waitHTTPServer(ctx context.Context, shutdown func(context.Context) error, e
 // Used by tests and unary HTTP adapters.
 func (s *Server) HandleMessage(ctx context.Context, body []byte, w MessageWriter) {
 	conn := &Conn{Writer: w, RPC: s.Client}
-	if s.Client != nil {
-		conn.Caps = s.Client.GetCaps()
-		conn.RPC = s.Client
-	}
 	env := ProtocolEnv{Registry: s.Registry, Conn: conn}
 	if err := s.Protocols[0].HandleInbound(ctx, env, body); err != nil {
 		slog.Debug("HandleMessage", "error", err)
 	}
-}
-
-// serveHTTPRPC is a test/helper entry for ACP unary HTTP (POST /).
-func (s *Server) serveHTTPRPC(w http.ResponseWriter, req *http.Request) {
-	env := ProtocolEnv{Registry: s.Registry, Conn: &Conn{}}
-	for _, p := range s.Protocols {
-		if p.Name() == "acp" {
-			for _, route := range p.HTTPRoutes() {
-				if route.Method == http.MethodPost && route.Pattern == "/" {
-					route.Handler(env, w, req)
-					return
-				}
-			}
-		}
-	}
-	http.Error(w, "acp protocol not registered", http.StatusInternalServerError)
-}
-
-// serveHTTPSSE is a test/helper entry for SSE POST handlers.
-func (s *Server) serveHTTPSSE(w http.ResponseWriter, req *http.Request) {
-	env := ProtocolEnv{Registry: s.Registry, Conn: &Conn{}}
-	path := req.URL.Path
-	if path == "" {
-		path = "/"
-	}
-	for _, p := range s.Protocols {
-		if p.Name() != "sse" {
-			continue
-		}
-		for _, route := range p.HTTPRoutes() {
-			if route.Method == http.MethodPost && route.Pattern == path {
-				route.Handler(env, w, req)
-				return
-			}
-		}
-	}
-	// Fallback: try POST /
-	for _, p := range s.Protocols {
-		if p.Name() != "sse" {
-			continue
-		}
-		for _, route := range p.HTTPRoutes() {
-			if route.Method == http.MethodPost && route.Pattern == "/" {
-				route.Handler(env, w, req)
-				return
-			}
-		}
-	}
-	http.Error(w, "sse protocol not registered", http.StatusInternalServerError)
 }

--- a/server/transport.go
+++ b/server/transport.go
@@ -75,10 +75,9 @@ func (s *Server) ServeStdio(ctx context.Context, in io.Reader, out io.Writer) er
 	var wg sync.WaitGroup
 	// Each inbound line gets its own Conn so concurrent handlers do not race on
 	// Caps. Capabilities are loaded from / stored on the bridge under its mutex.
+	// initialize runs synchronously so later methods on the same input see it.
 	dispatch := func(body []byte) {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		run := func() {
 			reqConn := &Conn{
 				Writer: w,
 				RPC:    bridge,
@@ -87,10 +86,19 @@ func (s *Server) ServeStdio(ctx context.Context, in io.Reader, out io.Writer) er
 			if err := proto.HandleInbound(ctx, reqEnv, body); err != nil {
 				slog.Debug("inbound handler", "error", err, "protocol", proto.Name())
 			}
+		}
+		if peek, err := peekJSONRPC(body); err == nil && peek.Method == "initialize" {
+			run()
+			return
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			run()
 		}()
 	}
 
-	return runStdioLoop(ctx, readCh, bridge, dispatch, &wg)
+	return runStdioLoop(ctx, readCh, bridge, dispatch, &wg, bridge.Close)
 }
 
 // runStdioLoop is the ServeStdio select loop. Extracted so the readCh-closed
@@ -101,14 +109,20 @@ func runStdioLoop(
 	bridge *ClientBridge,
 	dispatch func([]byte),
 	wg *sync.WaitGroup,
+	onClose context.CancelFunc,
 ) error {
+	if onClose == nil {
+		onClose = func() {}
+	}
 	for {
 		select {
 		case <-ctx.Done():
+			onClose()
 			return ctx.Err()
 		case rr, ok := <-readCh:
 			if !ok {
 				// Reader exited without a final result (typically parent cancel).
+				onClose()
 				return ctx.Err()
 			}
 			if rr.err != nil {
@@ -118,9 +132,11 @@ func runStdioLoop(
 							dispatch(trimmed)
 						}
 					}
+					onClose()
 					wg.Wait()
 					return nil
 				}
+				onClose()
 				return fmt.Errorf("stdio read: %w", rr.err)
 			}
 			line := bytes.TrimRight(rr.line, "\n\r")

--- a/server/transport_test.go
+++ b/server/transport_test.go
@@ -27,16 +27,12 @@ func TestServeHTTP_listenCancelAndMountedHandlers(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := newSSERequest(t, "/", bytes.NewReader([]byte(`{"agent_id":"default","prompt":"hi"}`)))
-	srvSSE.serveHTTPSSE(rec, req)
+	serveSSEHTTP(srvSSE, rec, req)
 	if rec.Code != 200 || !strings.Contains(rec.Body.String(), "http-ok") {
 		t.Fatalf("sse: %d %s", rec.Code, rec.Body.String())
 	}
 
-	rec2 := httptest.NewRecorder()
-	req2 := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(
-		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}`,
-	)))
-	srvACP.serveHTTPRPC(rec2, req2)
+	rec2 := serveACPInbound(t, r, srvACP.Protocols[0], `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}`)
 	if rec2.Code != 200 || !strings.Contains(rec2.Body.String(), "protocolVersion") {
 		t.Fatalf("acp: %d %s", rec2.Code, rec2.Body.String())
 	}
@@ -60,18 +56,18 @@ func TestServeHTTP_listenCancelAndMountedHandlers(t *testing.T) {
 	_ = NewServer(r, SSE).ServeHTTP
 }
 
-func TestServeHelpers_protocolNotRegisteredAndFallback(t *testing.T) {
+func TestHTTPMux_unregisteredProtocolPaths(t *testing.T) {
 	r := newTestRegistry(testStore(t), &mockInferenceStrategy{}, nil)
 	acpOnly := NewServer(r, ACP)
 	rec := httptest.NewRecorder()
-	acpOnly.serveHTTPSSE(rec, httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(`{}`))))
-	if rec.Code != http.StatusInternalServerError {
-		t.Fatalf("sse without protocol status = %d", rec.Code)
+	serveSSEHTTP(acpOnly, rec, httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(`{}`))))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("sse path on acp-only mux status = %d", rec.Code)
 	}
 	rec2 := httptest.NewRecorder()
-	NewServer(r, SSE).serveHTTPRPC(rec2, httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(`{}`))))
-	if rec2.Code != http.StatusInternalServerError {
-		t.Fatalf("acp without protocol status = %d", rec2.Code)
+	NewServer(r, SSE).HTTPMux().ServeHTTP(rec2, httptest.NewRequest(http.MethodPost, "/acp", bytes.NewReader([]byte(`{}`))))
+	if rec2.Code != http.StatusNotFound {
+		t.Fatalf("acp path on sse-only mux status = %d", rec2.Code)
 	}
 
 	strategy := &mockInferenceStrategy{
@@ -82,10 +78,9 @@ func TestServeHelpers_protocolNotRegisteredAndFallback(t *testing.T) {
 	srv := NewServer(newTestRegistry(testStore(t), strategy, nil), SSE)
 	rec3 := httptest.NewRecorder()
 	req := newSSERequest(t, "/", bytes.NewReader([]byte(`{"agent_id":"default","prompt":"x"}`)))
-	req.URL.Path = ""
-	srv.serveHTTPSSE(rec3, req)
+	serveSSEHTTP(srv, rec3, req)
 	if !strings.Contains(rec3.Body.String(), "fb") {
-		t.Fatalf("fallback body = %s", rec3.Body.String())
+		t.Fatalf("sse body = %s", rec3.Body.String())
 	}
 }
 
@@ -190,7 +185,7 @@ func TestHandleSSE_invalidAgentAndMissingAccept(t *testing.T) {
 	// Missing Accept → 406 (handleSSE early path).
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(`{"agent_id":"default","prompt":"x"}`)))
-	srv.serveHTTPSSE(rec, req)
+	serveSSEHTTP(srv, rec, req)
 	if rec.Code != http.StatusNotAcceptable {
 		t.Fatalf("status = %d", rec.Code)
 	}
@@ -198,7 +193,7 @@ func TestHandleSSE_invalidAgentAndMissingAccept(t *testing.T) {
 	// Valid Accept but unknown agent → SSE error event after headers.
 	rec2 := httptest.NewRecorder()
 	req2 := newSSERequest(t, "/", bytes.NewReader([]byte(`{"agent_id":"nope","prompt":"x"}`)))
-	srv.serveHTTPSSE(rec2, req2)
+	serveSSEHTTP(srv, rec2, req2)
 	if !strings.Contains(rec2.Body.String(), "error") && !strings.Contains(rec2.Body.String(), "not found") {
 		t.Fatalf("body = %s", rec2.Body.String())
 	}
@@ -213,14 +208,9 @@ func TestServeHTTP_listenError(t *testing.T) {
 	}
 }
 
-func TestACP_handleHTTP_invalidJSON(t *testing.T) {
+func TestACP_handleInbound_invalidJSON(t *testing.T) {
 	r := newTestRegistry(testStore(t), &mockInferenceStrategy{}, nil)
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(`{`)))
-	NewACPProtocol(nil).(*acpProtocol).handleHTTP(ProtocolEnv{Registry: r}, rec, req)
-	if !strings.Contains(rec.Body.String(), "error") && rec.Code == 0 {
-		// jsonRPC writer may not set status; body should still have error JSON
-	}
+	rec := serveACPRaw(t, r, `{`)
 	if rec.Body.Len() == 0 {
 		t.Fatal("expected error body")
 	}

--- a/server/wire_outcomes_test.go
+++ b/server/wire_outcomes_test.go
@@ -93,7 +93,7 @@ func TestWireAndConstruct_outcomes(t *testing.T) {
 	if _, err := SSE.LoadSession(context.Background(), ProtocolEnv{}, "x", nil); !errors.Is(err, ErrWireSessionUnsupported) {
 		t.Fatalf("LoadSession: %v", err)
 	}
-	if _, err := SSE.BindTurn(context.Background(), ProtocolEnv{}, "x", nil); !errors.Is(err, ErrWireSessionUnsupported) {
+	if _, err := SSE.BindTurn(context.Background(), ProtocolEnv{}, "x", "", nil); !errors.Is(err, ErrWireSessionUnsupported) {
 		t.Fatalf("BindTurn: %v", err)
 	}
 	if err := SSE.CloseSession(context.Background(), ProtocolEnv{}, "x"); !errors.Is(err, ErrWireSessionUnsupported) {
@@ -143,8 +143,13 @@ func TestWireAndConstruct_outcomes(t *testing.T) {
 	if connElicitationForm(nil) {
 		t.Fatal("nil conn elicitation")
 	}
-	if connElicitationForm(&Conn{Caps: ClientCapabilities{ElicitationForm: true}}) != true {
-		t.Fatal("snapshot caps")
+	if connElicitationForm(&Conn{}) {
+		t.Fatal("no rpc means no elicitation")
+	}
+	live := NewClientBridge(&recordingWriter{})
+	live.SetCaps(ClientCapabilities{ElicitationForm: true})
+	if !connElicitationForm(&Conn{RPC: live}) {
+		t.Fatal("live bridge caps")
 	}
 
 	// --- Streamable HTTP protocol error matrix (one server, many outcomes) ---
@@ -449,7 +454,7 @@ func TestWireAndConstruct_outcomes(t *testing.T) {
 	if _, err := p2.LoadSession(context.Background(), env, "x", json.RawMessage(`{`)); err == nil {
 		t.Fatal("want invalid load params")
 	}
-	if _, err := p2.BindTurn(context.Background(), env, "", nil); err == nil {
+	if _, err := p2.BindTurn(context.Background(), env, "", "session/prompt", nil); err == nil {
 		t.Fatal("empty sessionId bind")
 	}
 	// persist failure on create
@@ -501,7 +506,7 @@ func TestWireAndConstruct_outcomes(t *testing.T) {
 		"sessionId": sidEmpty,
 		"prompt":    []map[string]any{{"type": "text", "text": "hi"}},
 	})
-	if _, err := pEmpty.BindTurn(context.Background(), ProtocolEnv{Registry: emptyReg}, sidEmpty, prompt); err == nil {
+	if _, err := pEmpty.BindTurn(context.Background(), ProtocolEnv{Registry: emptyReg}, sidEmpty, "session/prompt", prompt); err == nil {
 		t.Fatal("want no agent")
 	}
 	// empty text prompt
@@ -514,7 +519,7 @@ func TestWireAndConstruct_outcomes(t *testing.T) {
 		"sessionId": sidOk,
 		"prompt":    []map[string]any{{"type": "text", "text": ""}},
 	})
-	if _, err := pOk.BindTurn(context.Background(), env, sidOk, badPrompt); err == nil {
+	if _, err := pOk.BindTurn(context.Background(), env, sidOk, "session/prompt", badPrompt); err == nil {
 		t.Fatal("want invalid prompt")
 	}
 	// cwd mismatch on bind
@@ -523,7 +528,7 @@ func TestWireAndConstruct_outcomes(t *testing.T) {
 		"cwd":       "/other",
 		"prompt":    []map[string]any{{"type": "text", "text": "hi"}},
 	})
-	if _, err := pOk.BindTurn(context.Background(), env, sidOk, cwdPrompt); err == nil {
+	if _, err := pOk.BindTurn(context.Background(), env, sidOk, "session/prompt", cwdPrompt); err == nil {
 		t.Fatal("want cwd mismatch")
 	}
 	// Load cwd mismatch + empty configValues envelope path

--- a/server/wire_outcomes_test.go
+++ b/server/wire_outcomes_test.go
@@ -146,9 +146,9 @@ func TestWireAndConstruct_outcomes(t *testing.T) {
 	if connElicitationForm(&Conn{}) {
 		t.Fatal("no rpc means no elicitation")
 	}
-	live := NewClientBridge(&recordingWriter{})
-	live.SetCaps(ClientCapabilities{ElicitationForm: true})
-	if !connElicitationForm(&Conn{RPC: live}) {
+	formBridge := NewClientBridge(&recordingWriter{})
+	formBridge.SetCaps(ClientCapabilities{ElicitationForm: true})
+	if !connElicitationForm(&Conn{RPC: formBridge}) {
 		t.Fatal("live bridge caps")
 	}
 
@@ -365,7 +365,7 @@ func TestWireAndConstruct_outcomes(t *testing.T) {
 		t.Fatalf("deliver closed: %v", err)
 	}
 
-	// Live connection: attach session, deliver with fallback, double session conflict
+	// Live connection: attach session, default drop when session SSE is late
 	live := NewConnectionRegistry().Create(NewClientBridge(&httpBufferWriter{}), &httpBufferWriter{})
 	recW := httptest.NewRecorder()
 	detach, sink, err := live.attachConnSSE(recW, recW)
@@ -375,10 +375,30 @@ func TestWireAndConstruct_outcomes(t *testing.T) {
 	if err := sink.writeOpen(); err != nil {
 		t.Fatal(err)
 	}
-	// deliver session-scoped with no session sink → falls back to conn sink
 	if err := live.deliver("sess-x", []byte(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess-x"}}`), false); err != nil {
 		t.Fatal(err)
 	}
+	if strings.Contains(recW.Body.String(), "sess-x") {
+		t.Fatal("default must not fall back to connection SSE")
+	}
+	fbReg := NewConnectionRegistry()
+	fbReg.LateSessionSSEFallback = true
+	fb := fbReg.Create(NewClientBridge(&httpBufferWriter{}), &httpBufferWriter{})
+	fbRec := httptest.NewRecorder()
+	fbDetach, fbSink, err := fb.attachConnSSE(fbRec, fbRec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fbSink.writeOpen(); err != nil {
+		t.Fatal(err)
+	}
+	if err := fb.deliver("sess-x", []byte(`{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"sess-x"}}`), false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(fbRec.Body.String(), "sess-x") {
+		t.Fatal("opt-in fallback should deliver on connection SSE")
+	}
+	fbDetach()
 	// extractSessionID helpers
 	if extractSessionIDFromJSONRPC([]byte(`not-json`)) != "" {
 		t.Fatal("bad json extract")

--- a/server/ws_test.go
+++ b/server/ws_test.go
@@ -26,7 +26,7 @@ func TestWebSocket_promptStreamsMessageAndComplete(t *testing.T) {
 	mux := http.NewServeMux()
 	env := ProtocolEnv{Registry: r, Conn: &Conn{}}
 	for _, route := range SSE.HTTPRoutes() {
-		if route.Method == http.MethodGet && route.Pattern == "/" {
+		if route.Method == http.MethodGet && route.Pattern == "/{$}" {
 			mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
 				route.Handler(env, w, req)
 			})
@@ -100,7 +100,7 @@ func TestWebSocket_invalidRequestAndTurnError(t *testing.T) {
 	mux := http.NewServeMux()
 	env := ProtocolEnv{Registry: r, Conn: &Conn{}}
 	for _, route := range SSE.HTTPRoutes() {
-		if route.Method == http.MethodGet && route.Pattern == "/" {
+		if route.Method == http.MethodGet && route.Pattern == "/{$}" {
 			mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
 				route.Handler(env, w, req)
 			})

--- a/stores/inmemory_test.go
+++ b/stores/inmemory_test.go
@@ -21,7 +21,6 @@ func TestInMemoryStore_saveLoadRoundTrip(t *testing.T) {
 		map[string]PendingToolCall{
 			"call_1": {ToolCall: &streaming.ToolCall{ID: "call_1", Name: "greet"}, InterruptActive: true},
 		},
-		map[string]string{"intr-1": "call_1"},
 		map[string]any{"plan": []any{map[string]any{"title": "Ship", "status": "completed"}}},
 		map[string]any{"pending": true},
 		map[string]any{"resolved": "x"},
@@ -48,9 +47,6 @@ func TestInMemoryStore_saveLoadRoundTrip(t *testing.T) {
 	if !ok || ptc.ToolCall == nil || ptc.ToolCall.Name != "greet" || !ptc.InterruptActive {
 		t.Errorf("pending tool calls = %+v", loaded.State.PendingToolCalls)
 	}
-	if loaded.State.InterruptToRequester["intr-1"] != "call_1" {
-		t.Errorf("interrupt map = %+v", loaded.State.InterruptToRequester)
-	}
 	if loaded.State.RuntimeState["plan"] == nil {
 		t.Errorf("runtime state missing plan: %+v", loaded.State.RuntimeState)
 	}
@@ -72,11 +68,11 @@ func TestInMemoryStore_saveOverwritesSession(t *testing.T) {
 	store := NewInMemoryStore()
 	ctx := context.Background()
 
-	first, err := NewCheckpoint([]*streaming.Message{{Role: streaming.RoleUser, Content: "v1"}}, nil, nil, nil, nil, nil)
+	first, err := NewCheckpoint([]*streaming.Message{{Role: streaming.RoleUser, Content: "v1"}}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, err := NewCheckpoint([]*streaming.Message{{Role: streaming.RoleUser, Content: "v2"}}, nil, nil, nil, nil, nil)
+	second, err := NewCheckpoint([]*streaming.Message{{Role: streaming.RoleUser, Content: "v2"}}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +92,7 @@ func TestInMemoryStore_saveOverwritesSession(t *testing.T) {
 }
 
 func TestNewCheckpoint_nilInterruptBlobsAndMarshalError(t *testing.T) {
-	cp, err := NewCheckpoint(nil, nil, nil, map[string]any{"k": 1}, nil, nil)
+	cp, err := NewCheckpoint(nil, nil, map[string]any{"k": 1}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,10 +101,10 @@ func TestNewCheckpoint_nilInterruptBlobsAndMarshalError(t *testing.T) {
 			cp.State.PendingInterrupts, cp.State.ResolvedInterrupts)
 	}
 	// json.Marshal of a channel fails — exercise error return path.
-	if _, err := NewCheckpoint(nil, nil, nil, nil, make(chan int), nil); err == nil {
+	if _, err := NewCheckpoint(nil, nil, nil, make(chan int), nil); err == nil {
 		t.Fatal("expected marshal error for pending interrupts")
 	}
-	if _, err := NewCheckpoint(nil, nil, nil, nil, nil, make(chan int)); err == nil {
+	if _, err := NewCheckpoint(nil, nil, nil, nil, make(chan int)); err == nil {
 		t.Fatal("expected marshal error for resolved interrupts")
 	}
 }
@@ -123,7 +119,7 @@ func TestInMemoryStore_concurrentSaveLoad(t *testing.T) {
 			defer wg.Done()
 			cp, err := NewCheckpoint([]*streaming.Message{
 				{Role: streaming.RoleUser, Content: "n"},
-			}, nil, nil, map[string]any{"i": i}, nil, nil)
+			}, nil, map[string]any{"i": i}, nil, nil)
 			if err != nil {
 				t.Errorf("checkpoint: %v", err)
 				return

--- a/stores/postgres_integration_test.go
+++ b/stores/postgres_integration_test.go
@@ -41,7 +41,6 @@ func TestPostgresStore_liveSaveLoad(t *testing.T) {
 		map[string]PendingToolCall{
 			"c1": {ToolCall: &streaming.ToolCall{ID: "c1", Name: "search"}, InterruptActive: false},
 		},
-		map[string]string{"i1": "c1"},
 		map[string]any{"k": "v"},
 		map[string]any{"p": 1},
 		map[string]any{"r": 2},
@@ -70,7 +69,7 @@ func TestPostgresStore_liveSaveLoad(t *testing.T) {
 	// Overwrite
 	cp2, err := NewCheckpoint(
 		[]*streaming.Message{{Role: streaming.RoleUser, Content: "v2"}},
-		nil, nil, map[string]any{"n": float64(1)}, nil, nil,
+		nil, map[string]any{"n": float64(1)}, nil, nil,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/stores/stores.go
+++ b/stores/stores.go
@@ -16,11 +16,13 @@ type PendingToolCall struct {
 
 // sessionState is harness-owned durable agent state (not wire-protocol envelopes).
 type sessionState struct {
-	PendingToolCalls     map[string]PendingToolCall `json:"pendingToolCalls"`
-	InterruptToRequester map[string]string          `json:"interruptToRequester"`
-	RuntimeState         map[string]any             `json:"runtimeState"`
-	PendingInterrupts    []byte                     `json:"pendingInterrupts,omitempty"`
-	ResolvedInterrupts   []byte                     `json:"resolvedInterrupts,omitempty"`
+	PendingToolCalls map[string]PendingToolCall `json:"pendingToolCalls"`
+	// InterruptToRequester is read-only legacy (old checkpoints keyed wire
+	// interrupt ids separately from tool call ids). New saves omit it.
+	InterruptToRequester map[string]string `json:"interruptToRequester,omitempty"`
+	RuntimeState         map[string]any    `json:"runtimeState"`
+	PendingInterrupts    []byte            `json:"pendingInterrupts,omitempty"`
+	ResolvedInterrupts   []byte            `json:"resolvedInterrupts,omitempty"`
 	// SearchContext is an opaque brain.SearchContext export (JSON bytes).
 	// Owned by the harness, not SessionManager.
 	SearchContext []byte `json:"searchContext,omitempty"`
@@ -34,7 +36,7 @@ type SessionCheckpoint struct {
 	State         sessionState         `json:"state"`
 }
 
-func NewCheckpoint(contextWindow []*streaming.Message, pendingToolCalls map[string]PendingToolCall, interruptToRequester map[string]string, runtimeState map[string]any, pendingInterrupts, resolvedInterrupts any) (*SessionCheckpoint, error) {
+func NewCheckpoint(contextWindow []*streaming.Message, pendingToolCalls map[string]PendingToolCall, runtimeState map[string]any, pendingInterrupts, resolvedInterrupts any) (*SessionCheckpoint, error) {
 	var pendingJSON, resolvedJSON []byte
 	var err error
 
@@ -54,11 +56,10 @@ func NewCheckpoint(contextWindow []*streaming.Message, pendingToolCalls map[stri
 	return &SessionCheckpoint{
 		ContextWindow: contextWindow,
 		State: sessionState{
-			PendingToolCalls:     pendingToolCalls,
-			InterruptToRequester: interruptToRequester,
-			RuntimeState:         runtimeState,
-			PendingInterrupts:    pendingJSON,
-			ResolvedInterrupts:   resolvedJSON,
+			PendingToolCalls:   pendingToolCalls,
+			RuntimeState:       runtimeState,
+			PendingInterrupts:  pendingJSON,
+			ResolvedInterrupts: resolvedJSON,
 		},
 	}, nil
 }

--- a/subagents.go
+++ b/subagents.go
@@ -347,11 +347,14 @@ func (a *AgentHarness) childResolutionPayloads(parentToolCallID string, meta *pa
 func collectChildInterrupts(worker *AgentHarness, drainedIDs []string) (ids []string, primary interrupt.Interrupt) {
 	ids = drainedIDs
 	for _, id := range ids {
-		tcID, ok := worker.interruptToRequester[id]
-		if !ok {
-			continue
+		tcID := id
+		if mapped, ok := worker.legacyInterruptIDs[id]; ok {
+			tcID = mapped
 		}
 		if intr, ok := worker.session.PendingInterrupt(tcID); ok {
+			return ids, intr
+		}
+		if intr, ok := worker.session.PendingInterrupt(id); ok {
 			return ids, intr
 		}
 	}

--- a/tacklr_test.go
+++ b/tacklr_test.go
@@ -533,8 +533,8 @@ func TestAgentHarness_Run(t *testing.T) {
 		if !foundInterrupt {
 			t.Fatal("expected interrupt event")
 		}
-		if interruptId == "" {
-			t.Fatal("interruptId was not captured")
+		if interruptId != "call_int" {
+			t.Fatalf("interruptId = %q, want tool call id call_int", interruptId)
 		}
 		if callCount != 1 {
 			t.Errorf("callCount after first run = %d, want 1", callCount)

--- a/tools.go
+++ b/tools.go
@@ -213,10 +213,9 @@ func NewTool(cfg ToolConfig) *Tool {
 
 		if hasRuntime {
 			if runtime == nil {
-				callArgs = append(callArgs, reflect.Zero(harnessRuntimeType))
-			} else {
-				callArgs = append(callArgs, reflect.ValueOf(runtime))
+				return toolCallResult{}, fmt.Errorf("%w: tool %q requires a HarnessRuntime", ErrFailed, t.Name)
 			}
+			callArgs = append(callArgs, reflect.ValueOf(runtime))
 		}
 
 		results := handlerValue.Call(callArgs)
@@ -558,9 +557,10 @@ const (
 	EffectHandoff
 )
 
-// BuiltinResult is a tool success that can queue ACM window effects.
-// Output is the model-visible tool string. Plan tools use this type.
-type BuiltinResult struct {
+// ToolOutcome is the single post-tool result: model-visible output plus a
+// window effect. Plan builtins return this (as BuiltinResult). Host hooks
+// return the same type and leave Output empty.
+type ToolOutcome struct {
 	Output string
 	// Effect is merged for the batch and applied once at batch end.
 	Effect ToolResultEffect
@@ -568,6 +568,12 @@ type BuiltinResult struct {
 	// The client still receives StreamEventToolResult.
 	SuppressWindowMessage bool
 }
+
+// BuiltinResult is the tool-handler success type.
+type BuiltinResult = ToolOutcome
+
+// ToolResultDisposition is the window-effect view of ToolOutcome.
+type ToolResultDisposition = ToolOutcome
 
 // ToolResultObservation is a successful tool result seen by a ToolResultHook.
 type ToolResultObservation struct {
@@ -577,14 +583,8 @@ type ToolResultObservation struct {
 	Runtime  HarnessRuntime
 }
 
-// ToolResultDisposition is the window effect from a BuiltinResult or ToolResultHook.
-type ToolResultDisposition struct {
-	Effect                ToolResultEffect
-	SuppressWindowMessage bool
-}
-
 // ToolResultHook runs after a successful host tool and before the tool result is emitted.
-// Effects apply at batch end. Plan builtins use BuiltinResult instead.
+// Effects apply at batch end. Plan builtins return BuiltinResult instead.
 type ToolResultHook func(ctx context.Context, obs ToolResultObservation) ToolResultDisposition
 
 type toolResultHookRegistry struct {

--- a/tools_command.go
+++ b/tools_command.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -43,8 +44,15 @@ func newRunCommand(ms *vfs.MountSession, permissionRequired bool) *Tool {
 			}
 			rt.EmitUpdate("Running " + cmdStr)
 
-			cmd := exec.CommandContext(ctx, "/bin/sh", "-c", cmdStr)
-			cmd.Dir = dir
+			// Never set cmd.Dir to the FUSE HostDir. Go's fork/exec chdirs in
+			// the child before exec returns; that chdir is a FUSE request this
+			// same process must serve. If the parent is blocked on the exec
+			// pipe (coverage, GC stop-the-world), the FUSE server cannot run
+			// and the start deadlocks. cd after exec so the kernel only walks
+			// the mount once we are in Wait.
+			cmd := exec.CommandContext(ctx, "/bin/sh", "-c", "cd "+posixShQuote(dir)+" && "+cmdStr)
+			cmd.Dir = os.TempDir()
+			cmd.Stdin = bytes.NewReader(nil)
 			cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 			cmd.Cancel = func() error {
 				if cmd.Process == nil {
@@ -79,6 +87,11 @@ func newRunCommand(ms *vfs.MountSession, permissionRequired bool) *Tool {
 		cfg.OnCall = OnCalls(ToolPermissionOnCall)
 	}
 	return NewTool(cfg)
+}
+
+// posixShQuote wraps s in single quotes for /bin/sh -c.
+func posixShQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
 }
 
 func formatRunCommandResult(exit int, truncated bool, stdout, stderr *budgetWriter) string {

--- a/tools_command_test.go
+++ b/tools_command_test.go
@@ -3,6 +3,7 @@ package tacklr
 import (
 	"context"
 	"errors"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -37,7 +38,15 @@ func TestRunCommand_catDirtyAndFalseExit(t *testing.T) {
 	t.Cleanup(func() { _ = ms.Close() })
 
 	tool := newRunCommand(ms, false)
-	res, err := tool.invoke(ctx, `{"command":"cat work/note.md"}`, rt)
+	res, err := tool.invoke(ctx, `{"command":"pwd"}`, rt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(res.output, ms.HostDir()) {
+		t.Fatalf("pwd cwd: %s want %s", res.output, ms.HostDir())
+	}
+
+	res, err = tool.invoke(ctx, `{"command":"cat work/note.md"}`, rt)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,6 +130,22 @@ func TestRunCommand_truncatesOver1MiB(t *testing.T) {
 			head = head[:240]
 		}
 		t.Fatalf("truncate: %s", head)
+	}
+}
+
+func TestPosixShQuote_cdIntoQuotedPath(t *testing.T) {
+	dir := t.TempDir() + "/it's a dir"
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("/bin/sh", "-c", "cd "+posixShQuote(dir)+" && pwd")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.TrimSpace(string(out))
+	if got != dir {
+		t.Fatalf("pwd = %q want %q", got, dir)
 	}
 }
 

--- a/tools_test.go
+++ b/tools_test.go
@@ -99,6 +99,19 @@ func TestInvoke(t *testing.T) {
 		}
 	})
 
+	t.Run("handler that needs runtime fails closed without one", func(t *testing.T) {
+		tool := NewTool(ToolConfig{
+			Name: "needs_rt",
+			Handler: func(ctx context.Context, rt HarnessRuntime) (string, error) {
+				return "ok", nil
+			},
+		})
+		_, err := tool.invoke(context.Background(), "", nil)
+		if err == nil || !errors.Is(err, ErrFailed) {
+			t.Fatalf("nil runtime: %v", err)
+		}
+	})
+
 	t.Run("propagates handler error", func(t *testing.T) {
 		tool := NewTool(ToolConfig{Name: "err", Handler: errHandler})
 		_, err := tool.invoke(context.Background(), `{"name":"x","age":1}`, nil)

--- a/vfs/content.go
+++ b/vfs/content.go
@@ -128,9 +128,12 @@ func DefaultContentRegistry() *ContentRegistry {
 	return defaultContentRegistry
 }
 
-var defaultContentRegistry = mustDefaultContentRegistry()
+var defaultContentRegistry = mustDefaultContentRegistry(textMediaTypes)
 
-func mustDefaultContentRegistry() *ContentRegistry {
+func mustDefaultContentRegistry(types []string) *ContentRegistry {
+	if len(types) == 0 {
+		panic("vfs: text media types required before default registry init")
+	}
 	r := NewContentRegistry()
 	if err := r.Register(TextCodec{}); err != nil {
 		panic(err)

--- a/vfs/content.go
+++ b/vfs/content.go
@@ -29,30 +29,25 @@ type IdentityCodec interface {
 }
 
 // KernelWritable reports whether FUSE/host writes may persist raw bytes for
-// mediaType. True only when Decode would use an IdentityCodec (TextCodec, or
-// the unregistered text-like fallback). Projected documents stay EROFS.
+// mediaType. True only when a registered IdentityCodec owns the type.
+// Providers must set FileInfo.MediaType; unregistered types are EROFS.
 func KernelWritable(mediaType string) bool {
-	if i := strings.IndexByte(mediaType, ';'); i >= 0 {
-		mediaType = strings.TrimSpace(mediaType[:i])
-	}
+	mediaType = normalizeMediaType(mediaType)
 	if mediaType == "" || mediaType == "application/octet-stream" {
 		return false
 	}
 	c, ok := defaultContentRegistry.codec(mediaType)
 	if !ok {
-		return IsTextLike(mediaType)
+		return false
 	}
 	_, ok = c.(IdentityCodec)
 	return ok
 }
 
 // KernelWritableFile reports whether an existing file may take kernel writes.
+// Empty MediaType is not writable — providers classify at Stat.
 func KernelWritableFile(st FileInfo) bool {
-	mt := st.MediaType
-	if mt == "" {
-		mt = DetectMediaType(st.Name, nil)
-	}
-	return KernelWritable(mt)
+	return KernelWritable(st.MediaType)
 }
 
 // KernelCreateOK reports whether a new name may be created via FUSE.
@@ -100,10 +95,18 @@ func (r *ContentRegistry) Register(c Codec) error {
 	return nil
 }
 
+func normalizeMediaType(mediaType string) string {
+	if i := strings.IndexByte(mediaType, ';'); i >= 0 {
+		mediaType = mediaType[:i]
+	}
+	return strings.ToLower(strings.TrimSpace(mediaType))
+}
+
 func (r *ContentRegistry) codec(mediaType string) (Codec, bool) {
 	if r == nil {
 		return nil, false
 	}
+	mediaType = normalizeMediaType(mediaType)
 	r.mu.RLock()
 	c, ok := r.codecs[mediaType]
 	r.mu.RUnlock()
@@ -112,12 +115,10 @@ func (r *ContentRegistry) codec(mediaType string) (Codec, bool) {
 
 // Decode looks up a codec for mediaType and decodes data.
 func (r *ContentRegistry) Decode(ctx context.Context, path, mediaType string, data []byte) (Document, error) {
+	mediaType = normalizeMediaType(mediaType)
 	c, ok := r.codec(mediaType)
 	if !ok {
-		if !IsTextLike(mediaType) {
-			return nil, ErrNoCodec
-		}
-		c = TextCodec{}
+		return nil, ErrNoCodec
 	}
 	return c.Decode(ctx, path, mediaType, data)
 }
@@ -127,11 +128,15 @@ func DefaultContentRegistry() *ContentRegistry {
 	return defaultContentRegistry
 }
 
-var defaultContentRegistry = func() *ContentRegistry {
+var defaultContentRegistry = mustDefaultContentRegistry()
+
+func mustDefaultContentRegistry() *ContentRegistry {
 	r := NewContentRegistry()
-	_ = r.Register(TextCodec{})
+	if err := r.Register(TextCodec{}); err != nil {
+		panic(err)
+	}
 	return r
-}()
+}
 
 // DetectMediaType is a helper for providers filling FileInfo.MediaType.
 // OpenDocument does not call this — it trusts the provider.
@@ -201,19 +206,22 @@ func IsTextLike(mediaType string) bool {
 	}
 }
 
-// textMediaTypes is the unique set of extension-map media types for TextCodec registration.
-var textMediaTypes []string
+// textMediaTypes is the unique set of extension-map media types for TextCodec
+// registration. Computed as a package var (not init) so DefaultContentRegistry
+// can register TextCodec during variable initialization.
+var textMediaTypes = uniqueMediaTypes(extMediaTypes)
 
-func init() {
-	seen := make(map[string]struct{}, len(extMediaTypes))
-	textMediaTypes = make([]string, 0, len(extMediaTypes))
-	for _, mt := range extMediaTypes {
+func uniqueMediaTypes(m map[string]string) []string {
+	seen := make(map[string]struct{}, len(m))
+	out := make([]string, 0, len(m))
+	for _, mt := range m {
 		if _, ok := seen[mt]; ok {
 			continue
 		}
 		seen[mt] = struct{}{}
-		textMediaTypes = append(textMediaTypes, mt)
+		out = append(out, mt)
 	}
+	return out
 }
 
 func errFileExceeds(limit int) error {

--- a/vfs/document_session.go
+++ b/vfs/document_session.go
@@ -38,14 +38,9 @@ func decodeProviderDocument(ctx context.Context, name string, fi FileInfo, data 
 	if reg == nil {
 		reg = DefaultContentRegistry()
 	}
-	mt := fi.MediaType
+	mt := normalizeMediaType(fi.MediaType)
 	if mt == "" {
-		mt = "application/octet-stream"
-	}
-	if !IsTextLike(mt) {
-		if _, ok := reg.codec(mt); !ok {
-			return nil, ErrNoCodec
-		}
+		return nil, ErrNoCodec
 	}
 	return reg.Decode(ctx, name, mt, data)
 }

--- a/vfs/text.go
+++ b/vfs/text.go
@@ -14,7 +14,6 @@ type TextCodec struct{}
 func (TextCodec) Identity() {}
 
 // MediaTypes is the set of extension-map types this codec claims at registration.
-// Unregistered text-like types still fall back to TextCodec in ContentRegistry.Decode.
 func (TextCodec) MediaTypes() []string {
 	return textMediaTypes
 }

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -649,9 +649,9 @@ func TestMountSession_configErrors(t *testing.T) {
 	if err := creg.Register(blankTypeCodec{}); err == nil {
 		t.Fatal("blank media type")
 	}
-	// text-like fallback on empty registry
-	if _, err := creg.Decode(ctx, "/x.json", "application/json", []byte(`{}`)); err != nil {
-		t.Fatal(err)
+	// empty registry has no codec — Decode fails closed
+	if _, err := creg.Decode(ctx, "/x.json", "application/json", []byte(`{}`)); !errors.Is(err, vfs.ErrNoCodec) {
+		t.Fatalf("empty registry decode: %v", err)
 	}
 	// canceled decode
 	cctx, cancel := context.WithCancel(ctx)
@@ -706,6 +706,16 @@ func TestKernelWritable(t *testing.T) {
 	}
 	if vfs.KernelWritableFile(vfs.FileInfo{Name: "pic.png", MediaType: "image/png"}) {
 		t.Fatal("KernelWritableFile png")
+	}
+	if vfs.KernelWritableFile(vfs.FileInfo{Name: "a.go"}) {
+		t.Fatal("KernelWritableFile empty media type")
+	}
+	doc, err := vfs.DefaultContentRegistry().Decode(context.Background(), "/x.go", "text/x-go; charset=utf-8", []byte("package x\n"))
+	if err != nil {
+		t.Fatalf("default registry must own extension-map types: %v", err)
+	}
+	if doc.MediaType() != "text/x-go" {
+		t.Fatalf("decoded media type %q", doc.MediaType())
 	}
 	if !vfs.KernelCreateOK("README") || !vfs.KernelCreateOK("note.txt") {
 		t.Fatal("KernelCreateOK plaintext")

--- a/web_test.go
+++ b/web_test.go
@@ -69,22 +69,22 @@ func TestWebSearchTool_invokeAgainstServer(t *testing.T) {
 	if err != nil || !strings.Contains(res.output, "(untitled)") || !strings.Contains(res.output, `"answer"`) {
 		t.Fatalf("untitled/synth: %q err=%v", res.output, err)
 	}
-	if _, err := tool.invoke(ctx, `{"query":"  "}`, nil); err == nil || !strings.Contains(err.Error(), "query is required") {
+	if _, err := tool.invoke(ctx, `{"query":"  "}`, nopRuntime()); err == nil || !strings.Contains(err.Error(), "query is required") {
 		t.Fatalf("empty query: %v", err)
 	}
-	if _, err := tool.invoke(ctx, `{"query":"q","type":"nope"}`, nil); err == nil {
+	if _, err := tool.invoke(ctx, `{"query":"q","type":"nope"}`, nopRuntime()); err == nil {
 		t.Fatal("invalid type")
 	}
-	if _, err := tool.invoke(ctx, `{"query":"q","category":"nope"}`, nil); err == nil {
+	if _, err := tool.invoke(ctx, `{"query":"q","category":"nope"}`, nopRuntime()); err == nil {
 		t.Fatal("invalid category")
 	}
-	if _, err := tool.invoke(ctx, `{"query":"q","category":"company","exclude_domains":["x.com"]}`, nil); err == nil {
+	if _, err := tool.invoke(ctx, `{"query":"q","category":"company","exclude_domains":["x.com"]}`, nopRuntime()); err == nil {
 		t.Fatal("company exclude")
 	}
-	if _, err := tool.invoke(ctx, `{"query":"q","category":"people","start_published_date":"2024-01-01T00:00:00Z"}`, nil); err == nil {
+	if _, err := tool.invoke(ctx, `{"query":"q","category":"people","start_published_date":"2024-01-01T00:00:00Z"}`, nopRuntime()); err == nil {
 		t.Fatal("people dates")
 	}
-	if _, err := tool.invoke(ctx, `{"query":"q","content_mode":"raw"}`, nil); err == nil {
+	if _, err := tool.invoke(ctx, `{"query":"q","content_mode":"raw"}`, nopRuntime()); err == nil {
 		t.Fatal("invalid mode")
 	}
 	res, err = tool.invoke(ctx, `{"query":"q","type":"text","content_mode":"text","category":"news"}`, nopRuntime())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replace defensive fallbacks with explicit identities so the harness cannot silently drift.

### Interrupt identity + resume
- Wire `interruptId` to the tool-call id.
- `ReturnFromInterrupt` applies resolutions and calls `startTurn(ctx, nil)` (not `Run(ctx, "")`).
- Checkpoints no longer write `interruptToRequester`. Legacy ids stay read-only for old snapshots.

### Transactional tool turns
- Assistant `tool_calls` enter the window only after the model stream completes.
- Restored dirty windows pair open function calls with error tool results instead of stripping them.

### ACP state machine
- `session/prompt` waits for `initialize`.
- Interrupt envelope requires `type`.
- Cancel uses `errors.Is` only.
- Empty streamable initialize buffer is HTTP 500.
- Unary `POST /` removed; SSE routes are exact `/{$}` so they do not swallow `/acp`.
- Stdio `initialize` is synchronous; client-bridge `Close` unblocks `WaitInitialized` on EOF.

### VFS media type as provider invariant
- `ContentRegistry.Decode` and `KernelWritable` fail closed (`ErrNoCodec` if no codec).
- Empty media type is not writable and is rejected on provider decode.
- Default registry registers `TextCodec` after `textMediaTypes` is a real init dependency (the old fallback hid a zero-type registry).

### Other
- `CountTokens` local tiktoken fallback is opt-in (`WithLocalTokenFallback()`).
- Tool invoke fails closed if the handler needs `HarnessRuntime` and runtime is nil.

### CI fix
`Build, Test & Coverage` hung for 11 minutes in `TestRunCommand_truncatesOver1MiB`. `run_command` set `cmd.Dir` to the FUSE `HostDir()`, so `fork/exec` `chdir` waited for this same process to serve FUSE before exec returned. Under `-covermode=atomic` / GC stop-the-world that deadlocks.

`cmd.Dir` is now a real host path; the shell `cd`s into the FUSE root after exec. Commands still see the VFS projection.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00cd0-3d37-7b45-84e8-a8859d2a8707?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00cd0-3d37-7b45-84e8-a8859d2a8707&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

