### PR TITLE
fix: pass run_command cwd as argv to satisfy gosec G204

### DIFF
--- a/server/client_rpc.go
+++ b/server/client_rpc.go
@@ -90,6 +90,8 @@ func (b *ClientBridge) Close() {
 }
 
 // WaitInitialized blocks until initialize has run, the connection closes, or ctx is done.
+// If initialize already completed, that wins even when closed/ctx are also ready
+// (stdio EOF closes the bridge while in-flight prompt handlers still wait).
 func (b *ClientBridge) WaitInitialized(ctx context.Context) error {
 	if b == nil {
 		return nil
@@ -98,9 +100,19 @@ func (b *ClientBridge) WaitInitialized(ctx context.Context) error {
 	case <-b.initialized:
 		return nil
 	case <-b.closed:
-		return errConnectionNotInitialized
+		select {
+		case <-b.initialized:
+			return nil
+		default:
+			return errConnectionNotInitialized
+		}
 	case <-ctx.Done():
-		return ctx.Err()
+		select {
+		case <-b.initialized:
+			return nil
+		default:
+			return ctx.Err()
+		}
 	}
 }
 

--- a/server/client_rpc_test.go
+++ b/server/client_rpc_test.go
@@ -191,6 +191,15 @@ func TestClientBridge_WaitInitialized(t *testing.T) {
 	if err := b.WaitInitialized(context.Background()); err != nil {
 		t.Fatalf("after initialize: %v", err)
 	}
+	b.Close()
+	if err := b.WaitInitialized(context.Background()); err != nil {
+		t.Fatalf("initialized then closed: %v", err)
+	}
+	canceled, cancelInit := context.WithCancel(context.Background())
+	cancelInit()
+	if err := b.WaitInitialized(canceled); err != nil {
+		t.Fatalf("initialized with canceled ctx: %v", err)
+	}
 	closed := NewClientBridge(&recordingWriter{})
 	closed.Close()
 	if err := closed.WaitInitialized(context.Background()); !errors.Is(err, errConnectionNotInitialized) {

--- a/tools_command.go
+++ b/tools_command.go
@@ -50,7 +50,10 @@ func newRunCommand(ms *vfs.MountSession, permissionRequired bool) *Tool {
 			// pipe (coverage, GC stop-the-world), the FUSE server cannot run
 			// and the start deadlocks. cd after exec so the kernel only walks
 			// the mount once we are in Wait.
-			cmd := exec.CommandContext(ctx, "/bin/sh", "-c", "cd "+posixShQuote(dir)+" && "+cmdStr)
+			//
+			// dir and cmdStr are argv ($1, $2), not concatenated into -c, so
+			// HostDir metacharacters cannot break cd and gosec G204 stays quiet.
+			cmd := exec.CommandContext(ctx, "/bin/sh", "-c", `cd "$1" && eval "$2"`, "run_command", dir, cmdStr)
 			cmd.Dir = os.TempDir()
 			cmd.Stdin = bytes.NewReader(nil)
 			cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
@@ -87,11 +90,6 @@ func newRunCommand(ms *vfs.MountSession, permissionRequired bool) *Tool {
 		cfg.OnCall = OnCalls(ToolPermissionOnCall)
 	}
 	return NewTool(cfg)
-}
-
-// posixShQuote wraps s in single quotes for /bin/sh -c.
-func posixShQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
 }
 
 func formatRunCommandResult(exit int, truncated bool, stdout, stderr *budgetWriter) string {

--- a/tools_command_test.go
+++ b/tools_command_test.go
@@ -133,12 +133,12 @@ func TestRunCommand_truncatesOver1MiB(t *testing.T) {
 	}
 }
 
-func TestPosixShQuote_cdIntoQuotedPath(t *testing.T) {
+func TestRunCommand_cdIntoQuotedPath(t *testing.T) {
 	dir := t.TempDir() + "/it's a dir"
 	if err := os.Mkdir(dir, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	cmd := exec.Command("/bin/sh", "-c", "cd "+posixShQuote(dir)+" && pwd")
+	cmd := exec.Command("/bin/sh", "-c", `cd "$1" && pwd`, "run_command", dir)
 	out, err := cmd.Output()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#79 squash-merged the FUSE deadlock fix but not the G204 follow-up. CI Lint on `main` fails because `run_command` concatenates `HostDir` into `sh -c`.

The `-c` script is a constant (`cd "$1" && eval "$2"`). The FUSE root and command are separate argv, so `cd` stays safe and G204 is quiet.

Also fixes a stdio flake from #79: `ServeStdio` closes the client bridge on EOF while prompt handlers still call `WaitInitialized`. When initialize already ran, both channels are ready and `select` could return `connection closed before initialize`. Initialized now wins.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00cd0-3d37-7b45-84e8-a8859d2a8707?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00cd0-3d37-7b45-84e8-a8859d2a8707&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

