### PR TITLE
feat(email): add inbox provider tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ opts.Specialists = []*tacklr.Specialist{{
 | MCP | External tool servers | [`mcp`](https://pkg.go.dev/github.com/ryanaldo34/tacklr/mcp) |
 | Skills | `SKILL.md` catalogs from VFS mounts | [`skills`](https://pkg.go.dev/github.com/ryanaldo34/tacklr/skills) |
 | Web | Search and fetch when Exa is configured | [`tacklr`](https://pkg.go.dev/github.com/ryanaldo34/tacklr) |
+| Email | `read_inbox` and permission-gated `send_email`; structured filters hide Gmail and Graph query languages | [`email`](https://pkg.go.dev/github.com/ryanaldo34/tacklr/email) |
 | Server | `Protocol` over Runtime; ACP is the native option | [`server`](https://pkg.go.dev/github.com/ryanaldo34/tacklr/server) |
 | Telemetry | One `tacklr.turn` span per prompt or resume; OTLP | [`telemetry`](https://pkg.go.dev/github.com/ryanaldo34/tacklr/telemetry) |
 
@@ -206,6 +207,7 @@ When VFS is wired, the harness injects file tools over virtual paths only. `run_
 | Package | Role |
 |---------|------|
 | `tacklr` | Harness, tools, plan loop, specialists |
+| `email` | Gmail and Outlook provider contract and SDK adapters |
 | `vfs` | Virtual filesystem, mounts, content IR |
 | `vfsindex` | Optional mount → brain ingest |
 | `brain` | Knowledge engine |

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ opts.Specialists = []*tacklr.Specialist{{
 | MCP | External tool servers | [`mcp`](https://pkg.go.dev/github.com/ryanaldo34/tacklr/mcp) |
 | Skills | `SKILL.md` catalogs from VFS mounts | [`skills`](https://pkg.go.dev/github.com/ryanaldo34/tacklr/skills) |
 | Web | Search and fetch when Exa is configured | [`tacklr`](https://pkg.go.dev/github.com/ryanaldo34/tacklr) |
-| Email | `read_inbox` and permission-gated `send_email`; structured filters hide Gmail and Graph query languages | [`email`](https://pkg.go.dev/github.com/ryanaldo34/tacklr/email) |
+| Email | `read_inbox` and permission-gated `send_email`; structured filters hide Gmail and Graph query languages | [`email`](https://pkg.go.dev/github.com/ryanaldo34/tacklr/email) · [`email/gmail`](https://pkg.go.dev/github.com/ryanaldo34/tacklr/email/gmail) · [`email/outlook`](https://pkg.go.dev/github.com/ryanaldo34/tacklr/email/outlook) |
 | Server | `Protocol` over Runtime; ACP is the native option | [`server`](https://pkg.go.dev/github.com/ryanaldo34/tacklr/server) |
 | Telemetry | One `tacklr.turn` span per prompt or resume; OTLP | [`telemetry`](https://pkg.go.dev/github.com/ryanaldo34/tacklr/telemetry) |
 

--- a/agent.go
+++ b/agent.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/ryanaldo34/tacklr/brain"
+	mail "github.com/ryanaldo34/tacklr/email"
 	mcpruntime "github.com/ryanaldo34/tacklr/internal/mcp"
 	session "github.com/ryanaldo34/tacklr/internal/session"
 	"github.com/ryanaldo34/tacklr/mcp"
@@ -47,6 +48,7 @@ type TurnManager struct {
 	hostInterceptors     []ToolInterceptor
 	hostResultHooks      map[string]ToolResultHook
 	exaAPIKey            string
+	emailProvider        mail.Provider
 	brain                *brain.Engine
 	brainWriteKinds      brain.WriteKinds
 	runCommandUnattended bool

--- a/agent_construct.go
+++ b/agent_construct.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/ryanaldo34/tacklr/brain"
+	mail "github.com/ryanaldo34/tacklr/email"
 	"github.com/ryanaldo34/tacklr/internal/exa"
 	session "github.com/ryanaldo34/tacklr/internal/session"
 	"github.com/ryanaldo34/tacklr/mcp"
@@ -41,7 +42,8 @@ func (c Config) Validate() error {
 
 // AgentOptions configures NewTurnManager.
 //
-// Usual fields: Config, Model, Tools, MCPConfigs, Specialists, SessionID.
+// Usual fields: Config, Model, Tools, MCPConfigs, EmailProvider, Specialists,
+// SessionID.
 // ContextPolicy knobs (ratios, stream-summary) stay host-settable. Adaptive
 // Case Management itself is harness-owned and cannot be replaced.
 //
@@ -80,6 +82,9 @@ type AgentOptions struct {
 	// ExaAPIKey enables web_search and web_fetch. Empty falls back to EXA_API_KEY.
 	// When both are empty, those tools are not registered.
 	ExaAPIKey string
+	// EmailProvider enables read_inbox and send_email for Gmail or Outlook.
+	// The host owns provider authentication and lifecycle.
+	EmailProvider mail.Provider
 	// Brain enables knowledge builtins when non-nil. Workers inherit the same engine.
 	// Configure Store, optional QueryEmbedder, and optional GraphReader/GraphWriter on the Engine
 	// before NewTurnManager (e.g. brain.WithGraph(helixgraph.New(...))). The harness does
@@ -126,6 +131,7 @@ func NewTurnManager(ctx context.Context, opts AgentOptions) (*TurnManager, error
 		hostInterceptors:      slices.Clone(opts.ToolInterceptors),
 		hostResultHooks:       maps.Clone(opts.ToolResultHooks),
 		exaAPIKey:             resolveExaAPIKey(opts.ExaAPIKey),
+		emailProvider:         opts.EmailProvider,
 		brain:                 opts.Brain,
 		brainWriteKinds:       opts.BrainWriteKinds,
 		sessionId:             opts.SessionID,
@@ -191,6 +197,9 @@ func (opts *AgentOptions) Validate() error {
 			return fmt.Errorf("tacklr: AgentOptions.Tools[%d] is nil", i)
 		}
 	}
+	if err := mail.ValidateProvider(opts.EmailProvider); err != nil {
+		return fmt.Errorf("tacklr: EmailProvider: %w", err)
+	}
 	seenMCP := make(map[string]struct{}, len(opts.MCPConfigs))
 	for i := range opts.MCPConfigs {
 		config := opts.MCPConfigs[i]
@@ -208,12 +217,17 @@ func (opts *AgentOptions) Validate() error {
 	return nil
 }
 
-func (h *TurnManager) finishInit(ctx context.Context, subAgents []*Specialist) error {
+func (h *TurnManager) finishInit(ctx context.Context, specialists []*Specialist) error {
+	if h.emailProvider != nil {
+		if err := h.emailProvider.Validate(ctx); err != nil {
+			return fmt.Errorf("initialize email provider %q: %w", h.emailProvider.Kind(), err)
+		}
+	}
 	if err := h.initSkills(ctx); err != nil {
 		return fmt.Errorf("initialize skills: %w", err)
 	}
 	h.initMCP(ctx)
-	if err := h.initSpecialists(subAgents); err != nil {
+	if err := h.initSpecialists(specialists); err != nil {
 		return err
 	}
 	if h.vfsBridge == nil {
@@ -238,6 +252,9 @@ func (a *TurnManager) injectBuiltinTools() {
 	if key := strings.TrimSpace(a.exaAPIKey); key != "" {
 		client := exa.NewClient(key)
 		a.tools = append(a.tools, newWebSearchTool(client), newWebFetchTool(client))
+	}
+	if a.emailProvider != nil {
+		a.tools = append(a.tools, newEmailTools(a.emailProvider)...)
 	}
 	br := a.vfsBridge
 	if ms := a.session.VFS; ms != nil {

--- a/email/gmail/provider.go
+++ b/email/gmail/provider.go
@@ -38,15 +38,15 @@ func (p *Provider) ReadInbox(ctx context.Context, req provider.ReadInboxRequest)
 	if err := p.Validate(ctx); err != nil {
 		return provider.Inbox{}, err
 	}
+	if err := req.Validate(); err != nil {
+		return provider.Inbox{}, err
+	}
 	call := p.service.Users.Messages.List("me").MaxResults(int64(req.Limit)).Context(ctx)
-	if req.Query != "" {
-		call.Q(req.Query)
+	if query := gmailQuery(req); query != "" {
+		call.Q(query)
 	}
 	if req.Mailbox != "" {
 		call.LabelIds(req.Mailbox)
-	}
-	if req.UnreadOnly {
-		call.Q(joinQuery(req.Query, "is:unread"))
 	}
 	if req.Cursor != "" {
 		call.PageToken(req.Cursor)
@@ -87,11 +87,38 @@ func (p *Provider) SendEmail(ctx context.Context, req provider.SendEmailRequest)
 	return provider.SentEmail{ID: sent.Id, ThreadID: sent.ThreadId}, nil
 }
 
-func joinQuery(query, extra string) string {
-	if strings.TrimSpace(query) == "" {
-		return extra
+func gmailQuery(req provider.ReadInboxRequest) string {
+	terms := make([]string, 0, 7)
+	if req.From != "" {
+		terms = append(terms, "from:"+gmailQuoted(req.From))
 	}
-	return query + " " + extra
+	if req.To != "" {
+		terms = append(terms, "to:"+gmailQuoted(req.To))
+	}
+	if req.Subject != "" {
+		terms = append(terms, "subject:"+gmailQuoted(req.Subject))
+	}
+	if req.ReceivedAfter != "" {
+		terms = append(terms, "after:"+strings.ReplaceAll(req.ReceivedAfter, "-", "/"))
+	}
+	if req.ReceivedBefore != "" {
+		terms = append(terms, "before:"+strings.ReplaceAll(req.ReceivedBefore, "-", "/"))
+	}
+	if req.HasAttachment != nil {
+		if *req.HasAttachment {
+			terms = append(terms, "has:attachment")
+		} else {
+			terms = append(terms, "-has:attachment")
+		}
+	}
+	if req.UnreadOnly {
+		terms = append(terms, "is:unread")
+	}
+	return strings.Join(terms, " ")
+}
+
+func gmailQuoted(value string) string {
+	return `"` + strings.ReplaceAll(strings.ReplaceAll(value, `\`, `\\`), `"`, `\"`) + `"`
 }
 
 func messageFromSDK(message *googlemail.Message) provider.Message {

--- a/email/gmail/provider.go
+++ b/email/gmail/provider.go
@@ -1,0 +1,175 @@
+// Package gmail adapts the official Gmail SDK to email.Provider.
+package gmail
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"mime"
+	"net/mail"
+	"strings"
+	"time"
+
+	provider "github.com/ryanaldo34/tacklr/email"
+	googlemail "google.golang.org/api/gmail/v1"
+)
+
+// Provider implements email.Provider with google.golang.org/api/gmail/v1.
+// Construct the Gmail service with the OAuth scopes your host permits.
+type Provider struct {
+	service *googlemail.Service
+}
+
+// New returns a Gmail provider backed by service.
+func New(service *googlemail.Service) *Provider { return &Provider{service: service} }
+
+func (*Provider) Kind() provider.ProviderKind { return provider.ProviderGmail }
+
+// Validate checks that the official Gmail SDK client is present.
+func (p *Provider) Validate(context.Context) error {
+	if p == nil || p.service == nil {
+		return fmt.Errorf("email/gmail: service is required")
+	}
+	return nil
+}
+
+// ReadInbox lists full messages through the Gmail API.
+func (p *Provider) ReadInbox(ctx context.Context, req provider.ReadInboxRequest) (provider.Inbox, error) {
+	if err := p.Validate(ctx); err != nil {
+		return provider.Inbox{}, err
+	}
+	call := p.service.Users.Messages.List("me").MaxResults(int64(req.Limit)).Context(ctx)
+	if req.Query != "" {
+		call.Q(req.Query)
+	}
+	if req.Mailbox != "" {
+		call.LabelIds(req.Mailbox)
+	}
+	if req.UnreadOnly {
+		call.Q(joinQuery(req.Query, "is:unread"))
+	}
+	if req.Cursor != "" {
+		call.PageToken(req.Cursor)
+	}
+	page, err := call.Do()
+	if err != nil {
+		return provider.Inbox{}, fmt.Errorf("email/gmail: list messages: %w", err)
+	}
+	out := provider.Inbox{NextCursor: page.NextPageToken}
+	for _, item := range page.Messages {
+		message, err := p.service.Users.Messages.Get("me", item.Id).Format("full").Context(ctx).Do()
+		if err != nil {
+			return provider.Inbox{}, fmt.Errorf("email/gmail: get message %q: %w", item.Id, err)
+		}
+		out.Messages = append(out.Messages, messageFromSDK(message))
+	}
+	return out, nil
+}
+
+// SendEmail sends a RFC 2822 message through the Gmail API.
+func (p *Provider) SendEmail(ctx context.Context, req provider.SendEmailRequest) (provider.SentEmail, error) {
+	if err := p.Validate(ctx); err != nil {
+		return provider.SentEmail{}, err
+	}
+	raw := buildMessage(req)
+	message := &googlemail.Message{Raw: base64.RawURLEncoding.EncodeToString([]byte(raw))}
+	if req.ReplyToMessageID != "" {
+		original, err := p.service.Users.Messages.Get("me", req.ReplyToMessageID).Format("metadata").Context(ctx).Do()
+		if err != nil {
+			return provider.SentEmail{}, fmt.Errorf("email/gmail: get reply message %q: %w", req.ReplyToMessageID, err)
+		}
+		message.ThreadId = original.ThreadId
+	}
+	sent, err := p.service.Users.Messages.Send("me", message).Context(ctx).Do()
+	if err != nil {
+		return provider.SentEmail{}, fmt.Errorf("email/gmail: send message: %w", err)
+	}
+	return provider.SentEmail{ID: sent.Id, ThreadID: sent.ThreadId}, nil
+}
+
+func joinQuery(query, extra string) string {
+	if strings.TrimSpace(query) == "" {
+		return extra
+	}
+	return query + " " + extra
+}
+
+func messageFromSDK(message *googlemail.Message) provider.Message {
+	headers := map[string]string{}
+	if message.Payload != nil {
+		for _, header := range message.Payload.Headers {
+			headers[strings.ToLower(header.Name)] = header.Value
+		}
+	}
+	received, _ := mail.ParseDate(headers["date"])
+	if received.IsZero() && message.InternalDate > 0 {
+		received = time.UnixMilli(message.InternalDate).UTC()
+	}
+	return provider.Message{
+		ID: message.Id, ThreadID: message.ThreadId, From: headers["from"],
+		To: splitAddresses(headers["to"]), CC: splitAddresses(headers["cc"]),
+		Subject: headers["subject"], Body: payloadText(message.Payload), ReceivedAt: received,
+		Unread: hasLabel(message.LabelIds, "UNREAD"),
+	}
+}
+
+func splitAddresses(value string) []string {
+	addresses, err := mail.ParseAddressList(value)
+	if err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(addresses))
+	for _, address := range addresses {
+		out = append(out, address.Address)
+	}
+	return out
+}
+
+func hasLabel(labels []string, want string) bool {
+	for _, label := range labels {
+		if label == want {
+			return true
+		}
+	}
+	return false
+}
+
+func payloadText(part *googlemail.MessagePart) string {
+	if part == nil {
+		return ""
+	}
+	if strings.HasPrefix(part.MimeType, "text/plain") && part.Body != nil {
+		body, err := base64.RawURLEncoding.DecodeString(part.Body.Data)
+		if err == nil {
+			return string(body)
+		}
+	}
+	for _, child := range part.Parts {
+		if body := payloadText(child); body != "" {
+			return body
+		}
+	}
+	return ""
+}
+
+func buildMessage(req provider.SendEmailRequest) string {
+	var b strings.Builder
+	b.WriteString("To: ")
+	b.WriteString(strings.Join(req.To, ", "))
+	b.WriteString("\r\n")
+	if len(req.CC) > 0 {
+		b.WriteString("Cc: ")
+		b.WriteString(strings.Join(req.CC, ", "))
+		b.WriteString("\r\n")
+	}
+	if len(req.BCC) > 0 {
+		b.WriteString("Bcc: ")
+		b.WriteString(strings.Join(req.BCC, ", "))
+		b.WriteString("\r\n")
+	}
+	b.WriteString("Subject: ")
+	b.WriteString(mime.QEncoding.Encode("UTF-8", req.Subject))
+	b.WriteString("\r\nMIME-Version: 1.0\r\nContent-Type: text/plain; charset=UTF-8\r\n\r\n")
+	b.WriteString(req.Body)
+	return b.String()
+}

--- a/email/gmail/provider_test.go
+++ b/email/gmail/provider_test.go
@@ -50,14 +50,15 @@ func TestProvider_usesOfficialGmailSDKForInboxAndSend(t *testing.T) {
 	p := New(service)
 
 	// Act
-	inbox, err := p.ReadInbox(t.Context(), provider.ReadInboxRequest{Query: "from:sender", Mailbox: "INBOX", UnreadOnly: true, Limit: 5, Cursor: "cursor"})
+	hasAttachment := true
+	inbox, err := p.ReadInbox(t.Context(), provider.ReadInboxRequest{From: "sender@example.com", To: "recipient@example.com", Subject: "Status", ReceivedAfter: "2026-08-01", ReceivedBefore: "2026-08-31", HasAttachment: &hasAttachment, Mailbox: "INBOX", UnreadOnly: true, Limit: 5, Cursor: "cursor"})
 	sent, sendErr := p.SendEmail(t.Context(), provider.SendEmailRequest{To: []string{"recipient@example.com"}, Subject: "Status", Body: "ready"})
 
 	// Assert
 	if err != nil || len(inbox.Messages) != 1 || inbox.Messages[0].Body != "hello" || !inbox.Messages[0].Unread || inbox.NextCursor != "next" {
 		t.Fatalf("inbox = %+v, err = %v", inbox, err)
 	}
-	for _, want := range []string{"q=from%3Asender+is%3Aunread", "labelIds=INBOX", "maxResults=5", "pageToken=cursor"} {
+	for _, want := range []string{"from%3A%22sender%40example.com%22", "to%3A%22recipient%40example.com%22", "subject%3A%22Status%22", "after%3A2026%2F08%2F01", "before%3A2026%2F08%2F31", "has%3Aattachment", "is%3Aunread", "labelIds=INBOX", "maxResults=5", "pageToken=cursor"} {
 		if !strings.Contains(listQuery, want) {
 			t.Fatalf("list query = %q, want %q", listQuery, want)
 		}
@@ -65,6 +66,16 @@ func TestProvider_usesOfficialGmailSDKForInboxAndSend(t *testing.T) {
 	raw, decodeErr := base64.RawURLEncoding.DecodeString(sentRaw)
 	if sendErr != nil || decodeErr != nil || sent.ID != "sent" || !strings.Contains(string(raw), "To: recipient@example.com") || !strings.Contains(string(raw), "Subject: Status") {
 		t.Fatalf("send = %+v, raw = %q, err = %v decode = %v", sent, raw, sendErr, decodeErr)
+	}
+}
+
+func TestGmailQuery_escapesStructuredFilters(t *testing.T) {
+	hasAttachment := false
+	got := gmailQuery(provider.ReadInboxRequest{From: "a'@example.com", Subject: `weekly "review"`, HasAttachment: &hasAttachment})
+	for _, want := range []string{`from:"a'@example.com"`, `subject:"weekly \"review\""`, "-has:attachment"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("query = %q, want %q", got, want)
+		}
 	}
 }
 

--- a/email/gmail/provider_test.go
+++ b/email/gmail/provider_test.go
@@ -1,0 +1,75 @@
+package gmail
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	provider "github.com/ryanaldo34/tacklr/email"
+	"golang.org/x/oauth2"
+	googlemail "google.golang.org/api/gmail/v1"
+	"google.golang.org/api/option"
+)
+
+func TestProvider_usesOfficialGmailSDKForInboxAndSend(t *testing.T) {
+	// Arrange
+	var listQuery string
+	var sentRaw string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/gmail/v1/users/me/messages":
+			listQuery = r.URL.RawQuery
+			_ = json.NewEncoder(w).Encode(map[string]any{"messages": []map[string]string{{"id": "m1"}}, "nextPageToken": "next"})
+		case r.Method == http.MethodGet && r.URL.Path == "/gmail/v1/users/me/messages/m1":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "m1", "threadId": "t1", "labelIds": []string{"UNREAD"}, "internalDate": "1760000000000",
+				"payload": map[string]any{"mimeType": "text/plain", "headers": []map[string]string{
+					{"name": "From", "value": "sender@example.com"}, {"name": "To", "value": "recipient@example.com"},
+					{"name": "Subject", "value": "Status"}, {"name": "Date", "value": "Thu, 9 Oct 2025 08:53:20 +0000"},
+				}, "body": map[string]string{"data": base64.RawURLEncoding.EncodeToString([]byte("hello"))}},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/gmail/v1/users/me/messages/send":
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			sentRaw = body["raw"]
+			_ = json.NewEncoder(w).Encode(map[string]string{"id": "sent", "threadId": "thread"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	service, err := googlemail.NewService(t.Context(), option.WithHTTPClient(oauth2.NewClient(t.Context(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "token"}))), option.WithEndpoint(server.URL+"/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := New(service)
+
+	// Act
+	inbox, err := p.ReadInbox(t.Context(), provider.ReadInboxRequest{Query: "from:sender", Mailbox: "INBOX", UnreadOnly: true, Limit: 5, Cursor: "cursor"})
+	sent, sendErr := p.SendEmail(t.Context(), provider.SendEmailRequest{To: []string{"recipient@example.com"}, Subject: "Status", Body: "ready"})
+
+	// Assert
+	if err != nil || len(inbox.Messages) != 1 || inbox.Messages[0].Body != "hello" || !inbox.Messages[0].Unread || inbox.NextCursor != "next" {
+		t.Fatalf("inbox = %+v, err = %v", inbox, err)
+	}
+	for _, want := range []string{"q=from%3Asender+is%3Aunread", "labelIds=INBOX", "maxResults=5", "pageToken=cursor"} {
+		if !strings.Contains(listQuery, want) {
+			t.Fatalf("list query = %q, want %q", listQuery, want)
+		}
+	}
+	raw, decodeErr := base64.RawURLEncoding.DecodeString(sentRaw)
+	if sendErr != nil || decodeErr != nil || sent.ID != "sent" || !strings.Contains(string(raw), "To: recipient@example.com") || !strings.Contains(string(raw), "Subject: Status") {
+		t.Fatalf("send = %+v, raw = %q, err = %v decode = %v", sent, raw, sendErr, decodeErr)
+	}
+}
+
+func TestProvider_rejectsMissingSDKService(t *testing.T) {
+	if err := New(nil).Validate(context.Background()); err == nil {
+		t.Fatal("nil service was accepted")
+	}
+}

--- a/email/outlook/provider.go
+++ b/email/outlook/provider.go
@@ -1,0 +1,203 @@
+// Package outlook adapts the official Microsoft Graph SDK to email.Provider.
+package outlook
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/microsoftgraph/msgraph-sdk-go/users"
+	provider "github.com/ryanaldo34/tacklr/email"
+)
+
+// Provider implements email.Provider with msgraph-sdk-go. The host constructs
+// the Graph client with the scopes and authentication flow it permits.
+type Provider struct {
+	client *msgraphsdk.GraphServiceClient
+}
+
+// New returns an Outlook provider backed by client.
+func New(client *msgraphsdk.GraphServiceClient) *Provider { return &Provider{client: client} }
+
+func (*Provider) Kind() provider.ProviderKind { return provider.ProviderOutlook }
+
+// Validate checks that the official Graph SDK client is present.
+func (p *Provider) Validate(context.Context) error {
+	if p == nil || p.client == nil {
+		return fmt.Errorf("email/outlook: Graph client is required")
+	}
+	return nil
+}
+
+// ReadInbox lists messages from the selected Graph mail folder. Mailbox accepts
+// Graph well-known folder names, such as inbox, or a Graph folder ID.
+func (p *Provider) ReadInbox(ctx context.Context, req provider.ReadInboxRequest) (provider.Inbox, error) {
+	if err := p.Validate(ctx); err != nil {
+		return provider.Inbox{}, err
+	}
+	top := int32(req.Limit)
+	filter := ""
+	if req.UnreadOnly {
+		filter = "isRead eq false"
+	}
+	if req.Cursor != "" {
+		if err := p.validCursor(req.Cursor); err != nil {
+			return provider.Inbox{}, err
+		}
+		page, err := p.client.Me().Messages().WithUrl(req.Cursor).Get(ctx, nil)
+		if err != nil {
+			return provider.Inbox{}, fmt.Errorf("email/outlook: list next page: %w", err)
+		}
+		return inboxFromPage(page), nil
+	}
+	if req.Mailbox == "" {
+		page, err := p.client.Me().Messages().Get(ctx, messageConfig(top, req.Query, filter))
+		if err != nil {
+			return provider.Inbox{}, fmt.Errorf("email/outlook: list messages: %w", err)
+		}
+		return inboxFromPage(page), nil
+	}
+	page, err := p.client.Me().MailFolders().ByMailFolderId(req.Mailbox).Messages().Get(ctx, folderMessageConfig(top, req.Query, filter))
+	if err != nil {
+		return provider.Inbox{}, fmt.Errorf("email/outlook: list mailbox %q: %w", req.Mailbox, err)
+	}
+	return inboxFromPage(page), nil
+}
+
+func (p *Provider) validCursor(cursor string) error {
+	if p == nil || p.client == nil {
+		return fmt.Errorf("email/outlook: Graph client is required")
+	}
+	next, err := url.Parse(cursor)
+	if err != nil || next.Scheme == "" || next.Host == "" {
+		return fmt.Errorf("email/outlook: invalid pagination cursor")
+	}
+	base, err := url.Parse(p.client.GetAdapter().GetBaseUrl())
+	if err != nil || !strings.EqualFold(next.Scheme, base.Scheme) || !strings.EqualFold(next.Host, base.Host) {
+		return fmt.Errorf("email/outlook: pagination cursor is outside the Graph API")
+	}
+	return nil
+}
+
+// SendEmail sends a Graph message. Graph sendMail returns no message ID, so
+// SentEmail is empty after a successful accepted request.
+func (p *Provider) SendEmail(ctx context.Context, req provider.SendEmailRequest) (provider.SentEmail, error) {
+	if err := p.Validate(ctx); err != nil {
+		return provider.SentEmail{}, err
+	}
+	if req.ReplyToMessageID != "" {
+		return provider.SentEmail{}, fmt.Errorf("email/outlook: replies are not supported")
+	}
+	message := models.NewMessage()
+	message.SetToRecipients(recipients(req.To))
+	message.SetCcRecipients(recipients(req.CC))
+	message.SetBccRecipients(recipients(req.BCC))
+	message.SetSubject(&req.Subject)
+	body := models.NewItemBody()
+	body.SetContent(&req.Body)
+	contentType := models.TEXT_BODYTYPE
+	body.SetContentType(&contentType)
+	message.SetBody(body)
+	payload := users.NewItemSendMailPostRequestBody()
+	payload.SetMessage(message)
+	save := true
+	payload.SetSaveToSentItems(&save)
+	if err := p.client.Me().SendMail().Post(ctx, payload, nil); err != nil {
+		return provider.SentEmail{}, fmt.Errorf("email/outlook: send message: %w", err)
+	}
+	return provider.SentEmail{}, nil
+}
+
+func messageConfig(top int32, search, filter string) *users.ItemMessagesRequestBuilderGetRequestConfiguration {
+	query := &users.ItemMessagesRequestBuilderGetQueryParameters{Top: &top, Filter: stringPtr(filter), Orderby: []string{"receivedDateTime DESC"}, Select: selectedFields}
+	if strings.TrimSpace(search) != "" {
+		query.Search = stringPtr(search)
+	}
+	return &users.ItemMessagesRequestBuilderGetRequestConfiguration{QueryParameters: query}
+}
+
+func folderMessageConfig(top int32, search, filter string) *users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration {
+	query := &users.ItemMailFoldersItemMessagesRequestBuilderGetQueryParameters{Top: &top, Filter: stringPtr(filter), Orderby: []string{"receivedDateTime DESC"}, Select: selectedFields}
+	if strings.TrimSpace(search) != "" {
+		query.Search = stringPtr(search)
+	}
+	return &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{QueryParameters: query}
+}
+
+var selectedFields = []string{"id", "conversationId", "from", "toRecipients", "ccRecipients", "subject", "body", "receivedDateTime", "isRead"}
+
+func inboxFromPage(page models.MessageCollectionResponseable) provider.Inbox {
+	if page == nil {
+		return provider.Inbox{}
+	}
+	out := provider.Inbox{}
+	if next := page.GetOdataNextLink(); next != nil {
+		out.NextCursor = *next
+	}
+	for _, message := range page.GetValue() {
+		out.Messages = append(out.Messages, messageFromSDK(message))
+	}
+	return out
+}
+
+func messageFromSDK(message models.Messageable) provider.Message {
+	if message == nil {
+		return provider.Message{}
+	}
+	out := provider.Message{ID: value(message.GetId()), ThreadID: value(message.GetConversationId()), From: recipient(message.GetFrom()), To: recipientList(message.GetToRecipients()), CC: recipientList(message.GetCcRecipients()), Subject: value(message.GetSubject()), Unread: !boolValue(message.GetIsRead())}
+	if body := message.GetBody(); body != nil {
+		out.Body = value(body.GetContent())
+	}
+	if received := message.GetReceivedDateTime(); received != nil {
+		out.ReceivedAt = received.UTC()
+	}
+	return out
+}
+
+func recipients(addresses []string) []models.Recipientable {
+	out := make([]models.Recipientable, 0, len(addresses))
+	for _, address := range addresses {
+		email := models.NewEmailAddress()
+		email.SetAddress(&address)
+		recipient := models.NewRecipient()
+		recipient.SetEmailAddress(email)
+		out = append(out, recipient)
+	}
+	return out
+}
+
+func recipientList(items []models.Recipientable) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if address := recipient(item); address != "" {
+			out = append(out, address)
+		}
+	}
+	return out
+}
+
+func recipient(item models.Recipientable) string {
+	if item == nil || item.GetEmailAddress() == nil {
+		return ""
+	}
+	return value(item.GetEmailAddress().GetAddress())
+}
+
+func stringPtr(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func value(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func boolValue(value *bool) bool { return value != nil && *value }

--- a/email/outlook/provider.go
+++ b/email/outlook/provider.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
@@ -38,11 +39,11 @@ func (p *Provider) ReadInbox(ctx context.Context, req provider.ReadInboxRequest)
 	if err := p.Validate(ctx); err != nil {
 		return provider.Inbox{}, err
 	}
-	top := int32(req.Limit)
-	filter := ""
-	if req.UnreadOnly {
-		filter = "isRead eq false"
+	if err := req.Validate(); err != nil {
+		return provider.Inbox{}, err
 	}
+	top := int32(req.Limit)
+	filter := odataFilter(req)
 	if req.Cursor != "" {
 		if err := p.validCursor(req.Cursor); err != nil {
 			return provider.Inbox{}, err
@@ -54,13 +55,13 @@ func (p *Provider) ReadInbox(ctx context.Context, req provider.ReadInboxRequest)
 		return inboxFromPage(page), nil
 	}
 	if req.Mailbox == "" {
-		page, err := p.client.Me().Messages().Get(ctx, messageConfig(top, req.Query, filter))
+		page, err := p.client.Me().Messages().Get(ctx, messageConfig(top, filter))
 		if err != nil {
 			return provider.Inbox{}, fmt.Errorf("email/outlook: list messages: %w", err)
 		}
 		return inboxFromPage(page), nil
 	}
-	page, err := p.client.Me().MailFolders().ByMailFolderId(req.Mailbox).Messages().Get(ctx, folderMessageConfig(top, req.Query, filter))
+	page, err := p.client.Me().MailFolders().ByMailFolderId(req.Mailbox).Messages().Get(ctx, folderMessageConfig(top, filter))
 	if err != nil {
 		return provider.Inbox{}, fmt.Errorf("email/outlook: list mailbox %q: %w", req.Mailbox, err)
 	}
@@ -111,21 +112,44 @@ func (p *Provider) SendEmail(ctx context.Context, req provider.SendEmailRequest)
 	return provider.SentEmail{}, nil
 }
 
-func messageConfig(top int32, search, filter string) *users.ItemMessagesRequestBuilderGetRequestConfiguration {
+func messageConfig(top int32, filter string) *users.ItemMessagesRequestBuilderGetRequestConfiguration {
 	query := &users.ItemMessagesRequestBuilderGetQueryParameters{Top: &top, Filter: stringPtr(filter), Orderby: []string{"receivedDateTime DESC"}, Select: selectedFields}
-	if strings.TrimSpace(search) != "" {
-		query.Search = stringPtr(search)
-	}
 	return &users.ItemMessagesRequestBuilderGetRequestConfiguration{QueryParameters: query}
 }
 
-func folderMessageConfig(top int32, search, filter string) *users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration {
+func folderMessageConfig(top int32, filter string) *users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration {
 	query := &users.ItemMailFoldersItemMessagesRequestBuilderGetQueryParameters{Top: &top, Filter: stringPtr(filter), Orderby: []string{"receivedDateTime DESC"}, Select: selectedFields}
-	if strings.TrimSpace(search) != "" {
-		query.Search = stringPtr(search)
-	}
 	return &users.ItemMailFoldersItemMessagesRequestBuilderGetRequestConfiguration{QueryParameters: query}
 }
+
+func odataFilter(req provider.ReadInboxRequest) string {
+	filters := make([]string, 0, 7)
+	if req.From != "" {
+		filters = append(filters, "from/emailAddress/address eq '"+odataString(req.From)+"'")
+	}
+	if req.To != "" {
+		filters = append(filters, "toRecipients/any(r:r/emailAddress/address eq '"+odataString(req.To)+"')")
+	}
+	if req.Subject != "" {
+		filters = append(filters, "contains(subject, '"+odataString(req.Subject)+"')")
+	}
+	if req.ReceivedAfter != "" {
+		filters = append(filters, "receivedDateTime ge "+req.ReceivedAfter+"T00:00:00Z")
+	}
+	if req.ReceivedBefore != "" {
+		before, _ := time.Parse(time.DateOnly, req.ReceivedBefore)
+		filters = append(filters, "receivedDateTime lt "+before.AddDate(0, 0, 1).Format(time.RFC3339))
+	}
+	if req.HasAttachment != nil {
+		filters = append(filters, fmt.Sprintf("hasAttachments eq %t", *req.HasAttachment))
+	}
+	if req.UnreadOnly {
+		filters = append(filters, "isRead eq false")
+	}
+	return strings.Join(filters, " and ")
+}
+
+func odataString(value string) string { return strings.ReplaceAll(value, "'", "''") }
 
 var selectedFields = []string{"id", "conversationId", "from", "toRecipients", "ccRecipients", "subject", "body", "receivedDateTime", "isRead"}
 

--- a/email/outlook/provider_test.go
+++ b/email/outlook/provider_test.go
@@ -1,0 +1,112 @@
+package outlook
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	abstractions "github.com/microsoft/kiota-abstractions-go"
+	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	provider "github.com/ryanaldo34/tacklr/email"
+)
+
+func TestMessageFromSDK_mapsGraphMessage(t *testing.T) {
+	// Arrange
+	message := models.NewMessage()
+	id, thread, subject := "id", "thread", "subject"
+	message.SetId(&id)
+	message.SetConversationId(&thread)
+	message.SetSubject(&subject)
+	read := false
+	message.SetIsRead(&read)
+	received := time.Date(2026, time.August, 25, 12, 0, 0, 0, time.UTC)
+	message.SetReceivedDateTime(&received)
+	bodyText := "body"
+	body := models.NewItemBody()
+	body.SetContent(&bodyText)
+	message.SetBody(body)
+	message.SetFrom(newRecipient("sender@example.com"))
+	message.SetToRecipients([]models.Recipientable{newRecipient("to@example.com")})
+	message.SetCcRecipients([]models.Recipientable{newRecipient("cc@example.com")})
+
+	// Act
+	got := messageFromSDK(message)
+
+	// Assert
+	if got.ID != id || got.ThreadID != thread || got.From != "sender@example.com" || len(got.To) != 1 || len(got.CC) != 1 || got.Subject != subject || got.Body != bodyText || got.Unread != true || !got.ReceivedAt.Equal(received) {
+		t.Fatalf("message = %+v", got)
+	}
+}
+
+func TestProvider_usesOfficialGraphSDKForInboxAndSend(t *testing.T) {
+	// Arrange
+	var sent map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		path := strings.TrimSuffix(r.URL.Path, "/")
+		switch {
+		case r.Method == http.MethodGet && path == "/users/me-token-to-replace/messages":
+			_ = json.NewEncoder(w).Encode(map[string]any{"value": []map[string]any{{
+				"id": "message", "conversationId": "thread", "subject": "Status", "isRead": false,
+				"from":         map[string]any{"emailAddress": map[string]string{"address": "sender@example.com"}},
+				"toRecipients": []map[string]any{{"emailAddress": map[string]string{"address": "recipient@example.com"}}},
+				"body":         map[string]string{"content": "hello", "contentType": "text"},
+			}}})
+		case r.Method == http.MethodPost && path == "/users/me-token-to-replace/sendMail":
+			_ = json.NewDecoder(r.Body).Decode(&sent)
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	adapter, err := msgraphsdk.NewGraphRequestAdapterWithParseNodeFactoryAndSerializationWriterFactoryAndHttpClient(testAuth{}, nil, nil, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter.SetBaseUrl(server.URL)
+	p := New(msgraphsdk.NewGraphServiceClient(adapter))
+
+	// Act
+	inbox, readErr := p.ReadInbox(t.Context(), provider.ReadInboxRequest{Limit: 5})
+	_, sendErr := p.SendEmail(t.Context(), provider.SendEmailRequest{To: []string{"recipient@example.com"}, Subject: "Status", Body: "ready"})
+
+	// Assert
+	if readErr != nil || len(inbox.Messages) != 1 || inbox.Messages[0].ID != "message" || inbox.Messages[0].Body != "hello" || !inbox.Messages[0].Unread {
+		t.Fatalf("inbox = %+v, err = %v", inbox, readErr)
+	}
+	message, ok := sent["Message"].(map[string]any)
+	if sendErr != nil || !ok || message["subject"] != "Status" {
+		t.Fatalf("send payload = %+v, err = %v", sent, sendErr)
+	}
+}
+
+func TestProvider_rejectsMissingGraphClientAndInvalidCursor(t *testing.T) {
+	p := New(nil)
+	if err := p.Validate(context.Background()); err == nil {
+		t.Fatal("nil client was accepted")
+	}
+	if err := p.validCursor("https://example.com/next"); err == nil {
+		t.Fatal("foreign cursor was accepted")
+	}
+}
+
+func newRecipient(address string) models.Recipientable {
+	email := models.NewEmailAddress()
+	email.SetAddress(&address)
+	recipient := models.NewRecipient()
+	recipient.SetEmailAddress(email)
+	return recipient
+}
+
+type testAuth struct{}
+
+func (testAuth) AuthenticateRequest(_ context.Context, request *abstractions.RequestInformation, _ map[string]any) error {
+	request.Headers.Add("Authorization", "Bearer test")
+	return nil
+}

--- a/email/outlook/provider_test.go
+++ b/email/outlook/provider_test.go
@@ -46,11 +46,13 @@ func TestMessageFromSDK_mapsGraphMessage(t *testing.T) {
 func TestProvider_usesOfficialGraphSDKForInboxAndSend(t *testing.T) {
 	// Arrange
 	var sent map[string]any
+	var listFilter string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		path := strings.TrimSuffix(r.URL.Path, "/")
 		switch {
 		case r.Method == http.MethodGet && path == "/users/me-token-to-replace/messages":
+			listFilter = r.URL.Query().Get("$filter")
 			_ = json.NewEncoder(w).Encode(map[string]any{"value": []map[string]any{{
 				"id": "message", "conversationId": "thread", "subject": "Status", "isRead": false,
 				"from":         map[string]any{"emailAddress": map[string]string{"address": "sender@example.com"}},
@@ -73,16 +75,31 @@ func TestProvider_usesOfficialGraphSDKForInboxAndSend(t *testing.T) {
 	p := New(msgraphsdk.NewGraphServiceClient(adapter))
 
 	// Act
-	inbox, readErr := p.ReadInbox(t.Context(), provider.ReadInboxRequest{Limit: 5})
+	hasAttachment := true
+	inbox, readErr := p.ReadInbox(t.Context(), provider.ReadInboxRequest{From: "sender@example.com", To: "recipient@example.com", Subject: "Status", ReceivedAfter: "2026-08-01", ReceivedBefore: "2026-08-31", HasAttachment: &hasAttachment, UnreadOnly: true, Limit: 5})
 	_, sendErr := p.SendEmail(t.Context(), provider.SendEmailRequest{To: []string{"recipient@example.com"}, Subject: "Status", Body: "ready"})
 
 	// Assert
 	if readErr != nil || len(inbox.Messages) != 1 || inbox.Messages[0].ID != "message" || inbox.Messages[0].Body != "hello" || !inbox.Messages[0].Unread {
 		t.Fatalf("inbox = %+v, err = %v", inbox, readErr)
 	}
+	for _, want := range []string{"from/emailAddress/address eq 'sender@example.com'", "toRecipients/any(r:r/emailAddress/address eq 'recipient@example.com')", "contains(subject, 'Status')", "receivedDateTime ge 2026-08-01T00:00:00Z", "receivedDateTime lt 2026-09-01T00:00:00Z", "hasAttachments eq true", "isRead eq false"} {
+		if !strings.Contains(listFilter, want) {
+			t.Fatalf("filter = %q, want %q", listFilter, want)
+		}
+	}
 	message, ok := sent["Message"].(map[string]any)
 	if sendErr != nil || !ok || message["subject"] != "Status" {
 		t.Fatalf("send payload = %+v, err = %v", sent, sendErr)
+	}
+}
+
+func TestODataFilter_escapesStructuredFilters(t *testing.T) {
+	got := odataFilter(provider.ReadInboxRequest{From: "o'hara@example.com", Subject: "status's update"})
+	for _, want := range []string{"from/emailAddress/address eq 'o''hara@example.com'", "contains(subject, 'status''s update')"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("filter = %q, want %q", got, want)
+		}
 	}
 }
 

--- a/email/provider.go
+++ b/email/provider.go
@@ -59,11 +59,38 @@ func ValidateProvider(p Provider) error {
 
 // ReadInboxRequest selects messages from the configured inbox.
 type ReadInboxRequest struct {
-	Query      string `json:"query,omitempty"`
-	Mailbox    string `json:"mailbox,omitempty"`
-	UnreadOnly bool   `json:"unread_only,omitempty"`
-	Limit      int    `json:"limit,omitempty"`
-	Cursor     string `json:"cursor,omitempty"`
+	From           string `json:"from,omitempty"`
+	To             string `json:"to,omitempty"`
+	Subject        string `json:"subject,omitempty"`
+	ReceivedAfter  string `json:"received_after,omitempty"`
+	ReceivedBefore string `json:"received_before,omitempty"`
+	HasAttachment  *bool  `json:"has_attachment,omitempty"`
+	Mailbox        string `json:"mailbox,omitempty"`
+	UnreadOnly     bool   `json:"unread_only,omitempty"`
+	Limit          int    `json:"limit,omitempty"`
+	Cursor         string `json:"cursor,omitempty"`
+}
+
+// Validate checks portable inbox filter values. Dates use YYYY-MM-DD.
+func (r ReadInboxRequest) Validate() error {
+	var after, before time.Time
+	for _, filter := range []struct {
+		name, value string
+		target      *time.Time
+	}{{"received_after", r.ReceivedAfter, &after}, {"received_before", r.ReceivedBefore, &before}} {
+		if filter.value == "" {
+			continue
+		}
+		parsed, err := time.Parse(time.DateOnly, filter.value)
+		if err != nil {
+			return fmt.Errorf("email: %s must use YYYY-MM-DD", filter.name)
+		}
+		*filter.target = parsed
+	}
+	if !after.IsZero() && !before.IsZero() && after.After(before) {
+		return fmt.Errorf("email: received_after must not be after received_before")
+	}
+	return nil
 }
 
 // Inbox is one provider page of messages.

--- a/email/provider.go
+++ b/email/provider.go
@@ -1,0 +1,122 @@
+// Package email defines provider-neutral email capabilities for Tacklr agents.
+package email
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+)
+
+// ProviderKind identifies an email service supported by the harness.
+type ProviderKind string
+
+const (
+	ProviderGmail   ProviderKind = "gmail"
+	ProviderOutlook ProviderKind = "outlook"
+)
+
+// Valid reports whether the provider kind is supported by the harness.
+func (k ProviderKind) Valid() bool {
+	switch k {
+	case ProviderGmail, ProviderOutlook:
+		return true
+	default:
+		return false
+	}
+}
+
+// Provider supplies the operations exposed by the built-in email tools.
+// Implementations own authentication and provider-specific API behavior and
+// must support concurrent calls when an agent uses workers.
+type Provider interface {
+	Kind() ProviderKind
+	Validate(context.Context) error
+	ReadInbox(context.Context, ReadInboxRequest) (Inbox, error)
+	SendEmail(context.Context, SendEmailRequest) (SentEmail, error)
+}
+
+// ValidateProvider checks that p is usable as a supported provider capability.
+// A nil interface means that email integration is disabled.
+func ValidateProvider(p Provider) error {
+	if p == nil {
+		return nil
+	}
+	v := reflect.ValueOf(p)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		if !v.IsNil() {
+			break
+		}
+		return fmt.Errorf("email: provider must not be nil")
+	}
+	if !p.Kind().Valid() {
+		return fmt.Errorf("email: unsupported provider %q", p.Kind())
+	}
+	return nil
+}
+
+// ReadInboxRequest selects messages from the configured inbox.
+type ReadInboxRequest struct {
+	Query      string `json:"query,omitempty"`
+	Mailbox    string `json:"mailbox,omitempty"`
+	UnreadOnly bool   `json:"unread_only,omitempty"`
+	Limit      int    `json:"limit,omitempty"`
+	Cursor     string `json:"cursor,omitempty"`
+}
+
+// Inbox is one provider page of messages.
+type Inbox struct {
+	Messages   []Message `json:"messages"`
+	NextCursor string    `json:"next_cursor,omitempty"`
+}
+
+// Message is a provider-neutral email returned to the agent.
+type Message struct {
+	ID         string    `json:"id"`
+	ThreadID   string    `json:"thread_id,omitempty"`
+	From       string    `json:"from"`
+	To         []string  `json:"to,omitempty"`
+	CC         []string  `json:"cc,omitempty"`
+	Subject    string    `json:"subject,omitempty"`
+	Body       string    `json:"body,omitempty"`
+	ReceivedAt time.Time `json:"received_at"`
+	Unread     bool      `json:"unread"`
+}
+
+// SendEmailRequest is an outbound email composed by an agent.
+type SendEmailRequest struct {
+	To               []string `json:"to"`
+	CC               []string `json:"cc,omitempty"`
+	BCC              []string `json:"bcc,omitempty"`
+	Subject          string   `json:"subject"`
+	Body             string   `json:"body"`
+	ReplyToMessageID string   `json:"reply_to_message_id,omitempty"`
+}
+
+// Validate checks the provider-neutral requirements for an outbound email.
+func (r SendEmailRequest) Validate() error {
+	if len(r.To) == 0 {
+		return fmt.Errorf("email: at least one recipient is required")
+	}
+	recipients := append(append(append([]string{}, r.To...), r.CC...), r.BCC...)
+	for _, recipient := range recipients {
+		if strings.TrimSpace(recipient) == "" {
+			return fmt.Errorf("email: recipients must not be empty")
+		}
+	}
+	if strings.TrimSpace(r.Subject) == "" {
+		return fmt.Errorf("email: subject is required")
+	}
+	if strings.TrimSpace(r.Body) == "" {
+		return fmt.Errorf("email: body is required")
+	}
+	return nil
+}
+
+// SentEmail identifies the message accepted by the provider.
+type SentEmail struct {
+	ID       string `json:"id"`
+	ThreadID string `json:"thread_id,omitempty"`
+}

--- a/email/provider_test.go
+++ b/email/provider_test.go
@@ -1,0 +1,73 @@
+package email
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+type testProvider struct {
+	kind ProviderKind
+}
+
+func (p *testProvider) Kind() ProviderKind           { return p.kind }
+func (*testProvider) Validate(context.Context) error { return nil }
+func (*testProvider) ReadInbox(context.Context, ReadInboxRequest) (Inbox, error) {
+	return Inbox{}, nil
+}
+func (*testProvider) SendEmail(context.Context, SendEmailRequest) (SentEmail, error) {
+	return SentEmail{}, nil
+}
+
+func TestValidateProvider_supportedKindsAndNilValues(t *testing.T) {
+	var typedNil *testProvider
+	cases := []struct {
+		name     string
+		provider Provider
+		wantErr  string
+	}{
+		{name: "disabled"},
+		{name: "gmail", provider: &testProvider{kind: ProviderGmail}},
+		{name: "outlook", provider: &testProvider{kind: ProviderOutlook}},
+		{name: "typed nil", provider: typedNil, wantErr: "must not be nil"},
+		{name: "unsupported", provider: &testProvider{kind: "imap"}, wantErr: "unsupported provider"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateProvider(tc.provider)
+			if tc.wantErr == "" && err != nil {
+				t.Fatal(err)
+			}
+			if tc.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tc.wantErr)) {
+				t.Fatalf("error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestSendEmailRequest_validateRequiredContent(t *testing.T) {
+	cases := []struct {
+		name string
+		req  SendEmailRequest
+		want string
+	}{
+		{name: "valid", req: SendEmailRequest{To: []string{"a@example.com"}, Subject: "Subject", Body: "Body"}},
+		{name: "missing to", req: SendEmailRequest{Subject: "Subject", Body: "Body"}, want: "recipient"},
+		{name: "empty recipient", req: SendEmailRequest{To: []string{"a@example.com"}, CC: []string{" "}, Subject: "Subject", Body: "Body"}, want: "must not be empty"},
+		{name: "missing subject", req: SendEmailRequest{To: []string{"a@example.com"}, Body: "Body"}, want: "subject"},
+		{name: "missing body", req: SendEmailRequest{To: []string{"a@example.com"}, Subject: "Subject"}, want: "body"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.req.Validate()
+			if tc.want == "" && err != nil {
+				t.Fatal(err)
+			}
+			if tc.want != "" && (err == nil || !strings.Contains(err.Error(), tc.want)) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/email/provider_test.go
+++ b/email/provider_test.go
@@ -71,3 +71,28 @@ func TestSendEmailRequest_validateRequiredContent(t *testing.T) {
 		})
 	}
 }
+
+func TestReadInboxRequest_validateDates(t *testing.T) {
+	cases := []struct {
+		name string
+		req  ReadInboxRequest
+		want string
+	}{
+		{name: "valid range", req: ReadInboxRequest{ReceivedAfter: "2026-08-01", ReceivedBefore: "2026-08-31"}},
+		{name: "invalid after", req: ReadInboxRequest{ReceivedAfter: "08/01/2026"}, want: "received_after"},
+		{name: "invalid before", req: ReadInboxRequest{ReceivedBefore: "2026-08"}, want: "received_before"},
+		{name: "reversed range", req: ReadInboxRequest{ReceivedAfter: "2026-08-31", ReceivedBefore: "2026-08-01"}, want: "must not be after"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.req.Validate()
+			if tc.want == "" && err != nil {
+				t.Fatal(err)
+			}
+			if tc.want != "" && (err == nil || !strings.Contains(err.Error(), tc.want)) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/tools_email.go
+++ b/tools_email.go
@@ -11,11 +11,16 @@ import (
 const maxInboxMessages = 100
 
 type readInboxArgs struct {
-	Query      string `json:"query,omitempty" desc:"Optional provider search query."`
-	Mailbox    string `json:"mailbox,omitempty" desc:"Optional mailbox or folder. Omit to use the provider inbox."`
-	UnreadOnly bool   `json:"unread_only,omitempty" desc:"Return only unread messages when true."`
-	Limit      int    `json:"limit,omitempty" desc:"Maximum messages to return. Default 20, maximum 100."`
-	Cursor     string `json:"cursor,omitempty" desc:"Provider cursor returned by a previous read_inbox call."`
+	From           string `json:"from,omitempty" desc:"Optional sender email address."`
+	To             string `json:"to,omitempty" desc:"Optional recipient email address."`
+	Subject        string `json:"subject,omitempty" desc:"Optional text that must occur in the subject."`
+	ReceivedAfter  string `json:"received_after,omitempty" desc:"Optional inclusive earliest received date in YYYY-MM-DD format."`
+	ReceivedBefore string `json:"received_before,omitempty" desc:"Optional inclusive latest received date in YYYY-MM-DD format."`
+	HasAttachment  *bool  `json:"has_attachment,omitempty" desc:"Optional attachment filter. null means do not filter by attachments."`
+	Mailbox        string `json:"mailbox,omitempty" desc:"Optional mailbox or folder. Omit to use the provider inbox."`
+	UnreadOnly     bool   `json:"unread_only,omitempty" desc:"Return only unread messages when true."`
+	Limit          int    `json:"limit,omitempty" desc:"Maximum messages to return. Default 20, maximum 100."`
+	Cursor         string `json:"cursor,omitempty" desc:"Provider cursor returned by a previous read_inbox call."`
 }
 
 type sendEmailArgs struct {
@@ -43,13 +48,16 @@ func newEmailTools(provider mail.Provider) []*Tool {
 				if limit < 1 || limit > maxInboxMessages {
 					return mail.Inbox{}, fmt.Errorf("read_inbox: limit must be between 1 and %d", maxInboxMessages)
 				}
-				return provider.ReadInbox(ctx, mail.ReadInboxRequest{
-					Query:      args.Query,
-					Mailbox:    args.Mailbox,
-					UnreadOnly: args.UnreadOnly,
-					Limit:      limit,
-					Cursor:     args.Cursor,
-				})
+				req := mail.ReadInboxRequest{
+					From: args.From, To: args.To, Subject: args.Subject,
+					ReceivedAfter: args.ReceivedAfter, ReceivedBefore: args.ReceivedBefore,
+					HasAttachment: args.HasAttachment, Mailbox: args.Mailbox,
+					UnreadOnly: args.UnreadOnly, Limit: limit, Cursor: args.Cursor,
+				}
+				if err := req.Validate(); err != nil {
+					return mail.Inbox{}, fmt.Errorf("read_inbox: %w", err)
+				}
+				return provider.ReadInbox(ctx, req)
 			},
 		}),
 		NewTool(ToolConfig{

--- a/tools_email.go
+++ b/tools_email.go
@@ -1,0 +1,78 @@
+package tacklr
+
+import (
+	"context"
+	"fmt"
+
+	mail "github.com/ryanaldo34/tacklr/email"
+	"github.com/ryanaldo34/tacklr/streaming"
+)
+
+const maxInboxMessages = 100
+
+type readInboxArgs struct {
+	Query      string `json:"query,omitempty" desc:"Optional provider search query."`
+	Mailbox    string `json:"mailbox,omitempty" desc:"Optional mailbox or folder. Omit to use the provider inbox."`
+	UnreadOnly bool   `json:"unread_only,omitempty" desc:"Return only unread messages when true."`
+	Limit      int    `json:"limit,omitempty" desc:"Maximum messages to return. Default 20, maximum 100."`
+	Cursor     string `json:"cursor,omitempty" desc:"Provider cursor returned by a previous read_inbox call."`
+}
+
+type sendEmailArgs struct {
+	To               []string `json:"to" desc:"Primary recipient email addresses."`
+	CC               []string `json:"cc,omitempty" desc:"Optional carbon-copy recipient email addresses."`
+	BCC              []string `json:"bcc,omitempty" desc:"Optional blind-carbon-copy recipient email addresses."`
+	Subject          string   `json:"subject" desc:"Email subject."`
+	Body             string   `json:"body" desc:"Plaintext email body."`
+	ReplyToMessageID string   `json:"reply_to_message_id,omitempty" desc:"Optional provider message ID to reply to."`
+}
+
+func newEmailTools(provider mail.Provider) []*Tool {
+	return []*Tool{
+		NewTool(ToolConfig{
+			Name:        "read_inbox",
+			DisplayName: "Read Email Inbox",
+			Description: "Read and search messages in the configured email inbox.",
+			Category:    streaming.ToolCategoryRead,
+			Access:      ToolReadAccess,
+			Handler: func(ctx context.Context, args readInboxArgs) (mail.Inbox, error) {
+				limit := args.Limit
+				if limit == 0 {
+					limit = 20
+				}
+				if limit < 1 || limit > maxInboxMessages {
+					return mail.Inbox{}, fmt.Errorf("read_inbox: limit must be between 1 and %d", maxInboxMessages)
+				}
+				return provider.ReadInbox(ctx, mail.ReadInboxRequest{
+					Query:      args.Query,
+					Mailbox:    args.Mailbox,
+					UnreadOnly: args.UnreadOnly,
+					Limit:      limit,
+					Cursor:     args.Cursor,
+				})
+			},
+		}),
+		NewTool(ToolConfig{
+			Name:        "send_email",
+			DisplayName: "Send Email: {subject}",
+			Description: "Send an email through the configured email account. Confirm recipients and content before sending.",
+			Category:    streaming.ToolCategoryEdit,
+			Access:      ToolWriteAccess,
+			OnCall:      []OnCallFunc{ToolPermissionOnCall},
+			Handler: func(ctx context.Context, args sendEmailArgs) (mail.SentEmail, error) {
+				req := mail.SendEmailRequest{
+					To:               args.To,
+					CC:               args.CC,
+					BCC:              args.BCC,
+					Subject:          args.Subject,
+					Body:             args.Body,
+					ReplyToMessageID: args.ReplyToMessageID,
+				}
+				if err := req.Validate(); err != nil {
+					return mail.SentEmail{}, fmt.Errorf("send_email: %w", err)
+				}
+				return provider.SendEmail(ctx, req)
+			},
+		}),
+	}
+}

--- a/tools_email_test.go
+++ b/tools_email_test.go
@@ -52,7 +52,7 @@ func (p *fakeEmailProvider) SendEmail(_ context.Context, req mail.SendEmailReque
 func TestEmailProvider_injectsAndDelegatesBuiltins(t *testing.T) {
 	// Arrange
 	provider := &fakeEmailProvider{kind: mail.ProviderGmail}
-	h := mustNewAgent(t, AgentOptions{Model: &mockStrategy{}, EmailProvider: provider})
+	h := mustNewTurnManager(t, AgentOptions{Model: &mockStrategy{}, EmailProvider: provider})
 	t.Cleanup(h.Close)
 	readTool := h.findTool("read_inbox", "")
 	sendTool := h.findTool("send_email", "")
@@ -84,8 +84,8 @@ func TestEmailProvider_injectsAndDelegatesBuiltins(t *testing.T) {
 	if len(provider.sendRequest.To) != 1 || provider.sendRequest.Subject != "Status" || provider.sendRequest.ReplyToMessageID != "message-1" {
 		t.Fatalf("send request = %+v", provider.sendRequest)
 	}
-	if sendTool.Access != ToolWriteAccess || len(sendTool.OnCall) != 1 {
-		t.Fatalf("send tool access = %v, on-call layers = %d", sendTool.Access, len(sendTool.OnCall))
+	if sendTool.access != ToolWriteAccess || len(sendTool.onCall) != 1 {
+		t.Fatalf("send tool access = %v, on-call layers = %d", sendTool.access, len(sendTool.onCall))
 	}
 	if !strings.Contains(catalog, `"name":"read_inbox"`) || !strings.Contains(catalog, `"name":"send_email"`) {
 		t.Fatalf("model tool catalog missing email tools: %s", catalog)
@@ -121,7 +121,7 @@ func TestEmailProvider_rejectsInvalidConfiguration(t *testing.T) {
 	// Act and assert
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := NewAgent(t.Context(), AgentOptions{Model: &mockStrategy{}, EmailProvider: tc.provider})
+			_, err := NewTurnManager(t.Context(), AgentOptions{Model: &mockStrategy{}, EmailProvider: tc.provider})
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("error = %v, want %q", err, tc.want)
 			}
@@ -132,9 +132,10 @@ func TestEmailProvider_rejectsInvalidConfiguration(t *testing.T) {
 func TestEmailTools_validateRequestsAndPropagateToWorkers(t *testing.T) {
 	// Arrange
 	provider := &fakeEmailProvider{kind: mail.ProviderOutlook}
-	parent := mustNewAgent(t, AgentOptions{Model: &mockStrategy{}, EmailProvider: provider})
+	parentOpts := AgentOptions{Model: &mockStrategy{}, EmailProvider: provider}
+	parent := mustNewTurnManager(t, parentOpts)
 	t.Cleanup(parent.Close)
-	worker := mustNewAgent(t, parent.workerOptsFromSpec(&SubAgent{WorkerName: "mail", Model: &mockStrategy{}}))
+	worker := mustNewTurnManager(t, parentOpts.WithSpecialist(&Specialist{Name: "mail", Model: &mockStrategy{}}))
 	t.Cleanup(worker.Close)
 
 	// Act and assert
@@ -161,7 +162,7 @@ func TestEmailTools_validateRequestsAndPropagateToWorkers(t *testing.T) {
 		t.Fatalf("send provider error = %v", err)
 	}
 
-	withoutEmail := mustNewAgent(t, AgentOptions{Model: &mockStrategy{}})
+	withoutEmail := mustNewTurnManager(t, AgentOptions{Model: &mockStrategy{}})
 	t.Cleanup(withoutEmail.Close)
 	if withoutEmail.findTool("read_inbox", "") != nil || withoutEmail.findTool("send_email", "") != nil {
 		t.Fatal("email tools were injected without a provider")

--- a/tools_email_test.go
+++ b/tools_email_test.go
@@ -1,0 +1,154 @@
+package tacklr
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	mail "github.com/ryanaldo34/tacklr/email"
+)
+
+type fakeEmailProvider struct {
+	kind        mail.ProviderKind
+	validateErr error
+	validated   int
+	readRequest mail.ReadInboxRequest
+	sendRequest mail.SendEmailRequest
+	readErr     error
+	sendErr     error
+}
+
+func (p *fakeEmailProvider) Kind() mail.ProviderKind { return p.kind }
+
+func (p *fakeEmailProvider) Validate(context.Context) error {
+	p.validated++
+	return p.validateErr
+}
+
+func (p *fakeEmailProvider) ReadInbox(_ context.Context, req mail.ReadInboxRequest) (mail.Inbox, error) {
+	p.readRequest = req
+	if p.readErr != nil {
+		return mail.Inbox{}, p.readErr
+	}
+	return mail.Inbox{
+		Messages: []mail.Message{{
+			ID: "message-1", From: "sender@example.com", Subject: "Status",
+			ReceivedAt: time.Date(2026, time.August, 19, 12, 0, 0, 0, time.UTC), Unread: true,
+		}},
+		NextCursor: "page-2",
+	}, nil
+}
+
+func (p *fakeEmailProvider) SendEmail(_ context.Context, req mail.SendEmailRequest) (mail.SentEmail, error) {
+	p.sendRequest = req
+	if p.sendErr != nil {
+		return mail.SentEmail{}, p.sendErr
+	}
+	return mail.SentEmail{ID: "sent-1", ThreadID: "thread-1"}, nil
+}
+
+func TestEmailProvider_injectsAndDelegatesBuiltins(t *testing.T) {
+	// Arrange
+	provider := &fakeEmailProvider{kind: mail.ProviderGmail}
+	h := mustNewAgent(t, AgentOptions{Model: &mockStrategy{}, EmailProvider: provider})
+	t.Cleanup(h.Close)
+	readTool := h.findTool("read_inbox", "")
+	sendTool := h.findTool("send_email", "")
+	if readTool == nil || sendTool == nil {
+		t.Fatal("email tools were not injected")
+	}
+
+	// Act
+	readResult, readErr := readTool.invoke(t.Context(), `{"query":"from:sender","unread_only":true}`, nopRuntime())
+	sendResult, sendErr := sendTool.invoke(t.Context(), `{
+		"to":["owner@example.com"],"cc":[],"bcc":[],"subject":"Status","body":"Ready",
+		"reply_to_message_id":"message-1"
+	}`, nopRuntime())
+	catalog := ToolsAsJson(h.tools)
+
+	// Assert
+	if provider.validated != 1 {
+		t.Fatalf("provider validation calls = %d, want 1", provider.validated)
+	}
+	if readErr != nil || !strings.Contains(readResult.output, `"id":"message-1"`) || !strings.Contains(readResult.output, `"next_cursor":"page-2"`) {
+		t.Fatalf("read result = %q, err = %v", readResult.output, readErr)
+	}
+	if provider.readRequest.Query != "from:sender" || !provider.readRequest.UnreadOnly || provider.readRequest.Limit != 20 {
+		t.Fatalf("read request = %+v", provider.readRequest)
+	}
+	if sendErr != nil || !strings.Contains(sendResult.output, `"id":"sent-1"`) {
+		t.Fatalf("send result = %q, err = %v", sendResult.output, sendErr)
+	}
+	if len(provider.sendRequest.To) != 1 || provider.sendRequest.Subject != "Status" || provider.sendRequest.ReplyToMessageID != "message-1" {
+		t.Fatalf("send request = %+v", provider.sendRequest)
+	}
+	if sendTool.Access != ToolWriteAccess || len(sendTool.OnCall) != 1 {
+		t.Fatalf("send tool access = %v, on-call layers = %d", sendTool.Access, len(sendTool.OnCall))
+	}
+	if !strings.Contains(catalog, `"name":"read_inbox"`) || !strings.Contains(catalog, `"name":"send_email"`) {
+		t.Fatalf("model tool catalog missing email tools: %s", catalog)
+	}
+}
+
+func TestEmailProvider_rejectsInvalidConfiguration(t *testing.T) {
+	// Arrange
+	validationFailure := errors.New("credentials expired")
+	var nilProvider *fakeEmailProvider
+	cases := []struct {
+		name     string
+		provider mail.Provider
+		want     string
+	}{
+		{name: "typed nil", provider: nilProvider, want: "must not be nil"},
+		{name: "unsupported kind", provider: &fakeEmailProvider{kind: "imap"}, want: "unsupported provider"},
+		{name: "provider validation", provider: &fakeEmailProvider{kind: mail.ProviderOutlook, validateErr: validationFailure}, want: "credentials expired"},
+	}
+
+	// Act and assert
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewAgent(t.Context(), AgentOptions{Model: &mockStrategy{}, EmailProvider: tc.provider})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestEmailTools_validateRequestsAndPropagateToWorkers(t *testing.T) {
+	// Arrange
+	provider := &fakeEmailProvider{kind: mail.ProviderOutlook}
+	parent := mustNewAgent(t, AgentOptions{Model: &mockStrategy{}, EmailProvider: provider})
+	t.Cleanup(parent.Close)
+	worker := mustNewAgent(t, parent.workerOptsFromSpec(&SubAgent{WorkerName: "mail", Model: &mockStrategy{}}))
+	t.Cleanup(worker.Close)
+
+	// Act and assert
+	if worker.findTool("read_inbox", "") == nil || worker.findTool("send_email", "") == nil {
+		t.Fatal("worker did not inherit email tools")
+	}
+	readTool := parent.findTool("read_inbox", "")
+	if _, err := readTool.invoke(t.Context(), `{"limit":101}`, nopRuntime()); err == nil || !strings.Contains(err.Error(), "between 1 and 100") {
+		t.Fatalf("read limit error = %v", err)
+	}
+	sendTool := parent.findTool("send_email", "")
+	if _, err := sendTool.invoke(t.Context(), `{"to":[],"cc":[],"bcc":[],"subject":"","body":"","reply_to_message_id":""}`, nopRuntime()); err == nil || !strings.Contains(err.Error(), "recipient") {
+		t.Fatalf("send validation error = %v", err)
+	}
+	provider.readErr = errors.New("inbox unavailable")
+	if _, err := readTool.invoke(t.Context(), `{}`, nopRuntime()); !errors.Is(err, provider.readErr) {
+		t.Fatalf("read provider error = %v", err)
+	}
+	provider.sendErr = errors.New("send rejected")
+	if _, err := sendTool.invoke(t.Context(), `{"to":["a@example.com"],"cc":[],"bcc":[],"subject":"S","body":"B","reply_to_message_id":""}`, nopRuntime()); !errors.Is(err, provider.sendErr) {
+		t.Fatalf("send provider error = %v", err)
+	}
+
+	withoutEmail := mustNewAgent(t, AgentOptions{Model: &mockStrategy{}})
+	t.Cleanup(withoutEmail.Close)
+	if withoutEmail.findTool("read_inbox", "") != nil || withoutEmail.findTool("send_email", "") != nil {
+		t.Fatal("email tools were injected without a provider")
+	}
+}

--- a/tools_email_test.go
+++ b/tools_email_test.go
@@ -61,7 +61,7 @@ func TestEmailProvider_injectsAndDelegatesBuiltins(t *testing.T) {
 	}
 
 	// Act
-	readResult, readErr := readTool.invoke(t.Context(), `{"query":"from:sender","unread_only":true}`, nopRuntime())
+	readResult, readErr := readTool.invoke(t.Context(), `{"from":"sender@example.com","to":"owner@example.com","subject":"Status","received_after":"2026-08-01","received_before":"2026-08-31","has_attachment":true,"unread_only":true}`, nopRuntime())
 	sendResult, sendErr := sendTool.invoke(t.Context(), `{
 		"to":["owner@example.com"],"cc":[],"bcc":[],"subject":"Status","body":"Ready",
 		"reply_to_message_id":"message-1"
@@ -75,7 +75,7 @@ func TestEmailProvider_injectsAndDelegatesBuiltins(t *testing.T) {
 	if readErr != nil || !strings.Contains(readResult.output, `"id":"message-1"`) || !strings.Contains(readResult.output, `"next_cursor":"page-2"`) {
 		t.Fatalf("read result = %q, err = %v", readResult.output, readErr)
 	}
-	if provider.readRequest.Query != "from:sender" || !provider.readRequest.UnreadOnly || provider.readRequest.Limit != 20 {
+	if provider.readRequest.From != "sender@example.com" || provider.readRequest.To != "owner@example.com" || provider.readRequest.Subject != "Status" || provider.readRequest.ReceivedAfter != "2026-08-01" || provider.readRequest.HasAttachment == nil || !*provider.readRequest.HasAttachment || !provider.readRequest.UnreadOnly || provider.readRequest.Limit != 20 {
 		t.Fatalf("read request = %+v", provider.readRequest)
 	}
 	if sendErr != nil || !strings.Contains(sendResult.output, `"id":"sent-1"`) {
@@ -89,6 +89,18 @@ func TestEmailProvider_injectsAndDelegatesBuiltins(t *testing.T) {
 	}
 	if !strings.Contains(catalog, `"name":"read_inbox"`) || !strings.Contains(catalog, `"name":"send_email"`) {
 		t.Fatalf("model tool catalog missing email tools: %s", catalog)
+	}
+	properties, ok := readTool.parameters["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("read_inbox schema properties = %#v", readTool.parameters)
+	}
+	if _, exists := properties["query"]; exists {
+		t.Fatal("read_inbox schema exposes a provider query parameter")
+	}
+	for _, name := range []string{"from", "to", "subject", "received_after", "received_before", "has_attachment"} {
+		if _, exists := properties[name]; !exists {
+			t.Fatalf("read_inbox schema missing %q", name)
+		}
 	}
 }
 
@@ -132,6 +144,9 @@ func TestEmailTools_validateRequestsAndPropagateToWorkers(t *testing.T) {
 	readTool := parent.findTool("read_inbox", "")
 	if _, err := readTool.invoke(t.Context(), `{"limit":101}`, nopRuntime()); err == nil || !strings.Contains(err.Error(), "between 1 and 100") {
 		t.Fatalf("read limit error = %v", err)
+	}
+	if _, err := readTool.invoke(t.Context(), `{"received_after":"not-a-date"}`, nopRuntime()); err == nil || !strings.Contains(err.Error(), "YYYY-MM-DD") {
+		t.Fatalf("read filter validation error = %v", err)
 	}
 	sendTool := parent.findTool("send_email", "")
 	if _, err := sendTool.invoke(t.Context(), `{"to":[],"cc":[],"bcc":[],"subject":"","body":"","reply_to_message_id":""}`, nopRuntime()); err == nil || !strings.Contains(err.Error(), "recipient") {


### PR DESCRIPTION
Adds optional email inbox support to Tacklr agents.
Hosts can provide an `email.Provider` through `AgentOptions.EmailProvider`. The provider must identify as Gmail or Outlook and is responsible for authentication and API access.

When configured, Tacklr automatically exposes these built-in tools to the agent:

- `read_inbox` reads or searches inbox messages with optional filters, pagination, and unread-only support.
- `send_email` sends an email through the configured provider. It requires normal tool permission approval before sending.

The provider is validated during agent setup and inherited by subagents. If no email provider is configured, no email tools are added.