### PR TITLE
refactor: collapse helpers, sentinels, and silent error handling

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -656,7 +656,13 @@ func (a *AgentHarness) Close() {
 		a.mcpCleanup = nil
 	}
 	if a.ownsVFSBridge && a.vfsBridge != nil {
-		_ = a.vfsBridge.Close()
+		if err := a.vfsBridge.Close(); err != nil {
+			slog.Error("vfsindex bridge close failed",
+				"area", telemetry.AreaHarness,
+				"session_id", a.sessionId,
+				"error", err,
+			)
+		}
 		a.vfsBridge = nil
 	}
 }

--- a/agent_construct_test.go
+++ b/agent_construct_test.go
@@ -145,7 +145,7 @@ func TestAgentHarness_checkpointFailureIsHostVisibleAndClearsAfterRecovery(t *te
 	h := mustNewAgent(t, AgentOptions{
 		SessionID: "checkpoint-health",
 		Model:     &mockStrategy{},
-		Store:     failSaveStore{InMemoryStore: stores.NewInMemoryStore()},
+		Store:     stores.FaultyStore{Inner: stores.NewInMemoryStore(), SaveErr: errors.New("checkpoint disk full")},
 	})
 
 	// Act

--- a/brain/engine.go
+++ b/brain/engine.go
@@ -86,7 +86,6 @@ func (c EngineConfig) withDefaults() EngineConfig {
 }
 
 func (c EngineConfig) allowEmbedderDegrade() bool { return !c.FailOnEmbedderError }
-func (c EngineConfig) allowGraphDegrade() bool    { return !c.FailOnGraphError }
 
 func posOr(v, fallback int) int {
 	if v > 0 {
@@ -135,11 +134,13 @@ func WithReranker(r Reranker) EngineOption {
 
 // WithExpandRecipes registers host-named expand views at construct time.
 // Each recipe is a named ExpandRequest template (ObjectID filled at call time).
-// Invalid recipes (empty name) are ignored here; use RegisterExpandRecipe for errors.
+// Invalid recipes (empty name) fail NewEngine.
 func WithExpandRecipes(recipes ...ExpandRecipe) EngineOption {
 	return func(eng *Engine) {
 		for _, r := range recipes {
-			_ = eng.RegisterExpandRecipe(r)
+			if err := eng.RegisterExpandRecipe(r); err != nil && eng.bootErr == nil {
+				eng.bootErr = err
+			}
 		}
 	}
 }
@@ -191,7 +192,9 @@ func NewEngine(store Store, opts ...EngineOption) (*Engine, error) {
 		return nil, e.bootErr
 	}
 	e.cfg = e.cfg.withDefaults()
-	e.observer = observerOrNoop(e.observer)
+	if e.observer == nil {
+		e.observer = noopObserver{}
+	}
 	return e, nil
 }
 
@@ -217,7 +220,7 @@ func (e *Engine) Catalog() *KindCatalog {
 // Read returns the full rich object for id under scope.
 func (e *Engine) Read(ctx context.Context, scope Scope, id uuid.UUID) (RichObject, error) {
 	if id == uuid.Nil {
-		return RichObject{}, ErrObjectIDRequired
+		return RichObject{}, fmt.Errorf("%w: object id is required", ErrInvalid)
 	}
 	obj, err := e.store.Get(ctx, scope, id)
 	if err != nil {
@@ -341,7 +344,7 @@ func (e *Engine) KindsWithObjects(ctx context.Context, scope Scope) ([]string, e
 func (e *Engine) objectLister() (ObjectLister, error) {
 	l, ok := e.store.(ObjectLister)
 	if !ok {
-		return nil, ErrListingUnsupported
+		return nil, fmt.Errorf("%w: store does not support object listing", ErrUnsupported)
 	}
 	return l, nil
 }
@@ -349,7 +352,7 @@ func (e *Engine) objectLister() (ObjectLister, error) {
 // Get returns the stored object (including Content) under scope.
 func (e *Engine) Get(ctx context.Context, scope Scope, id uuid.UUID) (Object, error) {
 	if id == uuid.Nil {
-		return Object{}, ErrObjectIDRequired
+		return Object{}, fmt.Errorf("%w: object id is required", ErrInvalid)
 	}
 	return e.store.Get(ctx, scope, id)
 }

--- a/brain/engine_options_test.go
+++ b/brain/engine_options_test.go
@@ -31,11 +31,13 @@ func (nopRerank) Rerank(context.Context, []brain.RichObject) ([]brain.RichObject
 func TestNewEngine_options(t *testing.T) {
 	ctx := context.Background()
 	store := brain.NewMemoryStore()
+	if _, err := brain.NewEngine(store, brain.WithExpandRecipes(brain.ExpandRecipe{Name: ""})); err == nil || !errors.Is(err, brain.ErrInvalid) {
+		t.Fatalf("empty expand recipe name must fail construct: %v", err)
+	}
 	eng, err := brain.NewEngine(store,
 		brain.WithObserver(nopObserver{}),
 		brain.WithReranker(nopRerank{}),
 		brain.WithExpandRecipes(
-			brain.ExpandRecipe{Name: ""}, // ignored empty name
 			brain.ExpandRecipe{Name: "kids", MaxHops: 1, WantContainment: true},
 		),
 		brain.WithKinds(brain.KindSpec{
@@ -79,10 +81,10 @@ func TestNewEngine_options(t *testing.T) {
 	}
 	if _, err := eng.FindLinks(ctx, brain.Scope{}, brain.FindLinksRequest{
 		RelationType: "about", Query: "x",
-	}); !errors.Is(err, brain.ErrEdgeSearchUnavailable) {
+	}); !errors.Is(err, brain.ErrUnsupported) {
 		t.Fatalf("FindLinks without graph: %v", err)
 	}
-	if _, err := eng.FindObjects(ctx, brain.Scope{}, brain.FindObjectsRequest{Query: "x"}, brain.NewSearchContext()); !errors.Is(err, brain.ErrObjectSearchUnavailable) {
+	if _, err := eng.FindObjects(ctx, brain.Scope{}, brain.FindObjectsRequest{Query: "x"}, brain.NewSearchContext()); !errors.Is(err, brain.ErrUnsupported) {
 		t.Fatalf("FindObjects without graph: %v", err)
 	}
 	if eng.HasObjectSearch() {

--- a/brain/eval_test.go
+++ b/brain/eval_test.go
@@ -289,7 +289,7 @@ func TestEval_graphRAGComposition(t *testing.T) {
 		t.Fatalf("link meta: %+v", links.Links[0].Meta)
 	}
 
-	if _, err := eng.FindLinks(ctx, scope, brain.FindLinksRequest{}); !errors.Is(err, brain.ErrLinkQueryRequired) {
+	if _, err := eng.FindLinks(ctx, scope, brain.FindLinksRequest{}); !errors.Is(err, brain.ErrInvalid) {
 		t.Fatalf("find_links required: %v", err)
 	}
 

--- a/brain/expand.go
+++ b/brain/expand.go
@@ -68,7 +68,7 @@ func (e *Engine) Expand(ctx context.Context, scope Scope, req ExpandRequest, res
 		return res, err
 	}
 	if req.ObjectID == uuid.Nil {
-		return res, ErrObjectIDRequired
+		return res, fmt.Errorf("%w: object id is required", ErrInvalid)
 	}
 	obj, err := e.store.Get(ctx, scope, req.ObjectID)
 	if err != nil {
@@ -77,7 +77,7 @@ func (e *Engine) Expand(ctx context.Context, scope Scope, req ExpandRequest, res
 
 	wantContainment, graphLabels := resolveExpandRelations(req.RelationTypes, req.WantContainment)
 	if len(graphLabels) > 0 && e.graph == nil {
-		return res, fmt.Errorf("%w for relation types %v", ErrGraphRequired, graphLabels)
+		return res, fmt.Errorf("%w: graph backend is required for relation types %v", ErrUnsupported, graphLabels)
 	}
 
 	var (
@@ -98,7 +98,7 @@ func (e *Engine) Expand(ctx context.Context, scope Scope, req ExpandRequest, res
 	if len(graphLabels) > 0 {
 		hits, gErr := e.graphNeighborsMulti(ctx, scope, obj.ID, graphLabels, req.MaxHops, req.Direction)
 		if gErr != nil {
-			if e.cfg.allowGraphDegrade() && usedContainment {
+			if !e.cfg.FailOnGraphError && usedContainment {
 				degrade = DegradeContainmentOnly
 			} else {
 				return res, gErr
@@ -171,7 +171,7 @@ func (e *Engine) ExpandMany(ctx context.Context, scope Scope, req ExpandManyRequ
 
 	wantContainment, graphLabels := resolveExpandRelations(req.RelationTypes, req.WantContainment)
 	if len(graphLabels) > 0 && e.graph == nil {
-		return res, fmt.Errorf("%w for relation types %v", ErrGraphRequired, graphLabels)
+		return res, fmt.Errorf("%w: graph backend is required for relation types %v", ErrUnsupported, graphLabels)
 	}
 
 	seen := make(map[uuid.UUID]struct{}, budget)
@@ -248,7 +248,7 @@ func (e *Engine) ExpandMany(ctx context.Context, scope Scope, req ExpandManyRequ
 func (e *Engine) ExpandByRecipe(ctx context.Context, scope Scope, objectID uuid.UUID, recipeName string, results ResultSetStore) (ExpandResult, error) {
 	r, ok := e.recipe(recipeName)
 	if !ok {
-		return ExpandResult{}, fmt.Errorf("%w: %q", ErrExpandRecipeNotFound, strings.TrimSpace(recipeName))
+		return ExpandResult{}, fmt.Errorf("%w: expand recipe %q", ErrNotFound, strings.TrimSpace(recipeName))
 	}
 	return e.Expand(ctx, scope, ExpandRequest{
 		ObjectID:        objectID,
@@ -264,7 +264,7 @@ func (e *Engine) ExpandByRecipe(ctx context.Context, scope Scope, objectID uuid.
 func (e *Engine) RegisterExpandRecipe(r ExpandRecipe) error {
 	name := strings.TrimSpace(r.Name)
 	if name == "" {
-		return ErrExpandRecipeNameRequired
+		return fmt.Errorf("%w: expand recipe name is required", ErrInvalid)
 	}
 	r.Name = name
 	e.recipeMu.Lock()

--- a/brain/find_links.go
+++ b/brain/find_links.go
@@ -39,12 +39,12 @@ func (e *Engine) FindLinks(ctx context.Context, scope Scope, req FindLinksReques
 		return res, err
 	}
 	if e.graphE == nil {
-		return res, ErrEdgeSearchUnavailable
+		return res, fmt.Errorf("%w: graph edge search is not available", ErrUnsupported)
 	}
 	rel := strings.TrimSpace(req.RelationType)
 	query := strings.TrimSpace(req.Query)
 	if rel == "" || query == "" {
-		return res, ErrLinkQueryRequired
+		return res, fmt.Errorf("%w: relation type and query are required", ErrInvalid)
 	}
 	limit := e.normalizeLimit(req.Limit)
 	hits, err := e.graphE.SearchEdgesText(ctx, rel, query, max(limit*2, e.cfg.CandidateK))

--- a/brain/find_objects.go
+++ b/brain/find_objects.go
@@ -27,14 +27,14 @@ func (e *Engine) FindObjects(ctx context.Context, scope Scope, req FindObjectsRe
 	defer func() { span.End(len(page.Objects), degrade, err) }()
 
 	if e.graphS == nil {
-		return page, ErrObjectSearchUnavailable
+		return page, fmt.Errorf("%w: graph object search is not available", ErrUnsupported)
 	}
 	if results == nil {
-		return page, ErrResultSetRequired
+		return page, fmt.Errorf("%w: result set store is required", ErrUnsupported)
 	}
 	query := strings.TrimSpace(req.Query)
 	if query == "" {
-		return page, ErrQueryRequired
+		return page, fmt.Errorf("%w: query is required", ErrInvalid)
 	}
 	filters, err := e.prepareFindObjectFilters(req)
 	if err != nil {

--- a/brain/graph.go
+++ b/brain/graph.go
@@ -86,6 +86,13 @@ type edgeKey struct {
 	rel      string
 }
 
+var (
+	_ GraphReader         = (*MemoryGraph)(nil)
+	_ GraphWriter         = (*MemoryGraph)(nil)
+	_ GraphObjectSearcher = (*MemoryGraph)(nil)
+	_ GraphEdgeSearcher   = (*MemoryGraph)(nil)
+)
+
 // MemoryGraph is an in-process GraphReader/GraphWriter/GraphObjectSearcher (tests / offline).
 // Edges are a single map; directions are derived on Neighbors.
 type MemoryGraph struct {
@@ -119,7 +126,7 @@ func (g *MemoryGraph) EnsureObject(ctx context.Context, obj Object) error {
 		return err
 	}
 	if obj.ID == uuid.Nil {
-		return ErrObjectIDRequired
+		return fmt.Errorf("%w: object id is required", ErrInvalid)
 	}
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -144,7 +151,7 @@ func (g *MemoryGraph) RemoveObject(ctx context.Context, id uuid.UUID) error {
 		return err
 	}
 	if id == uuid.Nil {
-		return ErrObjectIDRequired
+		return fmt.Errorf("%w: object id is required", ErrInvalid)
 	}
 	g.mu.Lock()
 	defer g.mu.Unlock()

--- a/brain/helixgraph/graph.go
+++ b/brain/helixgraph/graph.go
@@ -23,6 +23,13 @@ import (
 	"github.com/ryanaldo34/tacklr/brain"
 )
 
+var (
+	_ brain.GraphReader         = (*Graph)(nil)
+	_ brain.GraphWriter         = (*Graph)(nil)
+	_ brain.GraphObjectSearcher = (*Graph)(nil)
+	_ brain.GraphEdgeSearcher   = (*Graph)(nil)
+)
+
 // Graph implements brain.GraphWriter via HelixDB.
 type Graph struct {
 	client        *helix.Client
@@ -167,7 +174,7 @@ func (g *Graph) RemoveObject(ctx context.Context, id uuid.UUID) error {
 		return err
 	}
 	if id == uuid.Nil {
-		return brain.ErrObjectIDRequired
+		return fmt.Errorf("%w: object id is required", brain.ErrInvalid)
 	}
 	q := helix.WriteQuery("brain_remove_object")
 	oid := q.ParamString("object_id", id.String())
@@ -407,7 +414,7 @@ func (g *Graph) EnsureObject(ctx context.Context, obj brain.Object) error {
 		return err
 	}
 	if obj.ID == uuid.Nil {
-		return brain.ErrObjectIDRequired
+		return fmt.Errorf("%w: object id is required", brain.ErrInvalid)
 	}
 	exists, err := g.objectExists(ctx, obj.ID)
 	if err != nil {

--- a/brain/kind.go
+++ b/brain/kind.go
@@ -105,7 +105,7 @@ func (c *KindCatalog) register(specs ...KindSpec) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.frozen {
-		return errCatalogFrozen
+		return fmt.Errorf("%w: kind catalog is frozen", ErrInvalid)
 	}
 	maps.Copy(c.kinds, batch)
 	return nil
@@ -123,7 +123,7 @@ func (c *KindCatalog) replaceNormalized(batch map[string]KindSpec) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.frozen {
-		return errCatalogFrozen
+		return fmt.Errorf("%w: kind catalog is frozen", ErrInvalid)
 	}
 	if batch == nil {
 		batch = map[string]KindSpec{}
@@ -136,12 +136,10 @@ func (c *KindCatalog) ensureNotFrozen() error {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if c.frozen {
-		return errCatalogFrozen
+		return fmt.Errorf("%w: kind catalog is frozen", ErrInvalid)
 	}
 	return nil
 }
-
-var errCatalogFrozen = fmt.Errorf("brain: kind catalog is frozen")
 
 func normalizeKindBatch(specs []KindSpec) (map[string]KindSpec, error) {
 	out := make(map[string]KindSpec, len(specs))

--- a/brain/memory.go
+++ b/brain/memory.go
@@ -17,6 +17,13 @@ import (
 	"github.com/google/uuid"
 )
 
+var (
+	_ Store        = (*MemoryStore)(nil)
+	_ ObjectWriter = (*MemoryStore)(nil)
+	_ ObjectLister = (*MemoryStore)(nil)
+	_ KindWriter   = (*MemoryStore)(nil)
+)
+
 // MemoryStore is an in-process Store (tests, fixtures, and ObjectWriter for Engine.Put).
 type MemoryStore struct {
 	mu      sync.RWMutex
@@ -58,7 +65,7 @@ func (s *MemoryStore) Put(_ context.Context, obj Object) error {
 // SoftDelete implements ObjectWriter.
 func (s *MemoryStore) SoftDelete(_ context.Context, scope Scope, id uuid.UUID) error {
 	if id == uuid.Nil {
-		return ErrObjectIDRequired
+		return fmt.Errorf("%w: object id is required", ErrInvalid)
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/brain/observe.go
+++ b/brain/observe.go
@@ -35,10 +35,3 @@ func (noopObserver) StartOp(ctx context.Context, _ Op) (context.Context, OpSpan)
 type noopSpan struct{}
 
 func (noopSpan) End(int, DegradeMode, error) {}
-
-func observerOrNoop(o Observer) Observer {
-	if o == nil {
-		return noopObserver{}
-	}
-	return o
-}

--- a/brain/postgres.go
+++ b/brain/postgres.go
@@ -21,6 +21,13 @@ type PgxDB interface {
 	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
 }
 
+var (
+	_ Store        = (*PostgresStore)(nil)
+	_ ObjectWriter = (*PostgresStore)(nil)
+	_ ObjectLister = (*PostgresStore)(nil)
+	_ KindWriter   = (*PostgresStore)(nil)
+)
+
 // PostgresStore implements Store against the objects / object_kinds schema.
 type PostgresStore struct {
 	db PgxDB
@@ -174,7 +181,7 @@ func (s *PostgresStore) Put(ctx context.Context, obj Object) error {
 // SoftDelete implements ObjectWriter.
 func (s *PostgresStore) SoftDelete(ctx context.Context, scope Scope, id uuid.UUID) error {
 	if id == uuid.Nil {
-		return ErrObjectIDRequired
+		return fmt.Errorf("%w: object id is required", ErrInvalid)
 	}
 	q := `UPDATE objects SET deleted_at = $1, updated_at = $1 WHERE id = $2 AND deleted_at IS NULL`
 	args := []any{time.Now().UTC(), id}

--- a/brain/search.go
+++ b/brain/search.go
@@ -75,7 +75,7 @@ func (e *Engine) Continue(ctx context.Context, scope Scope, resultSetID uuid.UUI
 	defer func() { span.End(len(page.Objects), DegradeNone, err) }()
 
 	if resultSetID == uuid.Nil {
-		return page, ErrResultSetIDRequired
+		return page, fmt.Errorf("%w: result_set_id is required", ErrInvalid)
 	}
 	limit = e.normalizeLimit(limit)
 	set, err := results.Get(ctx, resultSetID)
@@ -135,7 +135,7 @@ func (e *Engine) materialize(ctx context.Context, scope Scope, ranked []ScoredID
 // rejected, and missing kind filters are expanded to all registered kinds.
 func (e *Engine) prepareSearch(req SearchRequest) (Filters, error) {
 	if strings.TrimSpace(req.Query) == "" {
-		return nil, ErrQueryRequired
+		return nil, fmt.Errorf("%w: query is required", ErrInvalid)
 	}
 	return e.effectiveFilters(req.Filters)
 }
@@ -269,7 +269,7 @@ func (e *Engine) hydrateIDs(ctx context.Context, scope Scope, ids []uuid.UUID) (
 // pageIDs materializes a ResultSet page. relations (optional) is stored for continue.
 func (e *Engine) pageIDs(ctx context.Context, scope Scope, ids []uuid.UUID, limit int, results ResultSetStore, relations map[uuid.UUID]Relation) (SearchPage, error) {
 	if results == nil {
-		return SearchPage{}, ErrResultSetRequired
+		return SearchPage{}, fmt.Errorf("%w: result set store is required", ErrUnsupported)
 	}
 	limit = e.normalizeLimit(limit)
 	if maxN := e.cfg.MaxResultSetSize; maxN > 0 && len(ids) > maxN {

--- a/brain/search_context.go
+++ b/brain/search_context.go
@@ -70,7 +70,7 @@ func (c *SearchContext) Namespace() (uuid.UUID, bool) {
 // Put implements ResultSetStore: stores set as the sole active ResultSet.
 func (c *SearchContext) Put(_ context.Context, set ResultSet) error {
 	if set.ID == uuid.Nil {
-		return ErrResultSetIDRequired
+		return fmt.Errorf("%w: result_set_id is required", ErrInvalid)
 	}
 	cp := cloneResultSet(set)
 	if cp.CreatedAt.IsZero() {

--- a/brain/types.go
+++ b/brain/types.go
@@ -8,47 +8,18 @@ import (
 	"github.com/google/uuid"
 )
 
-// Sentinel errors for Engine / store / graph call sites.
-// Callers should use errors.Is / errors.As — messages stay stable and wrap-friendly.
+// Coarse categories for errors.Is. Wrap a specific message at the call site
+// (fmt.Errorf("…: %w", ErrInvalid)) instead of adding a sentinel per situation.
 var (
 	// ErrNotFound is returned when an object is missing, soft-deleted, or outside scope.
 	ErrNotFound = errors.New("brain: object not found")
-	// ErrObjectIDRequired is returned when a UUID argument is the nil UUID.
-	ErrObjectIDRequired = errors.New("brain: object id is required")
-	// ErrQueryRequired is returned when a search/find query string is empty.
-	ErrQueryRequired = errors.New("brain: query is required")
-	// ErrResultSetRequired is returned when paging needs a ResultSetStore and none was provided.
-	ErrResultSetRequired = errors.New("brain: result set store is required")
-	// ErrResultSetIDRequired is returned when continue is called with a nil result set id.
-	ErrResultSetIDRequired = errors.New("brain: result_set_id is required")
-	// ErrGraphWriterRequired is returned when Link is called without a GraphWriter.
-	ErrGraphWriterRequired = errors.New("brain: graph writer is required for Link")
-	// ErrObjectSearchUnavailable is returned when FindObjects lacks a GraphObjectSearcher.
-	ErrObjectSearchUnavailable = errors.New("brain: graph object search is not available")
-	// ErrGraphRequired is returned when expand needs graph labels but no GraphReader is set.
-	ErrGraphRequired = errors.New("brain: graph backend is required")
-	// ErrWritesUnsupported is returned when Put/SoftDelete is used on a read-only store.
-	ErrWritesUnsupported = errors.New("brain: store does not support object writes")
-	// ErrListingUnsupported is returned when ListByKind/GetByProperty/KindsWithObjects
-	// is used on a store that does not implement ObjectLister.
-	ErrListingUnsupported = errors.New("brain: store does not support object listing")
-	// ErrSoftDeletedPut is returned when Put is called with DeletedAt already set.
-	ErrSoftDeletedPut = errors.New("brain: put refuses soft-deleted objects; use SoftDelete")
-	// ErrLinkNotFirstClass is returned when a link endpoint is a part (has parent_id).
-	ErrLinkNotFirstClass = errors.New("brain: link endpoint must be a first-class object (not a part)")
-	// ErrLinkArgs is returned when from/to/relation are incomplete.
-	ErrLinkArgs = errors.New("brain: from, to, and relation type are required")
+	// ErrInvalid groups validation failures (empty query, missing args, frozen catalog).
+	ErrInvalid = errors.New("brain: invalid")
+	// ErrUnsupported groups missing backend capabilities (no writer, no graph, no listing).
+	ErrUnsupported = errors.New("brain: unsupported")
 	// ErrGraphEnsure and ErrGraphRemove wrap dual-write failures (cause via errors.Unwrap).
 	ErrGraphEnsure = errors.New("brain: graph ensure object")
 	ErrGraphRemove = errors.New("brain: graph remove object")
-	// ErrEdgeSearchUnavailable is returned when FindLinks lacks a GraphEdgeSearcher.
-	ErrEdgeSearchUnavailable = errors.New("brain: graph edge search is not available")
-	// ErrLinkQueryRequired is returned when FindLinks is missing relation type or query.
-	ErrLinkQueryRequired = errors.New("brain: relation type and query are required")
-	// ErrExpandRecipeNotFound is returned when ExpandByRecipe names an unknown recipe.
-	ErrExpandRecipeNotFound = errors.New("brain: expand recipe not found")
-	// ErrExpandRecipeNameRequired is returned when registering a recipe without a name.
-	ErrExpandRecipeNameRequired = errors.New("brain: expand recipe name is required")
 )
 
 // Scope is optional retrieval isolation for Engine methods.

--- a/brain/write.go
+++ b/brain/write.go
@@ -33,7 +33,7 @@ func (e *Engine) Put(ctx context.Context, scope Scope, obj Object) (Object, erro
 		return Object{}, err
 	}
 	if obj.DeletedAt != nil {
-		return Object{}, ErrSoftDeletedPut
+		return Object{}, fmt.Errorf("%w: put refuses soft-deleted objects; use SoftDelete", ErrInvalid)
 	}
 	obj = preparePut(scope, obj, e.cfg.Now())
 	if err := ValidateObject(obj, e.catalog); err != nil {
@@ -95,11 +95,11 @@ func (e *Engine) LinkWith(ctx context.Context, scope Scope, from, to uuid.UUID, 
 		return err
 	}
 	if e.graphW == nil {
-		return ErrGraphWriterRequired
+		return fmt.Errorf("%w: graph writer is required for Link", ErrUnsupported)
 	}
 	rel := strings.TrimSpace(relationType)
 	if from == uuid.Nil || to == uuid.Nil || rel == "" {
-		return ErrLinkArgs
+		return fmt.Errorf("%w: from, to, and relation type are required", ErrInvalid)
 	}
 	if err := e.requireLinkEndpoint(ctx, scope, from, "from"); err != nil {
 		return err
@@ -116,11 +116,11 @@ func (e *Engine) Unlink(ctx context.Context, scope Scope, from, to uuid.UUID, re
 		return err
 	}
 	if e.graphW == nil {
-		return ErrGraphWriterRequired
+		return fmt.Errorf("%w: graph writer is required for Link", ErrUnsupported)
 	}
 	rel := strings.TrimSpace(relationType)
 	if from == uuid.Nil || to == uuid.Nil || rel == "" {
-		return ErrLinkArgs
+		return fmt.Errorf("%w: from, to, and relation type are required", ErrInvalid)
 	}
 	if err := e.requireLinkEndpoint(ctx, scope, from, "from"); err != nil {
 		return err
@@ -137,7 +137,7 @@ func (e *Engine) requireLinkEndpoint(ctx context.Context, scope Scope, id uuid.U
 		return fmt.Errorf("brain: link %s: %w", label, err)
 	}
 	if obj.ParentID != nil {
-		return fmt.Errorf("brain: link %s: %w", label, ErrLinkNotFirstClass)
+		return fmt.Errorf("brain: link %s: %w: endpoint must be a first-class object (not a part)", label, ErrInvalid)
 	}
 	return nil
 }
@@ -150,7 +150,7 @@ func (e *Engine) HasGraphWriter() bool {
 func (e *Engine) objectWriter() (ObjectWriter, error) {
 	w, ok := e.store.(ObjectWriter)
 	if !ok {
-		return nil, ErrWritesUnsupported
+		return nil, fmt.Errorf("%w: store does not support object writes", ErrUnsupported)
 	}
 	return w, nil
 }
@@ -362,13 +362,13 @@ func isReservedStoreProp(name string) bool {
 
 func requireObjectIdentity(obj Object) error {
 	if obj.ID == uuid.Nil {
-		return ErrObjectIDRequired
+		return fmt.Errorf("%w: object id is required", ErrInvalid)
 	}
 	if strings.TrimSpace(obj.Kind) == "" {
-		return fmt.Errorf("brain: object kind is required")
+		return fmt.Errorf("%w: object kind is required", ErrInvalid)
 	}
 	if obj.NamespaceID == uuid.Nil {
-		return fmt.Errorf("brain: object namespace_id is required")
+		return fmt.Errorf("%w: object namespace_id is required", ErrInvalid)
 	}
 	return nil
 }

--- a/brain/write_test.go
+++ b/brain/write_test.go
@@ -270,7 +270,7 @@ func TestPut_multiTurnMemoryGraph(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Parts cannot be link endpoints.
-	if err := eng.Link(ctx, scope, chunk.ID, b.ID, "about"); err == nil || !errors.Is(err, brain.ErrLinkNotFirstClass) {
+	if err := eng.Link(ctx, scope, chunk.ID, b.ID, "about"); err == nil || !errors.Is(err, brain.ErrInvalid) {
 		t.Fatalf("link part: %v", err)
 	}
 
@@ -310,7 +310,7 @@ func TestPut_multiTurnMemoryGraph(t *testing.T) {
 	// Soft-deleted Put is refused.
 	now := time.Now().UTC()
 	b.DeletedAt = &now
-	if _, err := eng.Put(ctx, scope, b); err == nil || !errors.Is(err, brain.ErrSoftDeletedPut) {
+	if _, err := eng.Put(ctx, scope, b); err == nil || !errors.Is(err, brain.ErrInvalid) {
 		t.Fatalf("put soft-deleted: %v", err)
 	}
 	// SoftDelete wrong namespace / missing id.
@@ -385,8 +385,8 @@ func TestLink_expandFindsNeighbor(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := eng.Link(ctx, scope, a.ID, b.ID, ""); !errors.Is(err, brain.ErrLinkArgs) {
-		t.Fatalf("want ErrLinkArgs: %v", err)
+	if err := eng.Link(ctx, scope, a.ID, b.ID, ""); !errors.Is(err, brain.ErrInvalid) {
+		t.Fatalf("want ErrInvalid for incomplete link: %v", err)
 	}
 	engNoGraph, err := brain.NewEngine(store)
 	if err != nil {
@@ -395,11 +395,11 @@ func TestLink_expandFindsNeighbor(t *testing.T) {
 	if engNoGraph.HasGraphWriter() {
 		t.Fatal("engine without WithGraph must not report HasGraphWriter")
 	}
-	if err := engNoGraph.Link(ctx, scope, a.ID, b.ID, "references"); !errors.Is(err, brain.ErrGraphWriterRequired) {
-		t.Fatalf("want ErrGraphWriterRequired: %v", err)
+	if err := engNoGraph.Link(ctx, scope, a.ID, b.ID, "references"); !errors.Is(err, brain.ErrUnsupported) {
+		t.Fatalf("want ErrUnsupported: %v", err)
 	}
-	if err := engNoGraph.Unlink(ctx, scope, a.ID, b.ID, "references"); !errors.Is(err, brain.ErrGraphWriterRequired) {
-		t.Fatalf("unlink want ErrGraphWriterRequired: %v", err)
+	if err := engNoGraph.Unlink(ctx, scope, a.ID, b.ID, "references"); !errors.Is(err, brain.ErrUnsupported) {
+		t.Fatalf("unlink want ErrUnsupported: %v", err)
 	}
 }
 

--- a/docs/badges/coverage.json
+++ b/docs/badges/coverage.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "coverage",
-  "message": "90.0%",
+  "message": "90.1%",
   "color": "green"
 }

--- a/inference/api.go
+++ b/inference/api.go
@@ -8,6 +8,8 @@ import (
 	"github.com/ryanaldo34/tacklr"
 )
 
+var _ tacklr.ProviderStatus = (*APIStatusError)(nil)
+
 // APIStatusError conveys an HTTP error response from an upstream LLM API.
 // Use errors.As to extract structured status/body details from a wrapped chain.
 type APIStatusError struct {

--- a/inference/inference.go
+++ b/inference/inference.go
@@ -47,6 +47,8 @@ var (
 	ErrIncompleteStream = errors.New("incomplete provider stream")
 	// ErrMalformedStream means a provider emitted invalid SSE event JSON.
 	ErrMalformedStream = errors.New("malformed provider stream")
+
+	_ tacklr.InferenceStrategy = (*OpenAIInferenceStrategy)(nil)
 )
 
 func (s *OpenAIInferenceStrategy) SetSystemPrompt(prompt string) {
@@ -177,10 +179,10 @@ var getEncoding = tiktoken.GetEncoding
 
 func (s *OpenAIInferenceStrategy) CountTokens(ctx context.Context, messages []*tacklr.Message, tools []*tacklr.Tool) (int, error) {
 	if s.apiKey == "" {
-		return 0, fmt.Errorf("count tokens: %w", tacklr.ErrApiKeyNotSet)
+		return 0, tacklr.ErrApiKeyNotSet
 	}
 	if s.model == "" {
-		return 0, fmt.Errorf("count tokens: %w", tacklr.ErrModelNotSet)
+		return 0, tacklr.ErrModelNotSet
 	}
 
 	items := marshalMessagesToInput(messages)
@@ -267,10 +269,10 @@ func (s *OpenAIInferenceStrategy) CountTokens(ctx context.Context, messages []*t
 
 func (s *OpenAIInferenceStrategy) Invoke(ctx context.Context, messages []*tacklr.Message, tools []*tacklr.Tool, systemPrompt string) (chan tacklr.LLMResponseChunk, error) {
 	if s.apiKey == "" {
-		return nil, fmt.Errorf("invoke: %w", tacklr.ErrApiKeyNotSet)
+		return nil, tacklr.ErrApiKeyNotSet
 	}
 	if s.model == "" {
-		return nil, fmt.Errorf("invoke: %w", tacklr.ErrModelNotSet)
+		return nil, tacklr.ErrModelNotSet
 	}
 
 	items := marshalMessagesToInput(messages)

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -126,6 +127,9 @@ func (s *SessionManager) returnInterrupt(id string, result []byte) (interrupt.In
 	}
 	if validator, ok := intr.(interrupt.PayloadValidator); ok {
 		if err := validator.ValidatePayload(result); err != nil {
+			if errors.Is(err, interrupt.ErrInvalidPayload) {
+				return nil, err
+			}
 			return nil, fmt.Errorf("%w: %w", interrupt.ErrInvalidPayload, err)
 		}
 	}

--- a/internal/testkit/model.go
+++ b/internal/testkit/model.go
@@ -9,6 +9,8 @@ import (
 	"github.com/ryanaldo34/tacklr"
 )
 
+var _ tacklr.InferenceStrategy = (*ScriptedModel)(nil)
+
 // ScriptedModel is a cancel-aware InferenceStrategy for tests.
 // Default CountTokens is sum of message content lengths (not zero), so window-pressure
 // paths can fire when MaxWindowSize is small. Override CountTokensFn to customize.

--- a/interrupt/interrupt.go
+++ b/interrupt/interrupt.go
@@ -2,7 +2,6 @@ package interrupt
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -61,14 +60,14 @@ func (c *UserSelectionInterrupt) Serialize() ([]byte, error) {
 func (c *UserSelectionInterrupt) ValidatePayload(payload []byte) error {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(payload, &raw); err != nil {
-		return fmt.Errorf("invalid JSON: %w", err)
+		return fmt.Errorf("%w: invalid JSON: %w", ErrInvalidPayload, err)
 	}
 	if _, ok := raw["selectionIdx"]; !ok {
-		return errors.New("missing required field: selectionIdx")
+		return fmt.Errorf("%w: missing required field: selectionIdx", ErrInvalidPayload)
 	}
 	var selection UserSelectionPayload
 	if err := json.Unmarshal(payload, &selection); err != nil {
-		return fmt.Errorf("invalid payload shape: %w", err)
+		return fmt.Errorf("%w: invalid payload shape: %w", ErrInvalidPayload, err)
 	}
 	if selection.SelectionIdx < 0 || selection.SelectionIdx >= len(c.Options) {
 		return fmt.Errorf("selectionIdx %d out of range [0, %d)", selection.SelectionIdx, len(c.Options))
@@ -169,21 +168,21 @@ func (p *ToolPermissionInterrupt) InitFromPayload(payload []byte) error {
 func (p *ToolPermissionInterrupt) ValidatePayload(payload []byte) error {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(payload, &raw); err != nil {
-		return fmt.Errorf("invalid JSON: %w", err)
+		return fmt.Errorf("%w: invalid JSON: %w", ErrInvalidPayload, err)
 	}
 	if _, ok := raw["optionId"]; !ok {
-		return errors.New("missing required field: optionId")
+		return fmt.Errorf("%w: missing required field: optionId", ErrInvalidPayload)
 	}
 	var res ToolPermissionPayload
 	if err := json.Unmarshal(payload, &res); err != nil {
-		return fmt.Errorf("invalid payload shape: %w", err)
+		return fmt.Errorf("%w: invalid payload shape: %w", ErrInvalidPayload, err)
 	}
 	for i := range p.Options {
 		if p.Options[i].OptionID == res.OptionID {
 			return nil
 		}
 	}
-	return fmt.Errorf("unknown optionId %q", res.OptionID)
+	return fmt.Errorf("%w: unknown optionId %q", ErrInvalidPayload, res.OptionID)
 }
 
 func (p *ToolPermissionInterrupt) Return(payload []byte) error {

--- a/interrupt/interrupt_test.go
+++ b/interrupt/interrupt_test.go
@@ -28,10 +28,10 @@ func TestUserSelection_fullLifecycle(t *testing.T) {
 		t.Fatal("error string")
 	}
 
-	if err := usi.ValidatePayload([]byte(`not-json`)); err == nil {
-		t.Fatal("invalid json")
+	if err := usi.ValidatePayload([]byte(`not-json`)); err == nil || !errors.Is(err, interrupt.ErrInvalidPayload) {
+		t.Fatalf("invalid json: %v", err)
 	}
-	if err := usi.ValidatePayload([]byte(`{}`)); err == nil || !strings.Contains(err.Error(), "selectionIdx") {
+	if err := usi.ValidatePayload([]byte(`{}`)); err == nil || !errors.Is(err, interrupt.ErrInvalidPayload) || !strings.Contains(err.Error(), "selectionIdx") {
 		t.Fatalf("missing field: %v", err)
 	}
 	if err := usi.ValidatePayload([]byte(`{"selectionIdx":99}`)); err == nil {

--- a/server/acp.go
+++ b/server/acp.go
@@ -633,9 +633,6 @@ func presentationToACP(threadID string, ev streaming.StreamEvent) ([][]byte, err
 	}
 }
 
-// acpToolCallID is the client lifecycle id (same as ToolCall.Key).
-func acpToolCallID(tc streaming.ToolCall) string { return tc.Key() }
-
 // acpToolCallUpdate builds the common tool_call / tool_call_update body.
 // Title is the human label; name is the programmatic tool id (ACP RFD-aligned).
 func acpToolCallUpdate(tc streaming.ToolCall, sessionUpdate, status, content string) map[string]any {
@@ -645,7 +642,7 @@ func acpToolCallUpdate(tc streaming.ToolCall, sessionUpdate, status, content str
 	}
 	update := map[string]any{
 		"sessionUpdate": sessionUpdate,
-		"toolCallId":    acpToolCallID(tc),
+		"toolCallId":    tc.Key(),
 		"title":         title,
 		"status":        status,
 	}

--- a/server/acp_protocol.go
+++ b/server/acp_protocol.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -180,7 +181,7 @@ func (p *acpProtocol) handleACPWebSocket(env ProtocolEnv, w http.ResponseWriter,
 
 func (p *acpProtocol) HandleInbound(ctx context.Context, env ProtocolEnv, body []byte) error {
 	if err := ctx.Err(); err != nil {
-		_ = env.Conn.Writer.WriteError(nil, err)
+		writeWireError(env.Conn.Writer, nil, err)
 		return err
 	}
 
@@ -188,7 +189,7 @@ func (p *acpProtocol) HandleInbound(ctx context.Context, env ProtocolEnv, body [
 	if err != nil {
 		// validateACPRequest always returns a nil *parsedRequest on error.
 		slog.Debug("client error", "error", err)
-		_ = env.Conn.Writer.WriteError(nil, err)
+		writeWireError(env.Conn.Writer, nil, err)
 		return err
 	}
 
@@ -294,7 +295,10 @@ func (p *acpProtocol) authenticate(ctx context.Context, env ProtocolEnv, methodI
 		Binding: binding,
 	})
 	if err != nil {
-		return clientErrorf(ErrAuthenticationRequired, "authentication required")
+		if errors.Is(err, tacklrsecurity.ErrAuthenticationFailed) {
+			return clientErrorCause(ErrAuthenticationFailed, err, "authentication failed")
+		}
+		return clientErrorCause(ErrAuthenticationRequired, err, "authentication required")
 	}
 	env.Conn.establishSecurity(securityContext)
 	return nil
@@ -313,13 +317,13 @@ func (p *acpProtocol) requireAuthentication(env ProtocolEnv) error {
 func (p *acpProtocol) handleSessionTurn(ctx context.Context, env ProtocolEnv, pr *parsedRequest) error {
 	if env.Conn != nil && env.Conn.RPC != nil {
 		if err := env.Conn.RPC.WaitInitialized(ctx); err != nil {
-			_ = env.Conn.Writer.WriteError(pr.ID, err)
+			writeWireError(env.Conn.Writer, pr.ID, err)
 			return err
 		}
 	}
 	req, err := p.BindTurn(ctx, env, pr.ThreadID, pr.Method, pr.Params)
 	if err != nil {
-		_ = env.Conn.Writer.WriteError(pr.ID, err)
+		writeWireError(env.Conn.Writer, pr.ID, err)
 		return err
 	}
 	stream, err := env.Registry.RunTurn(ctx, req)
@@ -327,7 +331,7 @@ func (p *acpProtocol) handleSessionTurn(ctx context.Context, env ProtocolEnv, pr
 		if !IsClientError(err) {
 			logTurnError(err, req.AgentID, req.ThreadID)
 		}
-		_ = env.Conn.Writer.WriteError(pr.ID, err)
+		writeWireError(env.Conn.Writer, pr.ID, err)
 		return err
 	}
 	defer func() {

--- a/server/errors.go
+++ b/server/errors.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/ryanaldo34/tacklr/interrupt"
 	tacklrsecurity "github.com/ryanaldo34/tacklr/security"
@@ -15,11 +17,12 @@ var (
 	ErrInvalidRequest            = errors.New("invalid request")
 	ErrMethodNotFound            = errors.New("method not found")
 	ErrAgentNotFound             = errors.New("agent not found")
-	ErrSessionNotFound           = errors.New("session not found")
+	ErrSessionNotFound           = stores.ErrSessionNotFound
 	ErrSessionStoreNotConfigured = errors.New("session store is not configured")
 	ErrStreamingNotSupported     = errors.New("streaming not supported")
 	ErrInternal                  = errors.New("internal server error")
 	ErrAuthenticationRequired    = tacklrsecurity.ErrAuthenticationRequired
+	ErrAuthenticationFailed      = tacklrsecurity.ErrAuthenticationFailed
 	ErrAuthorizationDenied       = tacklrsecurity.ErrAuthorizationDenied
 )
 
@@ -37,16 +40,38 @@ const (
 var ErrRequestCancelled = errors.New("request cancelled")
 
 // clientError is a caller-facing error that unwraps to a sentinel.
+// When cause is set, errors.Is/As can also match the underlying failure.
 type clientError struct {
 	sentinel error
 	msg      string
+	cause    error
 }
 
 func (e *clientError) Error() string { return e.msg }
-func (e *clientError) Unwrap() error { return e.sentinel }
+
+func (e *clientError) Unwrap() []error {
+	if e.cause != nil {
+		return []error{e.sentinel, e.cause}
+	}
+	return []error{e.sentinel}
+}
 
 func clientErrorf(sentinel error, format string, args ...any) error {
 	return &clientError{sentinel: sentinel, msg: fmt.Sprintf(format, args...)}
+}
+
+func clientErrorCause(sentinel, cause error, format string, args ...any) error {
+	return &clientError{sentinel: sentinel, cause: cause, msg: fmt.Sprintf(format, args...)}
+}
+
+// writeWireError writes a client-visible error and logs a write failure.
+func writeWireError(w MessageWriter, id json.RawMessage, err error) {
+	if w == nil {
+		return
+	}
+	if writeErr := w.WriteError(id, err); writeErr != nil {
+		slog.Warn("failed to write client error", "error", writeErr, "cause", err)
+	}
 }
 
 // IsClientError reports whether err is safe to surface to the client
@@ -68,6 +93,7 @@ func IsClientError(err error) bool {
 		errors.Is(err, ErrSessionNotFound) ||
 		errors.Is(err, ErrSessionStoreNotConfigured) ||
 		errors.Is(err, ErrAuthenticationRequired) ||
+		errors.Is(err, ErrAuthenticationFailed) ||
 		errors.Is(err, ErrAuthorizationDenied) ||
 		errors.Is(err, errConnectionNotInitialized)
 }

--- a/server/errors_test.go
+++ b/server/errors_test.go
@@ -74,3 +74,20 @@ func TestClientError_errorsIs(t *testing.T) {
 		t.Fatal("expected errors.Is to match ErrAgentNotFound through wrap")
 	}
 }
+
+func TestClientErrorCause_preservesUnderlyingClass(t *testing.T) {
+	cause := fmt.Errorf("%w: drive token expired", stores.ErrSessionNotFound)
+	err := clientErrorCause(ErrInvalidRequest, cause, "bind vfs")
+	if !errors.Is(err, ErrInvalidRequest) {
+		t.Fatalf("want ErrInvalidRequest: %v", err)
+	}
+	if !errors.Is(err, stores.ErrSessionNotFound) {
+		t.Fatalf("want underlying class preserved: %v", err)
+	}
+	if err.Error() != "bind vfs" {
+		t.Fatalf("wire message = %q", err.Error())
+	}
+	if !IsClientError(err) {
+		t.Fatal("clientErrorCause must stay client-safe")
+	}
+}

--- a/server/handler_failure_paths_test.go
+++ b/server/handler_failure_paths_test.go
@@ -256,17 +256,9 @@ func TestParsePermissionAndSelection_badData(t *testing.T) {
 	}
 }
 
-type failSaveStore struct {
-	*stores.InMemoryStore
-}
-
-func (f failSaveStore) SaveSession(ctx context.Context, id string, cp stores.SessionCheckpoint) error {
-	return errors.New("save fail")
-}
-
 func TestCreateSession_wireStoreIndependentOfHarnessStore(t *testing.T) {
 	// Wire session create does not require harness BaseStore.
-	r := NewRegistry(failSaveStore{InMemoryStore: stores.NewInMemoryStore()}, "default")
+	r := NewRegistry(stores.FaultyStore{Inner: stores.NewInMemoryStore(), SaveErr: errors.New("save fail")}, "default")
 	r.Register("default", AgentSpec{Options: tacklr.AgentOptions{Model: &mockInferenceStrategy{}}})
 	p := NewACPProtocol(nil).(*acpProtocol)
 	params, _ := json.Marshal(map[string]any{"cwd": "/tmp"})
@@ -582,7 +574,7 @@ func TestHandleInbound_sessionCancelRequestAndMethodNotFound(t *testing.T) {
 
 func TestHandleSessionTurn_nonClientError(t *testing.T) {
 	// Second session prompt loads from harness store; non-client LoadSession error.
-	r := NewRegistry(&failLoadStore{InMemoryStore: stores.NewInMemoryStore(), err: errors.New("db down")}, "default")
+	r := NewRegistry(stores.FaultyStore{Inner: stores.NewInMemoryStore(), LoadErr: errors.New("db down")}, "default")
 	r.Register("default", AgentSpec{
 		Options: tacklr.AgentOptions{
 			Config: tacklr.Config{MaxWindowSize: 1024},
@@ -616,22 +608,6 @@ func TestHandleSessionTurn_nonClientError(t *testing.T) {
 	if err == nil {
 		t.Fatal("want non-client load error on second prompt")
 	}
-}
-
-type failLoadStore struct {
-	*stores.InMemoryStore
-	err error
-}
-
-func (f *failLoadStore) LoadSession(ctx context.Context, id string) (stores.SessionCheckpoint, error) {
-	return stores.SessionCheckpoint{}, f.err
-}
-
-func (f *failLoadStore) SaveSession(ctx context.Context, id string, cp stores.SessionCheckpoint) error {
-	if f.InMemoryStore != nil {
-		return f.InMemoryStore.SaveSession(ctx, id, cp)
-	}
-	return nil
 }
 
 func TestOnStreamEvent_cancelledCompleteAndEncodeError(t *testing.T) {
@@ -968,10 +944,8 @@ func TestHandleSSE_bodyReadErrorAndInternalRunError(t *testing.T) {
 		t.Fatalf("code=%d", rec.Code)
 	}
 
-	// Non-client RunTurn error: use failLoadStore with Load via thread — agent path without session
-	// Internal: mock that returns error from Run is hard. Use agent not found is client error.
-	// logTurnError path for non-client: failLoadStore on load
-	r2 := NewRegistry(&failLoadStore{err: errors.New("disk fail")}, "default")
+	// Non-client RunTurn error: FaultyStore LoadSession fails on resume.
+	r2 := NewRegistry(stores.FaultyStore{LoadErr: errors.New("disk fail")}, "default")
 	r2.Register("default", AgentSpec{Options: tacklr.AgentOptions{
 		Config: tacklr.Config{MaxWindowSize: 1024},
 		Model:  &mockInferenceStrategy{},
@@ -1020,7 +994,7 @@ func TestHandleWS_acceptFailAndReadFail(t *testing.T) {
 
 func TestHandleWS_nonClientRunErrorAndWriteThreadFail(t *testing.T) {
 	// Non-client load error on WS resume path.
-	r := NewRegistry(&failLoadStore{err: errors.New("ws-db-down")}, "default")
+	r := NewRegistry(stores.FaultyStore{LoadErr: errors.New("ws-db-down")}, "default")
 	r.Register("default", AgentSpec{Options: tacklr.AgentOptions{
 		Config: tacklr.Config{MaxWindowSize: 1024},
 		Model:  &mockInferenceStrategy{},

--- a/server/registry.go
+++ b/server/registry.go
@@ -328,6 +328,15 @@ func (r *Registry) DropLiveHarness(sessionID string) {
 	r.closeSessionVFS(sessionID)
 }
 
+func closeMountLogged(ms *vfs.MountSession, sessionID, reason string) {
+	if ms == nil {
+		return
+	}
+	if err := ms.Close(); err != nil {
+		slog.Warn("session vfs close failed", "session_id", sessionID, "reason", reason, "error", err)
+	}
+}
+
 func (r *Registry) closeSessionVFS(sessionID string) {
 	if r.vfsAuth != nil {
 		r.vfsAuth.Clear(sessionID)
@@ -343,9 +352,11 @@ func (r *Registry) closeSessionVFS(sessionID string) {
 	if dir != "" {
 		telemetry.EmitEvent(context.Background(), telemetry.EventFuseUnmount)
 	}
-	_ = ms.Close()
+	closeMountLogged(ms, sessionID, "session_teardown")
 	if dir != "" {
-		_ = os.Remove(dir)
+		if err := os.Remove(dir); err != nil {
+			slog.Warn("session vfs host dir remove failed", "session_id", sessionID, "dir", dir, "error", err)
+		}
 	}
 }
 
@@ -369,17 +380,18 @@ func (r *Registry) sessionVFS(ctx context.Context, threadID string, spec *AgentS
 		return nil, err
 	}
 	if err := ms.Materialize(ctx, spec.FSBootstrap); err != nil {
+		closeMountLogged(ms, threadID, "materialize")
 		return nil, err
 	}
 	if hasBindings {
 		for _, b := range r.vfsAuth.Bindings(threadID) {
 			if err := ms.Mount(ctx, vfs.BindingSpec(b)); err != nil && !errors.Is(err, vfs.ErrAlreadyMounted) {
-				_ = ms.Close()
+				closeMountLogged(ms, threadID, "bind")
 				return nil, err
 			}
 		}
 		if err := ms.AttachSkills(ctx); err != nil {
-			_ = ms.Close()
+			closeMountLogged(ms, threadID, "attach_skills")
 			return nil, err
 		}
 	}

--- a/server/sse_protocol.go
+++ b/server/sse_protocol.go
@@ -53,7 +53,7 @@ func (p sseProtocol) handleSSE(env ProtocolEnv, w http.ResponseWriter, r *http.R
 	pr, err := validateSSERequest(body)
 	if err != nil {
 		mw := &sseMessageWriter{w: w, flusher: flusher}
-		_ = mw.WriteError(nil, err)
+		writeWireError(mw, nil, err)
 		return
 	}
 
@@ -69,7 +69,7 @@ func (p sseProtocol) handleSSE(env ProtocolEnv, w http.ResponseWriter, r *http.R
 	}, func(err error) {
 		flusher.Flush()
 		mw := &sseMessageWriter{w: w, flusher: flusher}
-		_ = mw.WriteError(nil, err)
+		writeWireError(mw, nil, err)
 	}); err != nil && !IsClientError(err) {
 		slog.Debug("sse turn stream ended", "error", err)
 	}

--- a/server/vfs_auth.go
+++ b/server/vfs_auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"github.com/ryanaldo34/tacklr/vfs"
 )
@@ -39,7 +40,7 @@ func (r *Registry) BindVFS(ctx context.Context, sessionID, agentID string, b vfs
 		return clientErrorf(ErrInvalidRequest, "sessionId is required")
 	}
 	if err := vfs.ValidateBinding(b); err != nil {
-		return clientErrorf(ErrInvalidRequest, "%s", err.Error())
+		return clientErrorCause(ErrInvalidRequest, err, "invalid vfs binding")
 	}
 	fsReg, err := r.agentFS(agentID)
 	if err != nil {
@@ -50,7 +51,7 @@ func (r *Registry) BindVFS(ctx context.Context, sessionID, agentID string, b vfs
 	}
 	auth := r.VFSAuth()
 	if err := auth.Bind(sessionID, b); err != nil {
-		return clientErrorf(ErrInvalidRequest, "%s", err.Error())
+		return clientErrorCause(ErrInvalidRequest, err, "bind vfs")
 	}
 	spec := vfs.BindingSpec(b)
 
@@ -58,15 +59,21 @@ func (r *Registry) BindVFS(ctx context.Context, sessionID, agentID string, b vfs
 	ms := r.mounts[sessionID]
 	r.mountsMu.Unlock()
 	if ms != nil {
-		_ = ms.Unmount(spec.Point)
+		if err := ms.Unmount(spec.Point); err != nil {
+			slog.Warn("vfs remount: unmount previous", "session_id", sessionID, "point", spec.Point, "error", err)
+		}
 		if err := ms.Mount(ctx, spec); err != nil {
-			_ = auth.Unbind(sessionID, spec.Point)
+			if unbindErr := auth.Unbind(sessionID, spec.Point); unbindErr != nil {
+				slog.Error("vfs bind rollback failed", "session_id", sessionID, "point", spec.Point, "error", unbindErr)
+			}
 			return err
 		}
 		return nil
 	}
 	if err := vfs.CheckMount(ctx, fsReg, sessionID, spec); err != nil {
-		_ = auth.Unbind(sessionID, spec.Point)
+		if unbindErr := auth.Unbind(sessionID, spec.Point); unbindErr != nil {
+			slog.Error("vfs bind rollback failed", "session_id", sessionID, "point", spec.Point, "error", unbindErr)
+		}
 		return err
 	}
 	return nil
@@ -78,7 +85,7 @@ func (r *Registry) RefreshVFS(sessionID, provider string, c vfs.Credential) erro
 		return clientErrorf(ErrInvalidRequest, "vfs auth is not configured")
 	}
 	if err := r.vfsAuth.Refresh(sessionID, provider, c); err != nil {
-		return clientErrorf(ErrInvalidRequest, "%s", err.Error())
+		return clientErrorCause(ErrInvalidRequest, err, "refresh vfs token")
 	}
 	return nil
 }
@@ -97,18 +104,22 @@ func (r *Registry) UnbindVFS(sessionID, point, provider string) error {
 		return clientErrorf(ErrInvalidRequest, "point or provider is required")
 	}
 	if err != nil {
-		return clientErrorf(ErrInvalidRequest, "%s", err.Error())
+		return clientErrorCause(ErrInvalidRequest, err, "unbind vfs")
 	}
 	r.mountsMu.Lock()
 	ms := r.mounts[sessionID]
 	r.mountsMu.Unlock()
 	if ms != nil && point != "" {
-		_ = ms.Unmount(point)
+		if unmountErr := ms.Unmount(point); unmountErr != nil {
+			slog.Warn("vfs unbind: unmount failed", "session_id", sessionID, "point", point, "error", unmountErr)
+		}
 	}
 	if ms != nil && point == "" && provider != "" {
 		for _, spec := range ms.Specs() {
 			if spec.Profile == provider {
-				_ = ms.Unmount(spec.Point)
+				if unmountErr := ms.Unmount(spec.Point); unmountErr != nil {
+					slog.Warn("vfs unbind: unmount failed", "session_id", sessionID, "point", spec.Point, "error", unmountErr)
+				}
 			}
 		}
 	}

--- a/stores/inmemory_test.go
+++ b/stores/inmemory_test.go
@@ -79,10 +79,10 @@ func TestFaultyStore_saveAndLoadFaults(t *testing.T) {
 		t.Fatal(err)
 	}
 	save := FaultyStore{Inner: inner, SaveErr: errors.New("disk full")}
-	if err := save.SaveSession(ctx, "s1", cp); err == nil || err.Error() != "disk full" {
+	if err := save.SaveSession(ctx, "s1", *cp); err == nil || err.Error() != "disk full" {
 		t.Fatalf("save fault: %v", err)
 	}
-	if err := inner.SaveSession(ctx, "s1", cp); err != nil {
+	if err := inner.SaveSession(ctx, "s1", *cp); err != nil {
 		t.Fatal(err)
 	}
 	load := FaultyStore{Inner: inner, LoadErr: errors.New("db down")}

--- a/stores/inmemory_test.go
+++ b/stores/inmemory_test.go
@@ -71,6 +71,31 @@ func TestInMemoryStore_saveLoadRoundTrip(t *testing.T) {
 	}
 }
 
+func TestFaultyStore_saveAndLoadFaults(t *testing.T) {
+	ctx := context.Background()
+	inner := NewInMemoryStore()
+	cp, err := NewCheckpoint([]*streaming.Message{{Role: streaming.RoleUser, Content: "hi"}}, nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	save := FaultyStore{Inner: inner, SaveErr: errors.New("disk full")}
+	if err := save.SaveSession(ctx, "s1", cp); err == nil || err.Error() != "disk full" {
+		t.Fatalf("save fault: %v", err)
+	}
+	if err := inner.SaveSession(ctx, "s1", cp); err != nil {
+		t.Fatal(err)
+	}
+	load := FaultyStore{Inner: inner, LoadErr: errors.New("db down")}
+	if _, err := load.LoadSession(ctx, "s1"); err == nil || err.Error() != "db down" {
+		t.Fatalf("load fault: %v", err)
+	}
+	ok := FaultyStore{Inner: inner}
+	got, err := ok.LoadSession(ctx, "s1")
+	if err != nil || len(got.ContextWindow) != 1 {
+		t.Fatalf("passthrough load: %+v err=%v", got, err)
+	}
+}
+
 func TestInMemoryStore_loadMissing_returnsErrSessionNotFound(t *testing.T) {
 	store := NewInMemoryStore()
 	_, err := store.LoadSession(context.Background(), "does-not-exist")

--- a/stores/stores.go
+++ b/stores/stores.go
@@ -163,3 +163,37 @@ type BaseStore interface {
 // ErrSessionNotFound is returned by LoadSession when the requested session
 // does not exist.
 var ErrSessionNotFound = errors.New("session not found")
+
+// FaultyStore wraps a BaseStore and injects Save/Load failures.
+// A nil Inner is a no-op store except when a fault is set.
+type FaultyStore struct {
+	Inner   BaseStore
+	SaveErr error
+	LoadErr error
+}
+
+func (s FaultyStore) SaveSession(ctx context.Context, id string, cp SessionCheckpoint) error {
+	if s.SaveErr != nil {
+		return s.SaveErr
+	}
+	if s.Inner != nil {
+		return s.Inner.SaveSession(ctx, id, cp)
+	}
+	return nil
+}
+
+func (s FaultyStore) LoadSession(ctx context.Context, id string) (SessionCheckpoint, error) {
+	if s.LoadErr != nil {
+		return SessionCheckpoint{}, s.LoadErr
+	}
+	if s.Inner != nil {
+		return s.Inner.LoadSession(ctx, id)
+	}
+	return SessionCheckpoint{}, fmt.Errorf("load session %q: %w", id, ErrSessionNotFound)
+}
+
+var (
+	_ BaseStore = (*InMemoryStore)(nil)
+	_ BaseStore = (*PostgresStore)(nil)
+	_ BaseStore = FaultyStore{}
+)

--- a/subagents_test.go
+++ b/subagents_test.go
@@ -628,16 +628,6 @@ func TestSpawnWorker_interruptSurvivesSessionReload(t *testing.T) {
 	}
 }
 
-// failSaveStore keeps LoadSession working but every SaveSession fails so a
-// worker interrupt must still bubble from the live park.
-type failSaveStore struct {
-	*stores.InMemoryStore
-}
-
-func (failSaveStore) SaveSession(context.Context, string, stores.SessionCheckpoint) error {
-	return errors.New("checkpoint disk full")
-}
-
 // newWorkerHost builds a parent with VFS+Brain+namespace and a spawn-shaped
 // worker that shares the mount, engine, and index bridge.
 func newWorkerHost(t *testing.T) (*AgentHarness, *AgentHarness, *vfs.MountSession, *brain.Engine, uuid.UUID) {

--- a/tool_runner.go
+++ b/tool_runner.go
@@ -55,16 +55,8 @@ func (r *toolRunner) Run(ctx context.Context, inv ToolInvocation) (string, ToolO
 	return out, toolDisp, err
 }
 
-func rejectedOnCall(name string) error {
-	return fmt.Errorf("%w: user rejected tool %q", ErrToolPermissionDenied, name)
-}
-
 func toolNameOf(inv ToolInvocation) string {
 	return inv.Tool.Name
-}
-
-func toolDisplayOf(inv ToolInvocation) string {
-	return inv.Tool.DisplayName
 }
 
 // ToolPermissionOnCall parks a tool_permission interrupt before the handler.
@@ -73,7 +65,7 @@ func ToolPermissionOnCall(inv ToolInvocation) Interrupt {
 	name := toolNameOf(inv)
 	return &interrupt.ToolPermissionInterrupt{
 		ToolName: name,
-		Title:    ResolveToolTitle(toolDisplayOf(inv), name, inv.ArgsJSON),
+		Title:    ResolveToolTitle(inv.Tool.DisplayName, name, inv.ArgsJSON),
 		Options:  interrupt.DefaultPermissionOptions(),
 	}
 }
@@ -105,7 +97,7 @@ func applyOnCallLayer(inv *ToolInvocation, ctor OnCallFunc, sm *session.SessionM
 	callID := inv.Runtime.CurrentToolCallID()
 	if layer, ok := sm.OnCall.Get(callID, intr.TypeName()); ok {
 		if layer.Denied {
-			return rejectedOnCall(toolNameOf(*inv))
+			return fmt.Errorf("%w: user rejected tool %q", ErrToolPermissionDenied, toolNameOf(*inv))
 		}
 		inv.ArgsJSON = layer.Args
 		return nil
@@ -136,7 +128,7 @@ func finishOnCallLayer(inv *ToolInvocation, typeName string, denied bool, sm *se
 		Denied: denied,
 	})
 	if denied {
-		return rejectedOnCall(toolNameOf(*inv))
+		return fmt.Errorf("%w: user rejected tool %q", ErrToolPermissionDenied, toolNameOf(*inv))
 	}
 	return nil
 }

--- a/tools.go
+++ b/tools.go
@@ -276,7 +276,9 @@ func ResolveToolTitle(displayName, toolName, argsJSON string) string {
 		return displayName
 	}
 	var args map[string]any
-	_ = json.Unmarshal([]byte(argsJSON), &args)
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+		return displayName
+	}
 	return titleParamRE.ReplaceAllStringFunc(displayName, func(m string) string {
 		key := m[1 : len(m)-1]
 		s, _ := args[key].(string)

--- a/tools_brain.go
+++ b/tools_brain.go
@@ -587,7 +587,7 @@ func (b brainTools) resolveEngramSavePath(ctx context.Context, kind, title, obje
 			return "", err
 		}
 		if p := vfsPathFromProps(obj.Properties); p != "" {
-			return absVirtual(p)
+			return vfs.CleanPath(p)
 		}
 		return "", fmt.Errorf("object_id %s has no vfs_path; cannot update as file", id)
 	}
@@ -613,7 +613,7 @@ func (b brainTools) resolveEngramSavePath(ctx context.Context, kind, title, obje
 func (b brainTools) resolveFileRef(ctx context.Context, pathStr, idStr, field string, requireFirstClass bool) (uuid.UUID, string, error) {
 	p := strings.TrimSpace(pathStr)
 	if p != "" {
-		abs, err := absVirtual(p)
+		abs, err := vfs.CleanPath(p)
 		if err != nil {
 			return uuid.Nil, "", err
 		}
@@ -657,8 +657,12 @@ func (b brainTools) resolveFileRef(ctx context.Context, pathStr, idStr, field st
 	if err != nil {
 		return uuid.Nil, "", err
 	}
+	obj, err := b.engine.Read(ctx, b.sc.Scope(), id)
+	if err != nil && !errors.Is(err, brain.ErrNotFound) {
+		return uuid.Nil, "", err
+	}
 	var vpath string
-	if obj, err := b.engine.Read(ctx, b.sc.Scope(), id); err == nil {
+	if err == nil {
 		vpath, _ = obj.Properties[brain.PropVFSPath].(string)
 	}
 	return id, vpath, nil

--- a/tools_brain_test.go
+++ b/tools_brain_test.go
@@ -3,6 +3,7 @@ package tacklr
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -733,5 +734,47 @@ func TestBrainTools_expandAndUnlinkValidationErrors(t *testing.T) {
 		"from_id":"not-a-uuid","to_id":"not-a-uuid","relation_type":"about"
 	}`, rt); err == nil || !strings.Contains(err.Error(), "from") {
 		t.Fatalf("unlink invalid uuid = %v", err)
+	}
+}
+
+type failGetStore struct {
+	*brain.MemoryStore
+	err error
+}
+
+func (s failGetStore) Get(ctx context.Context, scope brain.Scope, id uuid.UUID) (brain.Object, error) {
+	if s.err != nil {
+		return brain.Object{}, s.err
+	}
+	return s.MemoryStore.Get(ctx, scope, id)
+}
+
+func TestBrainTools_resolveFileRefPropagatesStoreFailure(t *testing.T) {
+	ctx := context.Background()
+	mem := brain.NewMemoryStore()
+	ns := uuid.New()
+	id := uuid.New()
+	if err := mem.Put(ctx, brain.Object{
+		ID: id, Kind: "Document", Title: "memo", NamespaceID: ns, UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	eng, err := brain.NewEngine(failGetStore{MemoryStore: mem, err: errors.New("brain store down")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := mustNewAgent(t, AgentOptions{
+		Config:          Config{MaxWindowSize: 1024},
+		Model:           &mockStrategy{},
+		Brain:           eng,
+		SearchNamespace: &ns,
+	})
+	expand := h.findTool("expand", "")
+	if expand == nil {
+		t.Fatal("expand required")
+	}
+	_, err = expand.invoke(ctx, `{"object_id":"`+id.String()+`"}`, turnRuntime(h))
+	if err == nil || !strings.Contains(err.Error(), "brain store down") {
+		t.Fatalf("want store failure propagated, got %v", err)
 	}
 }

--- a/tools_test.go
+++ b/tools_test.go
@@ -489,3 +489,14 @@ func asParams(t *testing.T, tool *Tool) map[string]any {
 	t.Helper()
 	return tool.AsJson()["parameters"].(map[string]any)
 }
+
+func TestResolveToolTitle_invalidJSONKeepsTemplate(t *testing.T) {
+	got := ResolveToolTitle("read {path}", "read", `{not-json`)
+	if got != "read {path}" {
+		t.Fatalf("got %q, want template unchanged", got)
+	}
+	got = ResolveToolTitle("read {path}", "read", `{"path":"/work/a.txt"}`)
+	if got != "read /work/a.txt" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/tools_vfs.go
+++ b/tools_vfs.go
@@ -72,7 +72,7 @@ Knowledge objects with no file: read_object. Live names/grep: run_command → ls
 		Access:   ToolReadAccess,
 		Timeout:  60 * time.Second,
 		Handler: func(ctx context.Context, args readArgs, rt HarnessRuntime) (string, error) {
-			p, err := absVirtual(args.Path)
+			p, err := vfs.CleanPath(args.Path)
 			if err != nil {
 				return "", err
 			}
@@ -224,7 +224,7 @@ Projected Docs/Word: use block_id or blocks. Inline marks in block text: **bold*
 		Access:   ToolWriteAccess,
 		Timeout:  60 * time.Second,
 		Handler: func(ctx context.Context, args writeArgs, rt HarnessRuntime) (string, error) {
-			p, err := absVirtual(args.Path)
+			p, err := vfs.CleanPath(args.Path)
 			if err != nil {
 				return "", err
 			}
@@ -344,5 +344,3 @@ func growLineWindow(b *strings.Builder, extra int, lines []string) {
 	}
 	b.Grow(n)
 }
-
-func absVirtual(p string) (string, error) { return vfs.CleanPath(p) }

--- a/tools_vfsindex.go
+++ b/tools_vfsindex.go
@@ -125,7 +125,7 @@ Does not delete the real VFS file. Idempotent if nothing was indexed. Requires a
 		Access:   ToolWriteAccess,
 		Timeout:  30 * time.Second,
 		Handler: func(ctx context.Context, args unindexArgs, runtime HarnessRuntime) (string, error) {
-			p, err := absVirtual(args.Path)
+			p, err := vfs.CleanPath(args.Path)
 			if err != nil {
 				return "", err
 			}
@@ -159,14 +159,14 @@ func collectIndexPaths(path string, paths []string) ([]string, error) {
 	}
 	out := make([]string, 0, n)
 	if single != "" {
-		abs, err := absVirtual(single)
+		abs, err := vfs.CleanPath(single)
 		if err != nil {
 			return nil, err
 		}
 		out = append(out, abs)
 	}
 	for _, p := range paths {
-		abs, err := absVirtual(p)
+		abs, err := vfs.CleanPath(p)
 		if err != nil {
 			return nil, err
 		}

--- a/vfs/errors.go
+++ b/vfs/errors.go
@@ -38,6 +38,4 @@ var (
 	// ErrStaleContent is for tool/host optimistic concurrency (expected hash ≠ current).
 	// vfs lower-level APIs do not return this; tools wrap ContentRev checks.
 	ErrStaleContent = errors.New("vfs: stale content revision")
-
-	errRegistryRequired = errors.New("vfs: registry required")
 )

--- a/vfs/registry.go
+++ b/vfs/registry.go
@@ -77,7 +77,7 @@ func (r *BackendRegistry) Profiles() []string {
 // Used to fail client binds before the mount is visible.
 func CheckMount(ctx context.Context, reg *BackendRegistry, sessionID string, spec MountSpec) error {
 	if reg == nil {
-		return errRegistryRequired
+		panic("vfs: CheckMount requires a backend registry")
 	}
 	p, err := reg.open(ctx, sessionID, spec)
 	if err != nil {

--- a/vfs/session.go
+++ b/vfs/session.go
@@ -83,7 +83,7 @@ func NewMountSession(sessionID string, reg *BackendRegistry) (*MountSession, err
 		return nil, fmt.Errorf("%w: session id is required", ErrInvalidPath)
 	}
 	if reg == nil {
-		return nil, errRegistryRequired
+		panic("vfs: NewMountSession requires a backend registry")
 	}
 	return &MountSession{id: sessionID, reg: reg, tab: newMountTable()}, nil
 }
@@ -108,7 +108,7 @@ func (m *MountSession) table() *mountTable {
 // Factories that implement SkillSource are then attached at /skills.
 func (m *MountSession) Materialize(ctx context.Context, specs []MountSpec) error {
 	if m.reg == nil {
-		return errRegistryRequired
+		panic("vfs: mount session has no registry")
 	}
 	var next *mountTable
 	var err error
@@ -133,7 +133,7 @@ func (m *MountSession) Materialize(ctx context.Context, specs []MountSpec) error
 // Non-union mounts refresh /skills from SkillSource factories.
 func (m *MountSession) Mount(ctx context.Context, spec MountSpec) error {
 	if m.reg == nil {
-		return errRegistryRequired
+		panic("vfs: mount session has no registry")
 	}
 	p, err := m.reg.open(ctx, m.id, spec)
 	if err != nil {
@@ -153,7 +153,7 @@ func (m *MountSession) Mount(ctx context.Context, spec MountSpec) error {
 // (Drive) should call this after bind so new members are picked up.
 func (m *MountSession) AttachSkills(ctx context.Context) error {
 	if m.reg == nil {
-		return errRegistryRequired
+		panic("vfs: mount session has no registry")
 	}
 	return attachSkillsTo(ctx, m.reg, m.id, m.table())
 }

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -647,10 +647,15 @@ func TestMountSession_configErrors(t *testing.T) {
 	if err := ms.Unmount("/missing"); !errors.Is(err, vfs.ErrNotMounted) {
 		t.Fatalf("unmount missing: %v", err)
 	}
-	// nil registry session is rejected at construct
-	if _, err := vfs.NewMountSession("s2", nil); err == nil {
-		t.Fatal("nil registry construct")
-	}
+	// nil registry is a programmer error
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("nil registry must panic")
+			}
+		}()
+		_, _ = vfs.NewMountSession("s2", nil)
+	}()
 	if _, err := vfs.NewMountSession("", reg); err == nil {
 		t.Fatal("empty session id construct")
 	}

--- a/vfsindex/indexer.go
+++ b/vfsindex/indexer.go
@@ -124,7 +124,7 @@ func (x *MountIndexer) IndexFileResult(ctx context.Context, virtualPath string, 
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
-	cleaned, err := cleanPath(virtualPath)
+	cleaned, err := vfs.CleanPath(virtualPath)
 	if err != nil {
 		return "", err
 	}
@@ -144,7 +144,7 @@ func (x *MountIndexer) UnindexPath(ctx context.Context, virtualPath string) (boo
 	if err := ctx.Err(); err != nil {
 		return false, err
 	}
-	cleaned, err := cleanPath(virtualPath)
+	cleaned, err := vfs.CleanPath(virtualPath)
 	if err != nil {
 		return false, err
 	}
@@ -170,7 +170,7 @@ func (x *MountIndexer) indexPath(ctx context.Context, virtualPath string) (PathI
 	if err := ctx.Err(); err != nil {
 		return "", err
 	}
-	cleaned, err := cleanPath(virtualPath)
+	cleaned, err := vfs.CleanPath(virtualPath)
 	if err != nil {
 		return "", err
 	}
@@ -196,7 +196,7 @@ func (x *MountIndexer) indexPath(ctx context.Context, virtualPath string) (PathI
 // IndexPrefix walks a directory (or single file) and indexes text-like files.
 func (x *MountIndexer) IndexPrefix(ctx context.Context, prefix string, opts IndexOpts) (Stats, error) {
 	var stats Stats
-	cleaned, err := cleanPath(prefix)
+	cleaned, err := vfs.CleanPath(prefix)
 	if err != nil {
 		return stats, err
 	}
@@ -678,8 +678,6 @@ func chunkID(parent uuid.UUID, pos int) uuid.UUID {
 	buf = strconv.AppendInt(buf, int64(pos), 10)
 	return uuid.NewSHA1(parent, buf)
 }
-
-func cleanPath(p string) (string, error) { return vfs.CleanPath(p) }
 
 func walk(ctx context.Context, ms *vfs.MountSession, vpath string, fn func(vpath string, isDir bool) error) error {
 	if err := ctx.Err(); err != nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This is a quality sweep of helpers, error classification, error handling, and test seams. Nobody is consuming the public API yet, so unused sentinels were removed rather than kept for compatibility.

## Helpers
- Inlined one-off aliases (`cleanPath`, `absVirtual`, `acpToolCallID`, `toolDisplayOf`, `rejectedOnCall`, `allowGraphDegrade`, `observerOrNoop`).
- Call sites now use the real API (`vfs.CleanPath`, `tc.Key()`, config flags).

## Assertions / frozen API guards
- Compile-time `var _ Interface = (*Impl)(nil)` checks on stores, brain memory/postgres/graph, Helix, inference, and `testkit.ScriptedModel`.
- `vfs.NewMountSession` / `CheckMount` panic on a nil registry (programmer error).
- `WithExpandRecipes` fails `NewEngine` on an empty recipe name instead of ignoring it.

## Sentinels and wrapping
- Brain now has coarse classes: `ErrNotFound`, `ErrInvalid`, `ErrUnsupported`, plus dual-write `ErrGraphEnsure` / `ErrGraphRemove`.
- Removed situation-specific sentinels (`ErrQueryRequired`, `ErrLinkArgs`, `ErrObjectIDRequired`, `ErrGraphWriterRequired`, etc.). Call sites wrap the class with a message.
- `server.ErrSessionNotFound` is now an alias of `stores.ErrSessionNotFound`.
- Interrupt validation wraps `ErrInvalidPayload` instead of bare `errors.New`.
- Inference returns `ErrApiKeyNotSet` / `ErrModelNotSet` directly (no `"count tokens:"` / `"invoke:"` wrap).

## Error handling
- `resolveFileRef` no longer treats store/read failures as “no vfs path”.
- VFS bind/unbind/refresh preserve the underlying error via `clientErrorCause` (`errors.Is` still works).
- ACP authenticate maps failed credentials to `ErrAuthenticationFailed` instead of “authentication required”.
- Wire `WriteError` failures are logged; session VFS close/unmount/remove failures are logged; harness logs `vfsindex.Bridge.Close` errors.
- `ResolveToolTitle` keeps the display template when args JSON is invalid.

## Tests
- Shared `stores.FaultyStore` replaces duplicated `failSaveStore` / `failLoadStore` doubles.
- Added outcome tests for title fallback, store-failure propagation, client error unwrapping, and FaultyStore save/load faults.

## Breaking
- Removed exported brain sentinels listed above. Branch on `ErrInvalid` / `ErrUnsupported` / `ErrNotFound`.
- `NewMountSession(nil registry)` panics.
- Empty expand recipes fail engine construction.

Local short tests passed for `interrupt`, `stores`, `brain`, `inference`, `server`, `vfs`, `vfsindex`, and the root harness package. Waiting on GitHub CI for lint + full coverage.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a022e8-a36f-7ac4-bf34-1248da33062b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a022e8-a36f-7ac4-bf34-1248da33062b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

