### PR TITLE
Encapsulate the public SDK behind one root init

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ tool := tacklr.NewTool(tacklr.ToolConfig{
 })
 ```
 
+Construct with `NewTool(ToolConfig{...})`. After construction, read metadata through getters (`Name()`, `Access()`, and the rest). Importing `tacklr` registers built-in interrupts, Word/Excel codecs, and the durable driver adapter. VFS backend factories and brain kinds stay host-owned.
+
 ### Sessions
 
 ```go
@@ -218,7 +220,7 @@ That boundary exists so product code cannot accidentally trash planning.
 
 ### VFS
 
-Register backends, bootstrap mounts—[docs/vfs.md](docs/vfs.md). When VFS is wired, the harness injects file tools (`read`, `write`, `run_command`) over **virtual paths only**. The agent never gets a host path or a bucket key. Live names/grep/tree ops go through `run_command` (`ls` / `fd` / `rg` / `mkdir` / `rm`). With Brain + VFS + search namespace, the harness registers **`brain.BrainFactory`**, mounts **`/engram`** (prefix, `IndexPolicy=none`) unless the host already provided a brain-profile mount, and injects **`index_file` / `unindex`** for **artifact** mounts only. Indexed recall is brain `search`; objects without a file use `read_object`. Engrams are Markdown files on the brain Provider; `save_*` writes those paths (or `Engine.Put` if no brain mount). Path-native **link / unlink / expand / find_links**. Artifact → brain still uses one **IndexPath** pipeline (hash skip). Brain-profile mounts are never remirrored as Document/Chunk artifacts.
+Register backends, bootstrap mounts—[docs/vfs.md](docs/vfs.md). When VFS is wired, the harness injects file tools (`read`, `write`, `run_command`) over **virtual paths only**. `run_command` requires permission by default. The agent never gets a host path or a bucket key. Live names/grep/tree ops go through `run_command` (`ls` / `fd` / `rg` / `mkdir` / `rm`). With Brain + VFS + search namespace, the harness registers **`brain.BrainFactory`**, mounts **`/engram`** (prefix, `IndexPolicy=none`) unless the host already provided a brain-profile mount, and injects **`index_file` / `unindex`** for **artifact** mounts only. Indexed recall is brain `search`; objects without a file use `read_object`. Engrams are Markdown files on the brain Provider; `save_*` writes those paths (or `Engine.Put` if no brain mount). Path-native **link / unlink / expand / find_links**. Artifact → brain still uses one **IndexPath** pipeline (hash skip). Brain-profile mounts are never remirrored as Document/Chunk artifacts.
 
 ---
 

--- a/agent.go
+++ b/agent.go
@@ -23,7 +23,9 @@ import (
 )
 
 // AgentHarness is the product agent. Create with NewAgent.
-// Fields are unexported. Session conversation is persisted by durable.Runtime
+// Hosts use Run / RunMessage / ReturnFromInterrupt, Checkpoint /
+// RestoreCheckpoint, Close, VFS, SessionID, and Messages. Fields are
+// unexported. Session conversation is persisted by durable.Runtime
 // via Checkpoint/RestoreCheckpoint, not by this type.
 type AgentHarness struct {
 	model                 InferenceStrategy

--- a/agent.go
+++ b/agent.go
@@ -71,7 +71,7 @@ type AgentHarness struct {
 	mcpCleanup       func()
 	mcpInitialized   bool
 	builtinsInjected bool
-	context          ContextManager
+	context          contextManager
 	tasks            modelTasks
 	contextPolicy    ContextPolicy
 	toolRunner       *toolRunner
@@ -301,7 +301,7 @@ func (a *AgentHarness) applyBatchToolResultEffect(ctx context.Context, effect To
 
 func (a *AgentHarness) findTool(name, namespace string) *Tool {
 	idx := slices.IndexFunc(a.tools, func(t *Tool) bool {
-		return t.Name == name && t.Namespace == namespace
+		return t.name == name && t.namespace == namespace
 	})
 	if idx < 0 {
 		return nil
@@ -351,8 +351,8 @@ func (a *AgentHarness) withToolPresentation(tc ToolCall) ToolCall {
 	if tool == nil {
 		return tc
 	}
-	tc.Category = tool.Category
-	tc.Title = ResolveToolTitle(tool.DisplayName, tool.Name, tc.Arguments)
+	tc.Category = tool.category
+	tc.Title = ResolveToolTitle(tool.displayName, tool.name, tc.Arguments)
 	return tc
 }
 

--- a/agent_construct.go
+++ b/agent_construct.go
@@ -97,9 +97,10 @@ type AgentOptions struct {
 	// projection is available. Embedders pass their own. The injector Closes
 	// it after the turn; the harness never does (workers inherit the pointer).
 	MountSession *vfs.MountSession
-	// RunCommandUnattended injects run_command without ToolPermissionOnCall.
-	// Zero value parks run_command for permission.
-	RunCommandUnattended bool
+	// runCommandUnattended injects run_command without ToolPermissionOnCall.
+	// Zero value parks run_command for permission. Unexported so hosts cannot
+	// disable the permission park from AgentOptions.
+	runCommandUnattended bool
 	// shareIndexBridge is the parent index bridge. Nil means Start a new bridge.
 	shareIndexBridge *vfsindex.Bridge
 }
@@ -136,9 +137,9 @@ func NewAgent(ctx context.Context, opts AgentOptions) (*AgentHarness, error) {
 		interruptPayloads:     make(map[string][]byte),
 		parkedWorkersLive:     make(map[string]*AgentHarness),
 		jobs:                  make(map[string]*workerRun),
-		context:               NewModelContextManager(),
+		context:               newModelContextManager(),
 		contextPolicy:         opts.ContextPolicy,
-		runCommandUnattended:  opts.RunCommandUnattended,
+		runCommandUnattended:  opts.runCommandUnattended,
 		writeUnattended:       opts.writeUnattended,
 		vfsBridge:             opts.shareIndexBridge,
 	}
@@ -325,7 +326,7 @@ func (a *AgentHarness) SearchNamespace() (uuid.UUID, bool) {
 
 // planningWriteLock blocks write tools until create_plan has set a plan.
 func (a *AgentHarness) planningWriteLock(ctx context.Context, inv ToolInvocation, next ToolCallFunc) (string, error) {
-	if inv.Tool != nil && inv.Tool.Access.Allows(WritePermission) &&
+	if inv.Tool != nil && inv.Tool.access.Allows(WritePermission) &&
 		!a.session.Plan.HasActive() {
 		return "", fmt.Errorf("%w: write tools are locked until create_plan establishes a todo list", ErrToolPermissionDenied)
 	}

--- a/agent_run.go
+++ b/agent_run.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/ryanaldo34/tacklr/internal/drive"
 	"github.com/ryanaldo34/tacklr/interrupt"
 	"github.com/ryanaldo34/tacklr/stores"
 	"github.com/ryanaldo34/tacklr/telemetry"
@@ -34,13 +35,13 @@ func (a *AgentHarness) RunMessage(ctx context.Context, user *Message) (<-chan St
 // ReturnFromInterrupt applies host resolutions and resumes the parked tool batch.
 // Keys are tool call ids, which are also the wire interrupt ids.
 func (a *AgentHarness) ReturnFromInterrupt(ctx context.Context, finishedInterrupts map[string][]byte) (<-chan StreamEvent, error) {
-	if err := a.ApplyResume(finishedInterrupts); err != nil {
+	if err := a.applyResume(finishedInterrupts); err != nil {
 		return nil, err
 	}
 	return a.startTurn(ctx, nil)
 }
 
-func (a *AgentHarness) ApplyResume(finishedInterrupts map[string][]byte) error {
+func (a *AgentHarness) applyResume(finishedInterrupts map[string][]byte) error {
 	a.pendingMu.Lock()
 	defer a.pendingMu.Unlock()
 	if a.interruptPayloads == nil {
@@ -101,7 +102,7 @@ func (a *AgentHarness) startTurn(ctx context.Context, user *Message) (<-chan Str
 		}
 
 		if user != nil {
-			if err := a.AbsorbUser(ctx, user, out); err != nil {
+			if err := a.absorbUser(ctx, user, out); err != nil {
 				if ctx.Err() != nil {
 					emitCancelled()
 					return
@@ -122,7 +123,7 @@ func (a *AgentHarness) startTurn(ctx context.Context, user *Message) (<-chan Str
 }
 
 func (a *AgentHarness) runTurnLoop(ctx context.Context, out chan StreamEvent, emitCancelled func()) string {
-	st := &TurnState{}
+	st := &drive.TurnState{}
 	for {
 		if ctx.Err() != nil {
 			emitCancelled()
@@ -131,7 +132,7 @@ func (a *AgentHarness) runTurnLoop(ctx context.Context, out chan StreamEvent, em
 		var toolCalls []ToolCall
 		pending := a.pendingSnapshot()
 		if len(pending) == 0 {
-			step, err := a.RunInference(ctx, st, out)
+			step, err := a.runInference(ctx, st, out)
 			if ctx.Err() != nil {
 				emitCancelled()
 				return telemetry.OutcomeCancelled
@@ -166,7 +167,7 @@ func (a *AgentHarness) runTurnLoop(ctx context.Context, out chan StreamEvent, em
 				if ctx.Err() != nil {
 					return
 				}
-				_, _ = a.RunToolCall(ctx, tc, out)
+				_, _ = a.runToolCall(ctx, tc, out)
 			}(tc)
 		}
 		wg.Wait()

--- a/context_manager.go
+++ b/context_manager.go
@@ -39,10 +39,10 @@ func DefaultContextPolicy() ContextPolicy {
 	}
 }
 
-// ContextManager owns the conversation window structure only (no inference).
+// contextManager owns the conversation window structure only (no inference).
 // modelTasks does model work and applies results with Replace or InstallPlanDocument.
 // Messages must be safe while another path Absorbs or Replaces after resume.
-type ContextManager interface {
+type contextManager interface {
 	// Messages returns a retainable snapshot of the live window (also used for checkpoints).
 	Messages() []*Message
 	// Restore copies window into storage (caller keeps its slice).
@@ -55,18 +55,17 @@ type ContextManager interface {
 	InstallPlanDocument(planRaw string) error
 }
 
-// ModelContextManager is the default ContextManager (name is historical).
-type ModelContextManager struct {
+// modelContextManager is the default contextManager (name is historical).
+type modelContextManager struct {
 	mu     sync.RWMutex
 	window []*Message
 }
 
-// NewModelContextManager returns an empty ContextManager.
-func NewModelContextManager() *ModelContextManager {
-	return &ModelContextManager{}
+func newModelContextManager() *modelContextManager {
+	return &modelContextManager{}
 }
 
-func (m *ModelContextManager) Messages() []*Message {
+func (m *modelContextManager) Messages() []*Message {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	if len(m.window) == 0 {
@@ -75,7 +74,7 @@ func (m *ModelContextManager) Messages() []*Message {
 	return slices.Clone(m.window)
 }
 
-func (m *ModelContextManager) Restore(window []*Message) {
+func (m *modelContextManager) Restore(window []*Message) {
 	assertValidContextWindow(window)
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -86,14 +85,14 @@ func (m *ModelContextManager) Restore(window []*Message) {
 	m.window = slices.Clone(window)
 }
 
-func (m *ModelContextManager) Replace(window []*Message) {
+func (m *modelContextManager) Replace(window []*Message) {
 	assertValidContextWindow(window)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.window = window
 }
 
-func (m *ModelContextManager) Add(msg *Message) {
+func (m *modelContextManager) Add(msg *Message) {
 	if err := streaming.ValidateMessages([]*Message{msg}); err != nil {
 		panic("tacklr: invalid context message: " + err.Error())
 	}
@@ -108,7 +107,7 @@ func assertValidContextWindow(window []*Message) {
 	}
 }
 
-func (m *ModelContextManager) InstallPlanDocument(planRaw string) error {
+func (m *modelContextManager) InstallPlanDocument(planRaw string) error {
 	if planRaw == "" {
 		return fmt.Errorf("install plan document: no plan document")
 	}

--- a/context_manager_test.go
+++ b/context_manager_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestModelContextManager_enforcesMessageInvariantsAtMutation(t *testing.T) {
 	// Arrange
-	manager := NewModelContextManager()
+	manager := newModelContextManager()
 	assertPanics := func(name string, fn func()) {
 		t.Helper()
 		t.Run(name, func(t *testing.T) {
@@ -49,7 +49,7 @@ func TestContextPolicy_validateRejectsInvalidRatios(t *testing.T) {
 }
 
 func TestModelContextManager_installPlanDocument(t *testing.T) {
-	manager := NewModelContextManager()
+	manager := newModelContextManager()
 
 	if err := manager.InstallPlanDocument(""); err == nil || !strings.Contains(err.Error(), "no plan document") {
 		t.Fatalf("empty plan error = %v", err)

--- a/doc.go
+++ b/doc.go
@@ -7,6 +7,10 @@
 //   - vfs owns virtual filesystem providers and mount sessions.
 //   - mcp owns MCP connection configuration.
 //
+// Process-wide registrations (built-in interrupts, common VFS codecs, the
+// durable driver adapter) run in this package's init. Hosts import tacklr
+// once; they do not register those defaults themselves.
+//
 // New APIs should use the canonical domain packages and must not add server
 // transport, wire protocol, persistence backend, or provider-client details
 // here.

--- a/docs/durable.md
+++ b/docs/durable.md
@@ -12,7 +12,7 @@ events, _ := h.Run(ctx, prompt)
 // HITL: read yield, then h.ReturnFromInterrupt
 ```
 
-Human-in-the-loop waits in-process on the same harness. Persistence is `h.Checkpoint` / `h.RestoreCheckpoint` (the same blob `durable.Runtime` writes to SnapshotStore). This path does not require Temporal.
+Human-in-the-loop waits in-process on the same harness. Persistence is `h.Checkpoint` / `h.RestoreCheckpoint` (the same blob `durable.Runtime` writes to SnapshotStore). This path does not require Temporal. Durable drivers call unexported harness steps through `internal/drive`; that adapter is not a host API.
 
 ## Path B — in-process Runtime
 

--- a/docs/fuse-vfs-run-command.md
+++ b/docs/fuse-vfs-run-command.md
@@ -48,7 +48,7 @@ The **agent file catalog** is collapsed. Discovery (`find_files`, `find_content`
 
 **Byte identity (shipped).** Textual FUSE `Read` / `getattr` use `ReadText`. Binaries use `Stat` + `io.ReaderAt`. Writes are write-through, so host `rg` sees the last persist, not a dirty IR buffer.
 
-**`run_command` (shipped).** `tools_vfs.go`. cwd = `HostDir()`; empty HostDir → `ErrFuseNotMounted`. Timeout 60 s, 1 MiB shared stdout+stderr, `Setpgid` + kill group, `exit=N` is success. `PermissionRequired` unless `RunCommandUnattended`. Injected when `session.VFS != nil`.
+**`run_command` (shipped).** `tools_vfs.go`. cwd = `HostDir()`; empty HostDir → `ErrFuseNotMounted`. Timeout 60 s, 1 MiB shared stdout+stderr, `Setpgid` + kill group, `exit=N` is success. `PermissionRequired` by default. Injected when `session.VFS != nil`.
 
 ---
 
@@ -195,7 +195,7 @@ Update `docs/vfs.md`, `docs/knowledge.md`, `README.md`, `vfs/doc.go` so they mat
 1. FUSE root is virtual `/`. Single-segment points only.
 2. Harness tools, `MountInfo`, `Specs`, and checkpoints never print `HostDir`. The child may `pwd` it.
 3. `run_command` is cwd-only `/bin/sh -c`. No chroot in this train. Residual escape risk is documented, not tested as a negative.
-4. Registry `run_command` is `PermissionRequired: true` unless `RunCommandUnattended`.
+4. Registry `run_command` is `PermissionRequired: true` by default.
 5. `list` / `stat` stay whenever a `MountSession` exists. Do not gate them on `FuseAvailable()`.
 6. `write` modes are counted by field presence. IR body field is `ir_text`.
 7. Tests assert positive outcomes. Kernel and host-exec tests `Skip` without a FUSE device.
@@ -268,7 +268,7 @@ Each PR is independently reviewable. Do not combine Phase 3 removal with the `wr
 - `tools_vfs.go` — `read`, `write`, `run_command`
 - `tools_vfsindex.go` — `index_file` / `unindex` / `find_content` (until PR A)
 - `agent.go` — turn-scoped `Close` (does not close MountSession)
-- `agent_construct.go` — `injectBuiltinTools`, `RunCommandUnattended`
+- `agent_construct.go` — `injectBuiltinTools`
 - Runtime catalog `FSBootstrap` — `Point: /work`
 - `docs/vfs.md`, `docs/knowledge.md`, `README.md` — update in PR D
 

--- a/docs/vfs.md
+++ b/docs/vfs.md
@@ -237,7 +237,8 @@ Tool guidance:
 |------|------|
 | Read | `ReadFile` once (32 MiB cap) |
 | Detect | **Provider** sets `FileInfo.MediaType` on Stat (S3 Content-Type or key/name; local extension + peek). Session does not sniff. |
-| Lookup | `ContentRegistry` media type → `Codec` |
+| Lookup | `ContentRegistry` media type → `Codec` (`Lookup`) |
+| Register | First binding wins. A second `Register` for the same media type returns `ErrAlreadyRegistered`. `adapters.RegisterCommon` is idempotent (skips DOCX/XLSX when already bound). Importing `tacklr` registers Word/Excel on the process default registry. |
 | Fallback | Unregistered but text-like (`text/*`, JSON, YAML, …) → `TextCodec` |
 | Decode | `Codec.Decode(path, mediaType, data)` — no second read or re-sniff |
 | Else | `ErrNoCodec` (e.g. PNG) |

--- a/docs/vfs.md
+++ b/docs/vfs.md
@@ -509,7 +509,7 @@ When the harness has **Brain + MountSession + search namespace**, it owns a
 |------|------|
 | `index_file` | Selective ingest of key virtual **files** (max 8); errors under `none` |
 | `unindex` | Soft-delete the brain mirror; drops selective track |
-| `run_command` | `/bin/sh -c` with cwd = FUSE root; relative paths (`work/foo`); `PermissionRequired` unless `RunCommandUnattended` |
+| `run_command` | `/bin/sh -c` with cwd = FUSE root; relative paths (`work/foo`); `PermissionRequired` by default |
 | `read` / `write` | File window / first page / block read; one mutation mode. Knowledge objects: `read_object`. |
 | `save_*` | Write the Engram file on the brain Provider (or `Engine.Put` if no brain mount) |
 | `link` / `expand` / `find_links` | Path-native graph (G1): prefer virtual paths; surface neighbor `vfs_path` |

--- a/durable/inprocess/driver.go
+++ b/durable/inprocess/driver.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ryanaldo34/tacklr"
 	"github.com/ryanaldo34/tacklr/durable"
+	"github.com/ryanaldo34/tacklr/internal/drive"
 	"github.com/ryanaldo34/tacklr/mcp"
 	"github.com/ryanaldo34/tacklr/streaming"
 	"github.com/ryanaldo34/tacklr/telemetry"
@@ -107,7 +108,8 @@ func (r *Runtime) driveTurn(ctx context.Context, p *sessionProc, user *tacklr.Me
 		durable.CloseTurnVFS(ms, string(p.id), "turn_end")
 	}()
 
-	out, stop := tacklr.PipeStreamEvents(func(ev streaming.StreamEvent) { r.emit(ctx, p, ev) })
+	eng := drive.EngineOf(h)
+	out, stop := drive.PipeStreamEvents(func(ev streaming.StreamEvent) { r.emit(ctx, p, ev) })
 	defer stop()
 
 	cancelled := func() turnOutcome {
@@ -119,11 +121,11 @@ func (r *Runtime) driveTurn(ctx context.Context, p *sessionProc, user *tacklr.Me
 	}
 
 	if len(resume) > 0 {
-		if err := h.ApplyResume(resume); err != nil {
+		if err := eng.ApplyResume(resume); err != nil {
 			return r.fail(ctx, p, err)
 		}
 	} else if user != nil {
-		if err := h.AbsorbUser(ctx, user, out); err != nil {
+		if err := eng.AbsorbUser(ctx, user, out); err != nil {
 			if ctx.Err() != nil {
 				return cancelled()
 			}
@@ -131,14 +133,14 @@ func (r *Runtime) driveTurn(ctx context.Context, p *sessionProc, user *tacklr.Me
 		}
 	}
 
-	st := &tacklr.TurnState{}
-	toolCalls := h.PendingToolCalls()
+	st := &drive.TurnState{}
+	toolCalls := eng.PendingToolCalls()
 	for {
 		if ctx.Err() != nil {
 			return cancelled()
 		}
 		if len(toolCalls) == 0 {
-			step, infErr := h.RunInference(ctx, st, out)
+			step, infErr := eng.RunInference(ctx, st, out)
 			if ctx.Err() != nil {
 				return cancelled()
 			}
@@ -163,7 +165,7 @@ func (r *Runtime) driveTurn(ctx context.Context, p *sessionProc, user *tacklr.Me
 			if ctx.Err() != nil {
 				return cancelled()
 			}
-			step, toolErr := h.RunToolCall(ctx, tc, out)
+			step, toolErr := eng.RunToolCall(ctx, tc, out)
 			if ctx.Err() != nil {
 				return cancelled()
 			}

--- a/durable/temporal/activities.go
+++ b/durable/temporal/activities.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ryanaldo34/tacklr"
 	"github.com/ryanaldo34/tacklr/durable"
+	"github.com/ryanaldo34/tacklr/internal/drive"
 	"github.com/ryanaldo34/tacklr/mcp"
 	"github.com/ryanaldo34/tacklr/streaming"
 	"github.com/ryanaldo34/tacklr/telemetry"
@@ -131,26 +132,27 @@ func (a *Activities) Inference(ctx context.Context, in InferenceInput) (Inferenc
 		h.Close()
 		durable.CloseTurnVFS(ms, string(in.SessionID), "inference")
 	}()
-	out, stop := tacklr.PipeStreamEvents(a.emitter(ctx, stream, in.SessionID))
+	eng := drive.EngineOf(h)
+	out, stop := drive.PipeStreamEvents(a.emitter(ctx, stream, in.SessionID))
 	defer stop()
 	if len(in.Resume) > 0 {
-		if err := h.ApplyResume(in.Resume); err != nil {
+		if err := eng.ApplyResume(in.Resume); err != nil {
 			_ = a.publish(ctx, stream, in.SessionID, durable.TopicEvents, streaming.StreamEvent{Type: streaming.StreamEventError, Error: err, Content: err.Error()}, true)
 			return InferenceOutput{}, canceledIf(ctx, err)
 		}
-		if pending := h.PendingToolCalls(); len(pending) > 0 {
+		if pending := eng.PendingToolCalls(); len(pending) > 0 {
 			etag, err = a.save(ctx, in.SessionID, in.AgentID, h, etag, in.Mounts)
 			return InferenceOutput{Etag: etag, ToolCalls: pending}, err
 		}
 	}
 	if in.User != nil {
-		if err := h.AbsorbUser(ctx, in.User, out); err != nil {
+		if err := eng.AbsorbUser(ctx, in.User, out); err != nil {
 			slog.ErrorContext(ctx, "inference absorb", "area", telemetry.AreaRuntime, "error", err)
 			return InferenceOutput{}, canceledIf(ctx, err)
 		}
 	}
-	st := &tacklr.TurnState{HadToolRound: in.HadToolRound, ModelRequests: in.ModelRequests}
-	step, err := h.RunInference(ctx, st, out)
+	st := &drive.TurnState{HadToolRound: in.HadToolRound, ModelRequests: in.ModelRequests}
+	step, err := eng.RunInference(ctx, st, out)
 	if err != nil {
 		pub := err
 		if ctx.Err() != nil {
@@ -205,9 +207,10 @@ func (a *Activities) Tool(ctx context.Context, in ToolInput) (ToolOutput, error)
 		h.Close()
 		durable.CloseTurnVFS(ms, string(in.SessionID), "tool")
 	}()
-	out, stop := tacklr.PipeStreamEvents(a.emitter(ctx, stream, in.SessionID))
+	eng := drive.EngineOf(h)
+	out, stop := drive.PipeStreamEvents(a.emitter(ctx, stream, in.SessionID))
 	defer stop()
-	step, runErr := h.RunToolCall(ctx, in.Call, out)
+	step, runErr := eng.RunToolCall(ctx, in.Call, out)
 	if runErr != nil && ctx.Err() != nil {
 		slog.WarnContext(ctx, "tool cancelled", "area", telemetry.AreaHarness, "tool", in.Call.Name)
 		_ = a.publish(ctx, stream, in.SessionID, durable.TopicEvents, streaming.StreamEvent{Type: streaming.StreamEventError, Error: context.Canceled, Content: context.Canceled.Error()}, true)

--- a/durable_steps.go
+++ b/durable_steps.go
@@ -6,35 +6,14 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ryanaldo34/tacklr/internal/drive"
 	"github.com/ryanaldo34/tacklr/internal/session"
 	"github.com/ryanaldo34/tacklr/interrupt"
 	"github.com/ryanaldo34/tacklr/stores"
 	"github.com/ryanaldo34/tacklr/telemetry"
 )
 
-// InferenceStep is the result of one model invocation for the durable driver.
-type InferenceStep struct {
-	ToolCalls []ToolCall
-	Complete  bool
-}
-
-// ToolStep is the result of one tool invocation for the durable driver.
-// Interrupted means the tool parked; the driver must persist, publish yield,
-// and wait for Resume. It must not block inside the tool function.
-type ToolStep struct {
-	Interrupted   bool
-	InterruptID   string
-	InterruptData []byte
-}
-
-// TurnState is per-slice counters for the durable inference loop.
-type TurnState struct {
-	ModelRequests int
-	HadToolRound  bool
-}
-
-// AbsorbUser adds a user message to the window (durable prompt start).
-func (a *AgentHarness) AbsorbUser(ctx context.Context, user *Message, out chan StreamEvent) error {
+func (a *AgentHarness) absorbUser(ctx context.Context, user *Message, out chan StreamEvent) error {
 	if user == nil {
 		return nil
 	}
@@ -45,8 +24,7 @@ func (a *AgentHarness) AbsorbUser(ctx context.Context, user *Message, out chan S
 	return a.addToContext(ctx, user, out)
 }
 
-// PendingToolCalls returns tool calls waiting to run (resume after yield).
-func (a *AgentHarness) PendingToolCalls() []ToolCall {
+func (a *AgentHarness) runnableToolCalls() []ToolCall {
 	pending := a.pendingSnapshot()
 	out := make([]ToolCall, 0, len(pending))
 	for _, tc := range pending {
@@ -78,17 +56,15 @@ func (a *AgentHarness) RestoreCheckpoint(cp stores.SessionCheckpoint) error {
 	return nil
 }
 
-// RunInference is the inference activity body: model Invoke plus StreamEvent
-// publish. Runtime drivers and in-process Run call this.
-func (a *AgentHarness) RunInference(ctx context.Context, st *TurnState, out chan StreamEvent) (InferenceStep, error) {
+func (a *AgentHarness) runInference(ctx context.Context, st *drive.TurnState, out chan StreamEvent) (drive.InferenceStep, error) {
 	if st == nil {
-		st = &TurnState{}
+		st = &drive.TurnState{}
 	}
 
 	if a.maxTurnRequests > 0 && st.ModelRequests >= a.maxTurnRequests {
 		err := fmt.Errorf("%w: limit %d", ErrMaxTurnRequests, a.maxTurnRequests)
 		out <- StreamEvent{Type: StreamEventError, Error: err}
-		return InferenceStep{}, err
+		return drive.InferenceStep{}, err
 	}
 	turnCtx := ctx
 	if st.HadToolRound {
@@ -97,7 +73,7 @@ func (a *AgentHarness) RunInference(ctx context.Context, st *TurnState, out chan
 	events, err := a.tasks.Turn(turnCtx, a.tools, a.constructSystemPrompt())
 	if err != nil {
 		if ctx.Err() != nil {
-			return InferenceStep{}, ctx.Err()
+			return drive.InferenceStep{}, ctx.Err()
 		}
 		var outErr error
 		if st.HadToolRound {
@@ -106,7 +82,7 @@ func (a *AgentHarness) RunInference(ctx context.Context, st *TurnState, out chan
 			outErr = fmt.Errorf("model request failed: %w", err)
 		}
 		out <- StreamEvent{Type: StreamEventError, Error: outErr}
-		return InferenceStep{}, outErr
+		return drive.InferenceStep{}, outErr
 	}
 	st.ModelRequests++
 	asm := newStreamAssembler()
@@ -130,14 +106,14 @@ func (a *AgentHarness) RunInference(ctx context.Context, st *TurnState, out chan
 	for {
 		if err := ctx.Err(); err != nil {
 			failAnnounced("tool call cancelled")
-			return InferenceStep{}, err
+			return drive.InferenceStep{}, err
 		}
 		var chunk LLMResponseChunk
 		var ok bool
 		select {
 		case <-ctx.Done():
 			failAnnounced("tool call cancelled")
-			return InferenceStep{}, ctx.Err()
+			return drive.InferenceStep{}, ctx.Err()
 		case chunk, ok = <-events:
 		}
 		if !ok {
@@ -148,14 +124,14 @@ func (a *AgentHarness) RunInference(ctx context.Context, st *TurnState, out chan
 		}
 		if !a.streamChunk(ctx, chunk, out) {
 			failAnnounced("tool call cancelled")
-			return InferenceStep{}, ctx.Err()
+			return drive.InferenceStep{}, ctx.Err()
 		}
 		if chunk.Type == StreamEventError || chunk.Error != nil {
 			failAnnounced("model error")
 			if chunk.Error != nil {
-				return InferenceStep{}, chunk.Error
+				return drive.InferenceStep{}, chunk.Error
 			}
-			return InferenceStep{}, errors.New(chunk.Content)
+			return drive.InferenceStep{}, errors.New(chunk.Content)
 		}
 		if chunk.Type == StreamEventFunctionCall {
 			for _, tc := range chunk.ToolCalls {
@@ -181,7 +157,7 @@ func (a *AgentHarness) RunInference(ctx context.Context, st *TurnState, out chan
 	}
 	if ctx.Err() != nil {
 		failAnnounced("tool call cancelled")
-		return InferenceStep{}, ctx.Err()
+		return drive.InferenceStep{}, ctx.Err()
 	}
 	executable := make(map[string]struct{}, len(toolCalls))
 	for _, tc := range toolCalls {
@@ -205,25 +181,22 @@ func (a *AgentHarness) RunInference(ctx context.Context, st *TurnState, out chan
 	if len(toolCalls) == 0 {
 		if nudge := a.backgroundJobsNudge(); nudge != "" {
 			if err := a.addToContext(ctx, &Message{Role: RoleUser, Content: nudge}, out); err != nil {
-				return InferenceStep{}, err
+				return drive.InferenceStep{}, err
 			}
 			st.HadToolRound = true
-			return a.RunInference(ctx, st, out)
+			return a.runInference(ctx, st, out)
 		}
 		out <- StreamEvent{Type: StreamEventComplete}
-		return InferenceStep{Complete: true}, nil
+		return drive.InferenceStep{Complete: true}, nil
 	}
 	a.context.Add(&Message{
 		Role:      RoleAssistant,
 		ToolCalls: append([]ToolCall(nil), toolCalls...),
 	})
-	return InferenceStep{ToolCalls: toolCalls}, nil
+	return drive.InferenceStep{ToolCalls: toolCalls}, nil
 }
 
-// RunToolCall is the tool activity body: toolRunner.Run plus interrupt-as-outcome.
-// VFS is injected by the caller (activity preamble). spawn_worker stays a tool
-// here; the Temporal workflow intercepts it as a child workflow.
-func (a *AgentHarness) RunToolCall(ctx context.Context, tc ToolCall, out chan StreamEvent) (ToolStep, error) {
+func (a *AgentHarness) runToolCall(ctx context.Context, tc ToolCall, out chan StreamEvent) (drive.ToolStep, error) {
 	turnRT := session.NewRuntime(out, a.session)
 	tcKey := tc.Key()
 	toolCtx, toolSpan := telemetry.StartToolSpan(ctx, tc.Name, tc.Namespace)
@@ -233,7 +206,7 @@ func (a *AgentHarness) RunToolCall(ctx context.Context, tc ToolCall, out chan St
 		toolSpan.Finish("error", toolErr)
 		msg := a.emitToolResult(out, tc, toolErr.Error(), "error")
 		_ = a.addToContext(ctx, msg, out)
-		return ToolStep{}, toolErr
+		return drive.ToolStep{}, toolErr
 	}
 	runtimeCopy := turnRT.WithToolCallID(tcKey)
 	output, toolDisp, err := a.toolRunner.Run(toolCtx, ToolInvocation{
@@ -247,7 +220,7 @@ func (a *AgentHarness) RunToolCall(ctx context.Context, tc ToolCall, out chan St
 		if serErr != nil {
 			toolSpan.Finish("error", serErr)
 			out <- StreamEvent{Type: StreamEventError, Error: fmt.Errorf("serialize interrupt: %w", serErr)}
-			return ToolStep{}, serErr
+			return drive.ToolStep{}, serErr
 		}
 		payload := map[string]any{
 			"interruptId": tcKey,
@@ -258,7 +231,7 @@ func (a *AgentHarness) RunToolCall(ctx context.Context, tc ToolCall, out chan St
 		if marErr != nil {
 			toolSpan.Finish("error", marErr)
 			out <- StreamEvent{Type: StreamEventError, Error: fmt.Errorf("marshal interrupt: %w", marErr)}
-			return ToolStep{}, marErr
+			return drive.ToolStep{}, marErr
 		}
 		telemetry.InstrumentsFromContext(ctx).RecordInterrupt(
 			toolCtx, telemetry.AgentIDFromContext(ctx), parked.TypeName(),
@@ -268,7 +241,7 @@ func (a *AgentHarness) RunToolCall(ctx context.Context, tc ToolCall, out chan St
 		a.pendingToolCalls[tcKey] = stores.PendingToolCall{ToolCall: &tc, InterruptActive: true}
 		a.pendingMu.Unlock()
 		out <- StreamEvent{Type: StreamEventInterrupt, MessageID: tcKey, Data: data}
-		return ToolStep{Interrupted: true, InterruptID: tcKey, InterruptData: data}, nil
+		return drive.ToolStep{Interrupted: true, InterruptID: tcKey, InterruptData: data}, nil
 	}
 	a.pendingMu.Lock()
 	delete(a.pendingToolCalls, tcKey)
@@ -281,7 +254,7 @@ func (a *AgentHarness) RunToolCall(ctx context.Context, tc ToolCall, out chan St
 		}
 		msg := a.emitToolResult(out, tc, content, "error")
 		_ = a.addToContext(ctx, msg, out)
-		return ToolStep{}, err
+		return drive.ToolStep{}, err
 	}
 	var effects batchToolResultEffects
 	effects.merge(toolDisp)
@@ -297,35 +270,16 @@ func (a *AgentHarness) RunToolCall(ctx context.Context, tc ToolCall, out chan St
 	msg := a.emitToolResult(out, tc, output, "success")
 	if !toolDisp.SuppressWindowMessage && !hookDisp.SuppressWindowMessage {
 		if err := a.addToContext(ctx, msg, out); err != nil {
-			return ToolStep{}, err
+			return drive.ToolStep{}, err
 		}
 	}
 	if effect := effects.resolved(); effect != EffectNone {
 		if err := a.applyBatchToolResultEffect(ctx, effect); err != nil {
 			out <- StreamEvent{Type: StreamEventError, Error: err, Content: err.Error()}
-			return ToolStep{}, err
+			return drive.ToolStep{}, err
 		}
 	}
-	return ToolStep{}, nil
-}
-
-// PipeStreamEvents copies channel events to emit. Durable backends adapt
-// emit callbacks to the harness chan StreamEvent API.
-func PipeStreamEvents(emit func(StreamEvent)) (chan StreamEvent, func()) {
-	out := make(chan StreamEvent, streamEventBuffer)
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		for ev := range out {
-			if emit != nil {
-				emit(ev)
-			}
-		}
-	}()
-	return out, func() {
-		close(out)
-		<-done
-	}
+	return drive.ToolStep{}, nil
 }
 
 // SpawnWorkerName is the tool the durable driver maps to a nested run

--- a/init.go
+++ b/init.go
@@ -1,0 +1,49 @@
+package tacklr
+
+import (
+	"context"
+
+	"github.com/ryanaldo34/tacklr/internal/drive"
+	"github.com/ryanaldo34/tacklr/interrupt"
+	"github.com/ryanaldo34/tacklr/streaming"
+	"github.com/ryanaldo34/tacklr/vfs"
+	"github.com/ryanaldo34/tacklr/vfs/adapters"
+)
+
+func init() {
+	interrupt.RegisterDefaults()
+	if err := adapters.RegisterCommon(vfs.DefaultContentRegistry()); err != nil {
+		panic("tacklr: register common content codecs: " + err.Error())
+	}
+	drive.Bind(func(h any) drive.Engine {
+		ah, ok := h.(*AgentHarness)
+		if !ok {
+			panic("drive: harness is not *AgentHarness")
+		}
+		return harnessDrive{ah}
+	})
+}
+
+// harnessDrive is the durable-runtime adapter. It lives here so driver
+// methods can stay unexported on AgentHarness.
+type harnessDrive struct{ a *AgentHarness }
+
+func (e harnessDrive) AbsorbUser(ctx context.Context, user *streaming.Message, out chan streaming.StreamEvent) error {
+	return e.a.absorbUser(ctx, user, out)
+}
+
+func (e harnessDrive) PendingToolCalls() []streaming.ToolCall {
+	return e.a.runnableToolCalls()
+}
+
+func (e harnessDrive) RunInference(ctx context.Context, st *drive.TurnState, out chan streaming.StreamEvent) (drive.InferenceStep, error) {
+	return e.a.runInference(ctx, st, out)
+}
+
+func (e harnessDrive) RunToolCall(ctx context.Context, tc streaming.ToolCall, out chan streaming.StreamEvent) (drive.ToolStep, error) {
+	return e.a.runToolCall(ctx, tc, out)
+}
+
+func (e harnessDrive) ApplyResume(finishedInterrupts map[string][]byte) error {
+	return e.a.applyResume(finishedInterrupts)
+}

--- a/init_test.go
+++ b/init_test.go
@@ -1,0 +1,39 @@
+package tacklr
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/ryanaldo34/tacklr/internal/drive"
+)
+
+func TestEngineOf_wrapsAgentHarness(t *testing.T) {
+	eng := drive.EngineOf(&AgentHarness{})
+	if eng == nil {
+		t.Fatal("engine")
+	}
+	if calls := eng.PendingToolCalls(); calls == nil {
+		t.Fatal("pending tool calls")
+	}
+}
+
+func TestEngineOf_rejectsNonHarness(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil || !strings.Contains(fmt.Sprint(r), "not *AgentHarness") {
+			t.Fatalf("got %v", r)
+		}
+	}()
+	drive.EngineOf("host")
+}
+
+func TestBind_alreadyBound(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil || !strings.Contains(fmt.Sprint(r), "already bound") {
+			t.Fatalf("got %v", r)
+		}
+	}()
+	drive.Bind(func(any) drive.Engine { return nil })
+}

--- a/internal/drive/engine.go
+++ b/internal/drive/engine.go
@@ -1,0 +1,77 @@
+package drive
+
+import (
+	"context"
+
+	"github.com/ryanaldo34/tacklr/streaming"
+)
+
+// InferenceStep is the result of one model invocation for the durable driver.
+type InferenceStep struct {
+	ToolCalls []streaming.ToolCall
+	Complete  bool
+}
+
+// ToolStep is the result of one tool invocation for the durable driver.
+// Interrupted means the tool parked; the driver must persist, publish yield,
+// and wait for Resume. It must not block inside the tool function.
+type ToolStep struct {
+	Interrupted   bool
+	InterruptID   string
+	InterruptData []byte
+}
+
+// TurnState is per-slice counters for the durable inference loop.
+type TurnState struct {
+	ModelRequests int
+	HadToolRound  bool
+}
+
+// Engine is the durable-runtime view of a harness. Hosts use Run /
+// RunMessage / ReturnFromInterrupt; only in-repo drivers bind this.
+type Engine interface {
+	AbsorbUser(ctx context.Context, user *streaming.Message, out chan streaming.StreamEvent) error
+	PendingToolCalls() []streaming.ToolCall
+	RunInference(ctx context.Context, st *TurnState, out chan streaming.StreamEvent) (InferenceStep, error)
+	RunToolCall(ctx context.Context, tc streaming.ToolCall, out chan streaming.StreamEvent) (ToolStep, error)
+	ApplyResume(finishedInterrupts map[string][]byte) error
+}
+
+var bound func(any) Engine
+
+// Bind installs the root-package adapter. tacklr.init calls this once.
+func Bind(fn func(any) Engine) {
+	if bound != nil {
+		panic("drive: already bound")
+	}
+	bound = fn
+}
+
+// EngineOf returns the durable driver for a harness constructed by tacklr.
+func EngineOf(h any) Engine {
+	if bound == nil {
+		panic("drive: not bound")
+	}
+	return bound(h)
+}
+
+const streamEventBuffer = 64
+
+// PipeStreamEvents copies channel events to emit. Durable backends adapt
+// emit callbacks to the harness chan StreamEvent API.
+func PipeStreamEvents(emit func(streaming.StreamEvent)) (chan streaming.StreamEvent, func()) {
+	out := make(chan streaming.StreamEvent, streamEventBuffer)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for ev := range out {
+			if emit != nil {
+				emit(ev)
+			}
+		}
+	}()
+	return out, func() {
+		close(out)
+		<-done
+	}
+}

--- a/internal/drive/engine_test.go
+++ b/internal/drive/engine_test.go
@@ -1,0 +1,50 @@
+package drive
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/ryanaldo34/tacklr/streaming"
+)
+
+func TestBind_onceThenEngineOf(t *testing.T) {
+	func() {
+		defer func() {
+			r := recover()
+			if r == nil || !strings.Contains(fmt.Sprint(r), "not bound") {
+				t.Fatalf("unbound EngineOf: %v", r)
+			}
+		}()
+		EngineOf(nil)
+	}()
+
+	Bind(func(any) Engine { return nil })
+	if EngineOf(nil) != nil {
+		t.Fatal("bound adapter returned a non-nil engine")
+	}
+
+	defer func() {
+		r := recover()
+		if r == nil || !strings.Contains(fmt.Sprint(r), "already bound") {
+			t.Fatalf("second Bind: %v", r)
+		}
+	}()
+	Bind(func(any) Engine { return nil })
+}
+
+func TestPipeStreamEvents_forwardsThenStops(t *testing.T) {
+	got := make([]streaming.StreamEvent, 0, 1)
+	ch, stop := PipeStreamEvents(func(ev streaming.StreamEvent) {
+		got = append(got, ev)
+	})
+	ch <- streaming.StreamEvent{Type: streaming.StreamEventComplete}
+	stop()
+	if len(got) != 1 || got[0].Type != streaming.StreamEventComplete {
+		t.Fatalf("got %#v", got)
+	}
+
+	ch2, stop2 := PipeStreamEvents(nil)
+	ch2 <- streaming.StreamEvent{Type: streaming.StreamEventComplete}
+	stop2()
+}

--- a/interrupt/interrupt.go
+++ b/interrupt/interrupt.go
@@ -3,6 +3,7 @@ package interrupt
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 )
 
 // Interrupt represents a pending interrupt in an agent workflow requesting
@@ -226,7 +227,20 @@ func (p *ToolPermissionInterrupt) Error() string {
 
 // --- Interrupt registry ---
 
-var interruptFactories = map[string]func() Interrupt{}
+var (
+	interruptFactories = map[string]func() Interrupt{}
+	defaultsOnce       sync.Once
+)
+
+// RegisterDefaults registers the built-in interrupt types. Safe to call
+// more than once. tacklr.init calls this; New also ensures defaults so
+// checkpoint rehydrate works without importing the root package.
+func RegisterDefaults() {
+	defaultsOnce.Do(func() {
+		Register(func() Interrupt { return &UserSelectionInterrupt{} })
+		Register(func() Interrupt { return &ToolPermissionInterrupt{} })
+	})
+}
 
 // Register adds a factory for an Interrupt type under its TypeName.
 // Call at init for custom interrupts so checkpoints can rehydrate them.
@@ -241,6 +255,7 @@ func Register(factory func() Interrupt) {
 
 // New returns a fresh Interrupt for a registered type name.
 func New(typeName string) (Interrupt, bool) {
+	RegisterDefaults()
 	f, ok := interruptFactories[typeName]
 	if !ok {
 		return nil, false
@@ -266,11 +281,6 @@ func Clone(intr Interrupt) Interrupt {
 		}
 	}
 	return nil
-}
-
-func init() {
-	Register(func() Interrupt { return &UserSelectionInterrupt{} })
-	Register(func() Interrupt { return &ToolPermissionInterrupt{} })
 }
 
 // PayloadInitializer is an optional capability Interrupt types implement

--- a/interrupt/interrupt_test.go
+++ b/interrupt/interrupt_test.go
@@ -225,7 +225,8 @@ func TestRegister_New_Clone(t *testing.T) {
 			t.Fatal("want panic on double register")
 		}
 	}()
-	interrupt.Register(func() interrupt.Interrupt { return &interrupt.UserSelectionInterrupt{} })
+	interrupt.Register(func() interrupt.Interrupt { return fakeInterrupt{name: "dup_once"} })
+	interrupt.Register(func() interrupt.Interrupt { return fakeInterrupt{name: "dup_once"} })
 }
 
 type fakeInterrupt struct{ name string }

--- a/model_tasks.go
+++ b/model_tasks.go
@@ -70,7 +70,7 @@ type AbsorbResult struct {
 	SummaryChunks []LLMResponseChunk
 }
 
-// modelTasks is Turn, Absorb, and Handoff against InferenceStrategy and ContextManager.
+// modelTasks is Turn, Absorb, and Handoff against InferenceStrategy and contextManager.
 type modelTasks interface {
 	Turn(ctx context.Context, tools []*Tool, systemPrompt string) (<-chan LLMResponseChunk, error)
 	Absorb(ctx context.Context, msg *Message, tools []*Tool, systemPrompt string) (AbsorbResult, error)
@@ -82,7 +82,7 @@ type defaultModelTasks struct {
 	mu sync.Mutex // Absorb/Handoff/Turn snapshot; parallel tool results serialize here
 
 	model    InferenceStrategy
-	context  ContextManager
+	context  contextManager
 	policy   ContextPolicy
 	maxSize  int
 	modelSeq int // 1-based Invoke count for model span seq
@@ -90,7 +90,7 @@ type defaultModelTasks struct {
 	countScratch []*Message // reused for progressive token counts
 }
 
-func newDefaultModelTasks(model InferenceStrategy, ctx ContextManager, policy ContextPolicy, maxSize int) *defaultModelTasks {
+func newDefaultModelTasks(model InferenceStrategy, ctx contextManager, policy ContextPolicy, maxSize int) *defaultModelTasks {
 	return &defaultModelTasks{
 		model:   model,
 		context: ctx,

--- a/model_tasks_test.go
+++ b/model_tasks_test.go
@@ -45,7 +45,7 @@ func TestDefaultModelTasks_respectsCancelledContext(t *testing.T) {
 	// Arrange
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	tasks := newDefaultModelTasks(&mockStrategy{}, NewModelContextManager(), DefaultContextPolicy(), 100)
+	tasks := newDefaultModelTasks(&mockStrategy{}, newModelContextManager(), DefaultContextPolicy(), 100)
 
 	// Act
 	_, turnErr := tasks.Turn(ctx, nil, "")
@@ -65,8 +65,8 @@ func TestDefaultModelTasks_absorbFitReportsCountTokenErrors(t *testing.T) {
 			return 0, fmt.Errorf("count failed")
 		},
 	}
-	tasks := newDefaultModelTasks(model, NewModelContextManager(), DefaultContextPolicy(), 100)
-	ctxMgr := NewModelContextManager()
+	tasks := newDefaultModelTasks(model, newModelContextManager(), DefaultContextPolicy(), 100)
+	ctxMgr := newModelContextManager()
 	ctxMgr.Restore([]*Message{{Role: RoleUser, Content: "goal"}})
 	tasks.context = ctxMgr
 
@@ -86,11 +86,11 @@ func TestDefaultModelTasks_absorbFitSkipsCompressWhenOnlyProtectedPrefix(t *test
 			return len(msgs) * 50, nil
 		},
 	}
-	tasks := newDefaultModelTasks(model, NewModelContextManager(), ContextPolicy{
+	tasks := newDefaultModelTasks(model, newModelContextManager(), ContextPolicy{
 		PressureRatio:    0.5,
 		CompressFraction: 0.25,
 	}, 40)
-	ctxMgr := NewModelContextManager()
+	ctxMgr := newModelContextManager()
 	ctxMgr.Restore([]*Message{{Role: RoleUser, Content: strings.Repeat("x", 40)}})
 	tasks.context = ctxMgr
 
@@ -131,12 +131,12 @@ func TestDefaultModelTasks_absorbFitCompressesOverMaxWindow(t *testing.T) {
 			ch <- LLMResponseChunk{Type: StreamEventMessage, Content: "unexpected", IsComplete: true}
 		},
 	}
-	tasks := newDefaultModelTasks(model, NewModelContextManager(), ContextPolicy{
+	tasks := newDefaultModelTasks(model, newModelContextManager(), ContextPolicy{
 		PressureRatio:    0.5,
 		CompressFraction: 0.5,
 		StreamFitSummary: true,
 	}, 20)
-	ctxMgr := NewModelContextManager()
+	ctxMgr := newModelContextManager()
 	ctxMgr.Restore([]*Message{
 		{Role: RoleUser, Content: "goal"},
 		{Role: RoleAssistant, Content: strings.Repeat("a", 30)},
@@ -172,11 +172,11 @@ func TestDefaultModelTasks_absorbFitReturnsCompressStreamErrors(t *testing.T) {
 			ch <- LLMResponseChunk{Type: StreamEventError, Error: errors.New("compress stream failed")}
 		},
 	}
-	tasks := newDefaultModelTasks(model, NewModelContextManager(), ContextPolicy{
+	tasks := newDefaultModelTasks(model, newModelContextManager(), ContextPolicy{
 		PressureRatio:    0.5,
 		CompressFraction: 0.5,
 	}, 50)
-	ctxMgr := NewModelContextManager()
+	ctxMgr := newModelContextManager()
 	ctxMgr.Restore([]*Message{
 		{Role: RoleUser, Content: "goal"},
 		{Role: RoleAssistant, Content: strings.Repeat("x", 80)},
@@ -197,8 +197,8 @@ func TestDefaultModelTasks_handoffUsesFallbackWhenModelFails(t *testing.T) {
 	model := &mockStrategy{
 		invokeErr: errors.New("handoff invoke failed"),
 	}
-	tasks := newDefaultModelTasks(model, NewModelContextManager(), DefaultContextPolicy(), 8192)
-	ctxMgr := NewModelContextManager()
+	tasks := newDefaultModelTasks(model, newModelContextManager(), DefaultContextPolicy(), 8192)
+	ctxMgr := newModelContextManager()
 	ctxMgr.Restore([]*Message{{Role: RoleUser, Content: "goal"}})
 	tasks.context = ctxMgr
 	plan := []Todo{{Title: "Ship", Description: "finish", Status: streaming.TodoStatusPending}}
@@ -223,8 +223,8 @@ func TestDefaultModelTasks_handoffUsesFallbackOnEmptyStream(t *testing.T) {
 			// Leave the stream empty; mockStrategy closes the channel after invokeFn returns.
 		},
 	}
-	tasks := newDefaultModelTasks(model, NewModelContextManager(), DefaultContextPolicy(), 8192)
-	ctxMgr := NewModelContextManager()
+	tasks := newDefaultModelTasks(model, newModelContextManager(), DefaultContextPolicy(), 8192)
+	ctxMgr := newModelContextManager()
 	ctxMgr.Restore([]*Message{{Role: RoleUser, Content: "goal"}})
 	tasks.context = ctxMgr
 
@@ -292,8 +292,8 @@ func TestDefaultModelTasks_handoffUsesFallbackOnStreamContentError(t *testing.T)
 			ch <- LLMResponseChunk{Type: StreamEventError, Content: "handoff stream failed"}
 		},
 	}
-	tasks := newDefaultModelTasks(model, NewModelContextManager(), DefaultContextPolicy(), 8192)
-	ctxMgr := NewModelContextManager()
+	tasks := newDefaultModelTasks(model, newModelContextManager(), DefaultContextPolicy(), 8192)
+	ctxMgr := newModelContextManager()
 	ctxMgr.Restore([]*Message{{Role: RoleUser, Content: "goal"}})
 	tasks.context = ctxMgr
 
@@ -325,11 +325,11 @@ func TestDefaultModelTasks_absorbFitProgressiveCountFailure(t *testing.T) {
 			return total, nil
 		},
 	}
-	tasks := newDefaultModelTasks(model, NewModelContextManager(), ContextPolicy{
+	tasks := newDefaultModelTasks(model, newModelContextManager(), ContextPolicy{
 		PressureRatio:    0.5,
 		CompressFraction: 0.5,
 	}, 25)
-	ctxMgr := NewModelContextManager()
+	ctxMgr := newModelContextManager()
 	ctxMgr.Restore([]*Message{
 		{Role: RoleUser, Content: "goal"},
 		{Role: RoleAssistant, Content: strings.Repeat("x", 15)},

--- a/server/acp_mcp_test.go
+++ b/server/acp_mcp_test.go
@@ -42,7 +42,7 @@ type toolRecorder struct {
 func (tr *toolRecorder) record(tools []*tacklr.Tool) {
 	var names []string
 	for _, tool := range tools {
-		names = append(names, tool.Namespace+"/"+tool.Name)
+		names = append(names, tool.Namespace()+"/"+tool.Name())
 	}
 	tr.mu.Lock()
 	tr.seen = append(tr.seen, names)
@@ -95,7 +95,7 @@ func TestHandleRPC_sessionMCPServers_partialFailureStillExposesHealthyTools(t *t
 				// Assert healthy tool is present, dead server is not.
 				var names []string
 				for _, tool := range tools {
-					names = append(names, tool.Namespace+"/"+tool.Name)
+					names = append(names, tool.Namespace()+"/"+tool.Name())
 				}
 				if !slices.Contains(names, "good/ping") {
 					t.Errorf("expected good/ping in tools, got %v", names)

--- a/subagents.go
+++ b/subagents.go
@@ -342,7 +342,7 @@ func (a *AgentHarness) workerOptsFromSpec(spec *SubAgent) AgentOptions {
 		Brain:                 a.brain,
 		BrainWriteKinds:       a.brainWriteKinds,
 		MountSession:          a.session.VFS,
-		RunCommandUnattended:  a.runCommandUnattended,
+		runCommandUnattended:  a.runCommandUnattended,
 		writeUnattended:       a.writeUnattended,
 		shareIndexBridge:      a.vfsBridge,
 		disablePlanningLock:   true,

--- a/tool_runner.go
+++ b/tool_runner.go
@@ -56,7 +56,7 @@ func (r *toolRunner) Run(ctx context.Context, inv ToolInvocation) (string, ToolO
 }
 
 func toolNameOf(inv ToolInvocation) string {
-	return inv.Tool.Name
+	return inv.Tool.name
 }
 
 // ToolPermissionOnCall parks a tool_permission interrupt before the handler.
@@ -65,7 +65,7 @@ func ToolPermissionOnCall(inv ToolInvocation) Interrupt {
 	name := toolNameOf(inv)
 	return &interrupt.ToolPermissionInterrupt{
 		ToolName: name,
-		Title:    ResolveToolTitle(inv.Tool.DisplayName, name, inv.ArgsJSON),
+		Title:    ResolveToolTitle(inv.Tool.displayName, name, inv.ArgsJSON),
 		Options:  interrupt.DefaultPermissionOptions(),
 	}
 }
@@ -74,13 +74,13 @@ func ToolPermissionOnCall(inv ToolInvocation) Interrupt {
 // and interrupt adopt live on SessionManager, not Runtime.
 func onCallMiddleware(sm *session.SessionManager) ToolInterceptor {
 	return func(ctx context.Context, inv ToolInvocation, next ToolCallFunc) (string, error) {
-		if inv.Tool == nil || len(inv.Tool.OnCall) == 0 {
+		if inv.Tool == nil || len(inv.Tool.onCall) == 0 {
 			return next(ctx, inv)
 		}
 		if inv.Runtime == nil || sm == nil {
 			return "", fmt.Errorf("%w: on-call interrupt requires a runtime", ErrFailed)
 		}
-		for _, ctor := range inv.Tool.OnCall {
+		for _, ctor := range inv.Tool.onCall {
 			if err := applyOnCallLayer(&inv, ctor, sm); err != nil {
 				return "", err
 			}

--- a/tool_runner_test.go
+++ b/tool_runner_test.go
@@ -376,7 +376,7 @@ func TestHarness_hostInterceptor_keepsPermissionGate(t *testing.T) {
 		disablePlanningLock: true,
 		ToolInterceptors: []ToolInterceptor{
 			func(ctx context.Context, inv ToolInvocation, next ToolCallFunc) (string, error) {
-				hostSaw = inv.Tool.Name
+				hostSaw = inv.Tool.name
 				return next(ctx, inv)
 			},
 		},

--- a/tools.go
+++ b/tools.go
@@ -48,6 +48,8 @@ type toolCallResult struct {
 	disp   ToolOutcome
 }
 
+// Tool is a registered harness tool. Construct with NewTool(ToolConfig{...}).
+// Fields are unexported; hosts read metadata through the getters below.
 type Tool struct {
 	displayName string
 	name        string

--- a/tools.go
+++ b/tools.go
@@ -70,7 +70,8 @@ type Tool struct {
 // Name is the programmatic tool name presented to the model.
 func (t *Tool) Name() string { return t.name }
 
-// DisplayName is the optional human title. Empty falls back to Name.
+// DisplayName is the optional human title from ToolConfig. Empty means unset;
+// stream titles fall back to Name via ResolveToolTitle.
 func (t *Tool) DisplayName() string { return t.displayName }
 
 // Description is the model-facing tool description.

--- a/tools.go
+++ b/tools.go
@@ -49,21 +49,42 @@ type toolCallResult struct {
 }
 
 type Tool struct {
-	DisplayName string
-	Name        string
-	Description string
-	Namespace   string
-	Category    streaming.ToolCategory
-	Access      ToolAccess
-	// Timeout is an optional per-invocation deadline. Zero means none.
-	Timeout time.Duration
-	// OnCall is the pre-invoke middleware stack. Each constructor may park.
-	OnCall []OnCallFunc
+	displayName string
+	name        string
+	description string
+	namespace   string
+	category    streaming.ToolCategory
+	access      ToolAccess
+	// timeout is an optional per-invocation deadline. Zero means none.
+	timeout time.Duration
+	// onCall is the pre-invoke middleware stack. Each constructor may park.
+	onCall []OnCallFunc
 
 	handlerFunc func(ctx context.Context, args map[string]any, runtime HarnessRuntime) (toolCallResult, error)
 	parameters  map[string]any
 	strict      bool
 }
+
+// Name is the programmatic tool name presented to the model.
+func (t *Tool) Name() string { return t.name }
+
+// DisplayName is the optional human title. Empty falls back to Name.
+func (t *Tool) DisplayName() string { return t.displayName }
+
+// Description is the model-facing tool description.
+func (t *Tool) Description() string { return t.description }
+
+// Namespace is the optional tool namespace (MCP server name, host grouping).
+func (t *Tool) Namespace() string { return t.namespace }
+
+// Category is the coarse streaming category for client presentation.
+func (t *Tool) Category() streaming.ToolCategory { return t.category }
+
+// Access is the permission bitmask for this tool.
+func (t *Tool) Access() ToolAccess { return t.access }
+
+// Timeout is the optional per-invocation deadline. Zero means none.
+func (t *Tool) Timeout() time.Duration { return t.timeout }
 
 type ToolConfig struct {
 	Name        string
@@ -156,14 +177,14 @@ func NewTool(cfg ToolConfig) *Tool {
 	}
 
 	t := &Tool{
-		Name:        cfg.Name,
-		DisplayName: cfg.DisplayName,
-		Description: cfg.Description,
-		Namespace:   cfg.Namespace,
-		Category:    cfg.Category,
-		Access:      cfg.Access,
-		Timeout:     cfg.Timeout,
-		OnCall:      cfg.OnCall,
+		name:        cfg.Name,
+		displayName: cfg.DisplayName,
+		description: cfg.Description,
+		namespace:   cfg.Namespace,
+		category:    cfg.Category,
+		access:      cfg.Access,
+		timeout:     cfg.Timeout,
+		onCall:      cfg.OnCall,
 		strict:      true,
 	}
 	for _, ctor := range cfg.OnCall {
@@ -214,7 +235,7 @@ func NewTool(cfg ToolConfig) *Tool {
 
 		if hasRuntime {
 			if runtime == nil {
-				return toolCallResult{}, fmt.Errorf("%w: tool %q requires a HarnessRuntime", ErrFailed, t.Name)
+				return toolCallResult{}, fmt.Errorf("%w: tool %q requires a HarnessRuntime", ErrFailed, t.name)
 			}
 			callArgs = append(callArgs, reflect.ValueOf(runtime))
 		}
@@ -249,11 +270,11 @@ func newMCPTool(cfg mcpToolConfig) *Tool {
 		}
 	}
 	return &Tool{
-		Name:        cfg.Name,
-		DisplayName: cfg.DisplayName,
-		Description: cfg.Description,
-		Namespace:   cfg.Namespace,
-		Timeout:     cfg.Timeout,
+		name:        cfg.Name,
+		displayName: cfg.DisplayName,
+		description: cfg.Description,
+		namespace:   cfg.Namespace,
+		timeout:     cfg.Timeout,
 		strict:      false,
 		parameters:  params,
 		handlerFunc: func(ctx context.Context, args map[string]any, runtime HarnessRuntime) (toolCallResult, error) {
@@ -292,15 +313,15 @@ func (t *Tool) invoke(ctx context.Context, argsJson string, runtime HarnessRunti
 	var args map[string]any
 	if argsJson != "" {
 		if err := json.Unmarshal([]byte(argsJson), &args); err != nil {
-			return toolCallResult{}, fmt.Errorf("unmarshal args for tool %q: %w", t.Name, err)
+			return toolCallResult{}, fmt.Errorf("unmarshal args for tool %q: %w", t.name, err)
 		}
 	}
 
-	if t.Timeout <= 0 {
+	if t.timeout <= 0 {
 		return t.handlerFunc(ctx, args, runtime)
 	}
 
-	callCtx, cancel := context.WithTimeout(ctx, t.Timeout)
+	callCtx, cancel := context.WithTimeout(ctx, t.timeout)
 	defer cancel()
 
 	type outcome struct {
@@ -316,14 +337,14 @@ func (t *Tool) invoke(ctx context.Context, argsJson string, runtime HarnessRunti
 	select {
 	case res := <-done:
 		if res.err != nil && ctx.Err() == nil && errors.Is(res.err, context.DeadlineExceeded) {
-			return toolCallResult{}, fmt.Errorf("tool %q: %w", t.Name, ErrToolTimeout)
+			return toolCallResult{}, fmt.Errorf("tool %q: %w", t.name, ErrToolTimeout)
 		}
 		return res.res, res.err
 	case <-callCtx.Done():
 		if err := ctx.Err(); err != nil {
 			return toolCallResult{}, err
 		}
-		return toolCallResult{}, fmt.Errorf("tool %q: %w", t.Name, ErrToolTimeout)
+		return toolCallResult{}, fmt.Errorf("tool %q: %w", t.name, ErrToolTimeout)
 	}
 }
 
@@ -340,8 +361,8 @@ func (t *Tool) AsJson() map[string]any {
 	}
 	return map[string]any{
 		"type":        "function",
-		"name":        t.Name,
-		"description": t.Description,
+		"name":        t.name,
+		"description": t.description,
 		"strict":      t.strict,
 		"parameters":  params,
 	}
@@ -533,8 +554,8 @@ func ToolsAsJson(tools []*Tool) string {
 	defs := make([]map[string]any, 0, len(tools))
 	for _, t := range tools {
 		def := t.AsJson()
-		if t.Namespace != "" {
-			def["name"] = t.Namespace + "." + t.Name
+		if t.namespace != "" {
+			def["name"] = t.namespace + "." + t.name
 		}
 		defs = append(defs, def)
 	}

--- a/tools_test.go
+++ b/tools_test.go
@@ -272,7 +272,7 @@ func TestAsJson(t *testing.T) {
 		t.Error("parameters missing")
 	}
 	// Nil parameters map → default empty object schema (strict tool host shape).
-	empty := (&Tool{Name: "bare"}).AsJson()
+	empty := (&Tool{name: "bare"}).AsJson()
 	params, _ := empty["parameters"].(map[string]any)
 	if params == nil || params["type"] != "object" {
 		t.Fatalf("nil params default = %#v", empty["parameters"])

--- a/tools_test.go
+++ b/tools_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ryanaldo34/tacklr/streaming"
 )
 
 type BasicArgs struct {
@@ -246,6 +248,32 @@ func TestSchema(t *testing.T) {
 		}
 		assertRequired(t, s, "value", "extra")
 	})
+}
+
+func TestNewTool_exposesConfig(t *testing.T) {
+	tool := NewTool(ToolConfig{
+		Name:        "search_records",
+		DisplayName: "Search",
+		Description: "Search operational records.",
+		Namespace:   "ops",
+		Category:    streaming.ToolCategorySearch,
+		Access:      ToolReadAccess,
+		Timeout:     5 * time.Second,
+		OnCall:      []OnCallFunc{nil},
+		Handler:     zeroArgsStringHandler,
+	})
+	if tool.Name() != "search_records" || tool.DisplayName() != "Search" {
+		t.Fatalf("name=%q display=%q", tool.Name(), tool.DisplayName())
+	}
+	if tool.Description() != "Search operational records." || tool.Namespace() != "ops" {
+		t.Fatalf("desc=%q ns=%q", tool.Description(), tool.Namespace())
+	}
+	if tool.Category() != streaming.ToolCategorySearch || tool.Access() != ToolReadAccess {
+		t.Fatalf("category=%q access=%v", tool.Category(), tool.Access())
+	}
+	if tool.Timeout() != 5*time.Second {
+		t.Fatalf("timeout=%v", tool.Timeout())
+	}
 }
 
 func TestAsJson(t *testing.T) {

--- a/tools_vfs.go
+++ b/tools_vfs.go
@@ -9,14 +9,7 @@ import (
 	"github.com/ryanaldo34/tacklr/internal/command"
 	"github.com/ryanaldo34/tacklr/streaming"
 	"github.com/ryanaldo34/tacklr/vfs"
-	"github.com/ryanaldo34/tacklr/vfs/adapters"
 )
-
-func init() {
-	// The harness default registry includes common editor formats. The vfs
-	// package itself remains format-agnostic and can be used standalone.
-	_ = adapters.RegisterCommon(vfs.DefaultContentRegistry())
-}
 
 const smallFormatCells = 32
 

--- a/tools_vfs_test.go
+++ b/tools_vfs_test.go
@@ -39,7 +39,7 @@ func TestVFSTools_readWriteRev(t *testing.T) {
 	})
 	tools := map[string]*Tool{}
 	for _, tool := range h.tools {
-		tools[tool.Name] = tool
+		tools[tool.name] = tool
 	}
 	for _, name := range []string{"read", "write", "run_command"} {
 		if tools[name] == nil {
@@ -446,7 +446,7 @@ func TestVFSTools_projectedDocOutlineAndBlocks(t *testing.T) {
 	})
 	tools := map[string]*Tool{}
 	for _, tool := range h.tools {
-		tools[tool.Name] = tool
+		tools[tool.name] = tool
 	}
 	rt := turnRuntime(h)
 
@@ -788,7 +788,7 @@ func TestVFSTools_writeDocxBlocksAndInlineMarks(t *testing.T) {
 	})
 	tools := map[string]*Tool{}
 	for _, tool := range h.tools {
-		tools[tool.Name] = tool
+		tools[tool.name] = tool
 	}
 	rt := turnRuntime(h)
 	mt := "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
@@ -864,7 +864,7 @@ func TestVFSTools_projectedSheetReadWrite(t *testing.T) {
 	})
 	tools := map[string]*Tool{}
 	for _, tool := range h.tools {
-		tools[tool.Name] = tool
+		tools[tool.name] = tool
 	}
 	rt := turnRuntime(h)
 

--- a/vfs/adapters/adapters_test.go
+++ b/vfs/adapters/adapters_test.go
@@ -129,6 +129,9 @@ func TestRegisterCommon(t *testing.T) {
 	if err == nil || errors.Is(err, vfs.ErrNoCodec) {
 		t.Fatalf("xlsx must be registered: %v", err)
 	}
+	if err := RegisterCommon(reg); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestMountSession_xlsxCreateFormatPersists(t *testing.T) {

--- a/vfs/adapters/registry.go
+++ b/vfs/adapters/registry.go
@@ -7,8 +7,13 @@ import (
 // RegisterCommon registers Word and Excel. HTML stays a TextCodec type unless a
 // host registers adapters.HTML itself — stealing text/html makes .html EROFS.
 func RegisterCommon(reg *vfs.ContentRegistry) error {
-	if err := reg.Register(vfs.BlockCodec{Types: []string{DOCXMediaType}, Normalizer: DOCX{}}); err != nil {
-		return err
+	if _, ok := reg.Lookup(DOCXMediaType); !ok {
+		if err := reg.Register(vfs.BlockCodec{Types: []string{DOCXMediaType}, Normalizer: DOCX{}}); err != nil {
+			return err
+		}
 	}
-	return reg.Register(vfs.TabularCodec{Types: []string{XLSXMediaType}, Normalizer: XLSX{}})
+	if _, ok := reg.Lookup(XLSXMediaType); !ok {
+		return reg.Register(vfs.TabularCodec{Types: []string{XLSXMediaType}, Normalizer: XLSX{}})
+	}
+	return nil
 }

--- a/vfs/adapters/registry.go
+++ b/vfs/adapters/registry.go
@@ -6,6 +6,8 @@ import (
 
 // RegisterCommon registers Word and Excel. HTML stays a TextCodec type unless a
 // host registers adapters.HTML itself — stealing text/html makes .html EROFS.
+// Safe to call more than once on the same registry: existing DOCX/XLSX bindings
+// are left in place (first registration wins).
 func RegisterCommon(reg *vfs.ContentRegistry) error {
 	if _, ok := reg.Lookup(DOCXMediaType); !ok {
 		if err := reg.Register(vfs.BlockCodec{Types: []string{DOCXMediaType}, Normalizer: DOCX{}}); err != nil {

--- a/vfs/content.go
+++ b/vfs/content.go
@@ -117,7 +117,8 @@ func NewContentRegistry() *ContentRegistry {
 	return &ContentRegistry{codecs: make(map[string]Codec)}
 }
 
-// Register adds or replaces codec bindings for each of c.MediaTypes().
+// Register binds c for each of c.MediaTypes(). It does not replace an existing
+// binding; first registration wins.
 func (r *ContentRegistry) Register(c Codec) error {
 	if c == nil {
 		return fmt.Errorf("vfs: codec required")
@@ -126,17 +127,30 @@ func (r *ContentRegistry) Register(c Codec) error {
 	if len(types) == 0 {
 		return fmt.Errorf("vfs: codec media types required")
 	}
+	normalized := make([]string, 0, len(types))
 	for _, mt := range types {
+		mt = normalizeMediaType(mt)
 		if mt == "" {
 			return fmt.Errorf("vfs: codec media type required")
 		}
+		normalized = append(normalized, mt)
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	for _, mt := range types {
+	for _, mt := range normalized {
+		if _, exists := r.codecs[mt]; exists {
+			return fmt.Errorf("%w: %s", ErrAlreadyRegistered, mt)
+		}
+	}
+	for _, mt := range normalized {
 		r.codecs[mt] = c
 	}
 	return nil
+}
+
+// Lookup returns the codec bound to mediaType, if any.
+func (r *ContentRegistry) Lookup(mediaType string) (Codec, bool) {
+	return r.codec(mediaType)
 }
 
 func normalizeMediaType(mediaType string) string {

--- a/vfs/content_test.go
+++ b/vfs/content_test.go
@@ -2,6 +2,7 @@ package vfs
 
 import (
 	"context"
+	"errors"
 	"testing"
 )
 
@@ -49,6 +50,35 @@ func TestKernelWritable(t *testing.T) {
 	if !kernelCreateOK("README") || !kernelCreateOK("note.txt") {
 		t.Fatal("kernelCreateOK plaintext")
 	}
+}
+
+func TestContentRegistry_registerDoesNotReplace(t *testing.T) {
+	r := NewContentRegistry()
+	if err := r.Register(TextCodec{}); err != nil {
+		t.Fatal(err)
+	}
+	err := r.Register(stealPlainCodec{})
+	if !errors.Is(err, ErrAlreadyRegistered) {
+		t.Fatalf("overwrite: %v", err)
+	}
+	doc, err := r.Decode(context.Background(), "/a.txt", "text/plain", []byte("hello"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt, ok := doc.(Textual)
+	if !ok || txt.Text() != "hello" {
+		t.Fatalf("text codec still owns text/plain: %T %v", doc, err)
+	}
+	if _, ok := r.Lookup("text/plain"); !ok {
+		t.Fatal("lookup text/plain")
+	}
+}
+
+type stealPlainCodec struct{}
+
+func (stealPlainCodec) MediaTypes() []string { return []string{"text/plain"} }
+func (stealPlainCodec) Decode(_ context.Context, _, _ string, _ []byte) (Document, error) {
+	return nil, errors.New("stolen")
 }
 
 type kernelProjectedCodec struct{}

--- a/vfs/doc.go
+++ b/vfs/doc.go
@@ -15,7 +15,8 @@
 //   - Document / Textual / Structured / TextDocument — content IR
 //   - Block / StyleMeta / Span / FindBlock / BlockReplaceSpan — structured view
 //   - ContentRegistry + Codec + TextCodec + IdentityCodec — optional custom decode
-//   - DetectMediaType, size-cap constants, sentinel errors (including ErrFuseNotMounted, ErrAuthExpired, ErrAmbiguous, ErrPermission)
+//     (Register is first-wins; Lookup is exported; overwrite returns ErrAlreadyRegistered)
+//   - DetectMediaType, size-cap constants, sentinel errors (including ErrFuseNotMounted, ErrAuthExpired, ErrAmbiguous, ErrPermission, ErrAlreadyRegistered)
 //
 // Providers own IR translation and persist immediately on WriteDocument.
 // MountSession routes; it does not encode or hold a dirty document cache.

--- a/vfs/errors.go
+++ b/vfs/errors.go
@@ -22,13 +22,14 @@ var (
 	ErrPermission      = errors.New("vfs: permission denied")
 
 	// Content IR
-	ErrNoCodec        = errors.New("vfs: no codec for media type")
-	ErrNotTextual     = errors.New("vfs: not a textual document")
-	ErrLineOutOfRange = errors.New("vfs: line out of range")
-	ErrInvalidUTF8    = errors.New("vfs: invalid utf-8")
-	ErrInvalidLine    = errors.New("vfs: line contains newline")
-	ErrLineTooLong    = errors.New("vfs: line too long")
-	ErrTooLarge       = errors.New("vfs: file too large")
+	ErrNoCodec           = errors.New("vfs: no codec for media type")
+	ErrAlreadyRegistered = errors.New("vfs: media type already registered")
+	ErrNotTextual        = errors.New("vfs: not a textual document")
+	ErrLineOutOfRange    = errors.New("vfs: line out of range")
+	ErrInvalidUTF8       = errors.New("vfs: invalid utf-8")
+	ErrInvalidLine       = errors.New("vfs: line contains newline")
+	ErrLineTooLong       = errors.New("vfs: line too long")
+	ErrTooLarge          = errors.New("vfs: file too large")
 	// ErrProjected is returned when a line/HTML/SetText mutation is applied to a
 	// projected document. Agents must use block IR instead.
 	ErrProjected = errors.New("vfs: use block IR for this media type")

--- a/vfs/errors.go
+++ b/vfs/errors.go
@@ -22,7 +22,9 @@ var (
 	ErrPermission      = errors.New("vfs: permission denied")
 
 	// Content IR
-	ErrNoCodec           = errors.New("vfs: no codec for media type")
+	ErrNoCodec = errors.New("vfs: no codec for media type")
+	// ErrAlreadyRegistered is returned when Register is called for a media type
+	// that already has a codec. First registration wins.
 	ErrAlreadyRegistered = errors.New("vfs: media type already registered")
 	ErrNotTextual        = errors.New("vfs: not a textual document")
 	ErrLineOutOfRange    = errors.New("vfs: line out of range")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#105 squash-merged AttachDocument removal, but the host-unsafe SDK encapsulation never landed on `main`. This PR is that remaining change, plus the docs that match it.

## Public surface

Host-unsafe APIs are no longer on the root SDK:

- Durable driver methods (`AbsorbUser`, `RunInference`, `RunToolCall`, `PendingToolCalls`, `ApplyResume`) and `PipeStreamEvents` moved behind `internal/drive`. In-process and Temporal runtimes bind through `drive.EngineOf`. Hosts keep `Run` / `RunMessage` / `ReturnFromInterrupt`, plus checkpoint, VFS, and session accessors.
- `ContextManager` / `NewModelContextManager` are unexported so ACM cannot be swapped mid-turn. `ContextPolicy` stays public.
- `Tool` fields are unexported. Construction is still `NewTool(ToolConfig{...})`; other packages read via getters.
- `ContentRegistry.Register` no longer replaces an existing media type, so hosts cannot overwrite `TextCodec`. `RegisterCommon` is idempotent (first binding wins).
- `RunCommandUnattended` is unexported, matching `writeUnattended`. `run_command` requires permission by default.

Process-wide registration now lives in one root `init()`: built-in interrupts, Word/Excel codecs, and the durable driver adapter. VFS factories and brain kinds stay per-host. `interrupt.RegisterDefaults` is `sync.Once` and is also invoked from `interrupt.New` so checkpoint rehydrate works in packages that do not import `tacklr`.

## Documentation

- Root `doc.go` describes the single `init()` registrations.
- `README.md` documents `NewTool(ToolConfig)`, getters, default registrations, and `run_command` permission.
- `docs/durable.md` states Path A hosts do not use `internal/drive`.
- `docs/vfs.md`, `docs/fuse-vfs-run-command.md`, `vfs/doc.go`, and codec godoc cover first-wins `Register` / `ErrAlreadyRegistered`.

## Tests

- Codec overwrite returns `ErrAlreadyRegistered`.
- `RegisterCommon` is idempotent.
- `NewTool` exposes `ToolConfig` through getters.
- `drive.Bind` / `EngineOf` reject a second adapter, an unbound engine, and a non-harness value.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e832f37-32cc-4880-aa0d-976e093152bd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e832f37-32cc-4880-aa0d-976e093152bd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

