### PR TITLE
refactor(brain): extract Postgres store into brain/postgres

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -33,6 +33,9 @@ override:
   # Live Testcontainers Helix (CI pulls enterprise-dev; never -short in CI).
   - path: github.com/ryanaldo34/tacklr/brain/helixgraph$
     threshold: 90
+  # Live Testcontainers Postgres (CI builds tacklr-pg-brain; never -short in CI).
+  - path: github.com/ryanaldo34/tacklr/brain/postgres$
+    threshold: 90
   # VFS/S3 unit surface + fake API; integration (MinIO) is separate.
   - path: github.com/ryanaldo34/tacklr/vfs$
     threshold: 85

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test: brain-pg-image helix-image
 test-short:
 	go test -short -race -count=1 -covermode=atomic ./...
 
-# pgvector + pg_textsearch image used by brain PostgresStore integration tests.
+# pgvector + pg_textsearch image used by brain/postgres integration tests.
 brain-pg-image: require-docker
 	$(DOCKER) build -f brain/testdata/Dockerfile.postgres -t tacklr-pg-brain:test brain/testdata
 

--- a/README.md
+++ b/README.md
@@ -63,12 +63,17 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+
 	"github.com/ryanaldo34/tacklr"
 	"github.com/ryanaldo34/tacklr/brain"
+	"github.com/ryanaldo34/tacklr/brain/helixgraph"
+	"github.com/ryanaldo34/tacklr/brain/postgres"
 	"github.com/ryanaldo34/tacklr/builtins"
 	"github.com/ryanaldo34/tacklr/durable"
 	"github.com/ryanaldo34/tacklr/durable/inprocess"
 	"github.com/ryanaldo34/tacklr/server"
+	"github.com/ryanaldo34/tacklr/telemetry"
 	"github.com/ryanaldo34/tacklr/vfs"
 )
 
@@ -76,17 +81,50 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	shutdown, err := telemetry.Init(ctx, telemetry.Config{
+		ServiceName:  "tacklr-host",
+		OTLPEndpoint: os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"),
+		Insecure:     true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() { _ = shutdown(context.Background()) }()
+
 	model := builtins.NewOpenAIInferenceStrategy(&http.Client{Timeout: 2 * time.Minute})
 	model.WithURL(os.Getenv("OPENAI_BASE_URL")).
 		WithApiKey(os.Getenv("OPENAI_API_KEY")).
 		WithModel(os.Getenv("OPENAI_MODEL"))
 
-	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithKinds(
-		brain.KindSpec{Kind: "Discovery", Description: "Research finding", IsParent: true},
-		brain.KindSpec{Kind: "Fact", Description: "Verified fact", IsParent: true},
-		brain.KindSpec{Kind: "Memory", Description: "Durable memory", IsParent: true},
-	))
+	pool, err := pgxpool.New(ctx, os.Getenv("DATABASE_URL"))
 	if err != nil {
+		log.Fatal(err)
+	}
+	defer pool.Close()
+	kinds := []brain.KindSpec{
+		{Kind: "Discovery", Description: "Research finding", IsParent: true},
+		{Kind: "Fact", Description: "Verified fact", IsParent: true},
+		{Kind: "Memory", Description: "Durable memory", IsParent: true},
+	}
+	store, err := postgres.New(pool)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := store.Setup(ctx, kinds...); err != nil {
+		log.Fatal(err)
+	}
+	g, err := helixgraph.New(os.Getenv("HELIX_URL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := g.Bootstrap(ctx, false); err != nil {
+		log.Fatal(err)
+	}
+	eng, err := brain.NewEngine(store, brain.WithGraph(g))
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := eng.LoadKindsFromStore(ctx); err != nil {
 		log.Fatal(err)
 	}
 	ns, err := brain.ParseNamespace("org", "acme")
@@ -163,6 +201,8 @@ func openVFS(jail string, eng *brain.Engine, ns brain.Namespace) vfs.OpenVFS {
 
 Importing `tacklr` registers built-in interrupts, Word/Excel codecs, and the durable driver adapter. The agent sees `/workspace/work`, `/workspace/engram`. Skills load from `OpenSkills` and reach the model only through `read_skill`. A Drive or SharePoint bind on the prompt adds `/workspace/drive` or `/workspace/sharepoint` for that turn. Tests pass a fake `DriveAPI` / `GraphAPI` into the same `builtins.Drive` / `builtins.Graph` constructors.
 
+`telemetry.Init` installs the process-wide OpenTelemetry providers. With `OTLPEndpoint` (or `OTEL_EXPORTER_OTLP_ENDPOINT`) it exports traces, metrics, and logs over OTLP (gRPC by default, or HTTP). Without an endpoint it still installs Temporal’s ReplaySafe tracer so workflow replay does not leak spans. Each Prompt or Resume is one `tacklr.turn` span; inference, tools, hand-off, and compress nest under it. `postgres.Store` Query/Exec spans join that same trace. Hosts must not start `tacklr.*` spans themselves. Metrics include turn duration and count, tool calls, model tokens, interrupts, hand-offs, compress, sessions, and checkpoints. Call `Init` before `durable/temporal.Dial`. Details: [`telemetry`](https://pkg.go.dev/github.com/ryanaldo34/tacklr/telemetry).
+
 ### Tools
 
 Tools are ordinary Go functions. Give a tool a client by closing over it in the constructor. That is the dependency injection. Tests pass a fake into the same constructor.
@@ -212,7 +252,7 @@ Register nested agents on `AgentOptions.Specialists`. Tools start them through `
 | Web | `web_search` and `web_fetch` via `builtins.WebSearch` / `builtins.WebFetch` | [`builtins`](https://pkg.go.dev/github.com/ryanaldo34/tacklr/builtins) |
 | Email | `read_inbox` and permission-gated `send_email` via `builtins.ReadInbox` / `builtins.SendEmail` | [`builtins`](https://pkg.go.dev/github.com/ryanaldo34/tacklr/builtins) |
 | Server | `Protocol` over Runtime; ACP is the native option | [`server`](https://pkg.go.dev/github.com/ryanaldo34/tacklr/server) |
-| Telemetry | One `tacklr.turn` span per prompt or resume; OTLP | [`telemetry`](https://pkg.go.dev/github.com/ryanaldo34/tacklr/telemetry) |
+| Telemetry | `telemetry.Init`: OTLP traces/metrics/logs; one `tacklr.turn` span per prompt or resume | [`telemetry`](https://pkg.go.dev/github.com/ryanaldo34/tacklr/telemetry) |
 
 When VFS is wired, the harness injects file tools over virtual paths only. `run_command` requires permission by default. Live names and grep go through `run_command` (`ls` / `fd` / `rg`). With Brain + VFS + a search namespace, knowledge tools attach to `/workspace/engram`. Details: [docs/vfs.md](docs/vfs.md) and [docs/knowledge.md](docs/knowledge.md).
 
@@ -240,8 +280,9 @@ When VFS is wired, the harness injects file tools over virtual paths only. `run_
 | `builtins` | Optional tools (email, Exa), VFS constructors, OpenAI model client |
 | `vfs` | Virtual filesystem, mounts, content IR |
 | `vfsindex` | Optional mount → brain ingest |
-| `brain` | Knowledge engine |
-| `brain/helixgraph` | Optional graph adapter |
+| `brain` | Knowledge engine, store/graph interfaces, in-memory backends |
+| `brain/postgres` | Optional Postgres `brain.Store` |
+| `brain/helixgraph` | Optional Helix graph adapter |
 | `server` | Protocol host over Runtime |
 | `durable` | Session Runtime (in-process or Temporal) |
 | `interrupt` | Pause / resume types |
@@ -276,7 +317,7 @@ Where to look:
 | Runtime | `durable/runtime.go`, `docs/durable.md` |
 | VFS | `vfs/`, `docs/vfs.md` |
 | Model client | `builtins/openai.go` (`tacklr.InferenceStrategy`) |
-| Knowledge | `brain/`, `docs/knowledge.md` |
+| Knowledge | `brain/`, `brain/postgres/`, `brain/helixgraph/`, `docs/knowledge.md` |
 | ACP / protocols | `server/` |
 
 Issues and pull requests are welcome. Match the surrounding code: `gofmt`, `go vet`, `golangci-lint`.

--- a/agent_construct.go
+++ b/agent_construct.go
@@ -84,8 +84,8 @@ type AgentOptions struct {
 	SkillsRoot string
 	// Brain enables knowledge builtins when non-nil. Workers inherit the same engine.
 	// Configure Store, optional QueryEmbedder, and optional GraphReader/GraphWriter on the Engine
-	// before NewTurnManager (e.g. brain.WithGraph(helixgraph.New(...))). The harness does
-	// not construct graph backends.
+	// before NewTurnManager (e.g. brain.WithGraph(g) after helixgraph.New). The harness
+	// does not construct store or graph backends.
 	Brain *brain.Engine
 	// BrainWriteKinds maps save_discovery / save_fact / save_memory to host kind names.
 	// Empty fields skip that tool. Kinds should be registered via brain.ApplyKinds / WithKinds.

--- a/brain/doc.go
+++ b/brain/doc.go
@@ -4,18 +4,21 @@
 //
 // # Public surface
 //
-// Hosts use Engine (NewEngine + options), Store implementations (MemoryStore /
-// PostgresStore), graph backends via WithGraph, kind registration (ApplyKinds /
-// WithKinds), and composition helpers (LandingIDs, ExpandMany, ExpandByRecipe,
-// SortRichObjects). Agent tools are registered by the harness when
+// Hosts use Engine (NewEngine + options), a Store implementation, an optional
+// graph via WithGraph, kind registration (ApplyKinds / WithKinds), and
+// composition helpers (LandingIDs, ExpandMany, ExpandByRecipe, SortRichObjects).
+// MemoryStore and MemoryGraph are in-process backends for tests and offline
+// hosts. Durable backends are injected: brain/postgres.Store and
+// brain/helixgraph.Graph. Agent tools are registered by the harness when
 // AgentOptions.Brain is set — they call Engine methods only.
 //
-// Graph backend packages (e.g. helixgraph) implement GraphReader / GraphWriter /
+// Graph backend packages implement GraphReader / GraphWriter /
 // GraphObjectSearcher / GraphEdgeSearcher. Dual-write property keys and Helix
 // schema details stay inside those packages.
 //
 // Hosts attach an Engine via AgentOptions.Brain. This package does not import
-// the harness, session, or telemetry packages; Scope is passed in by the caller.
+// postgres, helixgraph, the harness, session, or telemetry; Scope is passed
+// in by the caller.
 //
 // # Engrams as files (vfs.Provider)
 //
@@ -25,7 +28,8 @@
 // Kind names are host KindSpecs and must be path-safe (no '/' or '..'). Only parent
 // kinds are directories; parts/chunks are not files. Write/Close/PutFile parse,
 // validate, and Put (fail closed). Rename is delete+create. Graph edges stay in
-// Helix and show up through path-native link/expand/find_links — not sidecar files.
+// the graph backend and show up through path-native link/expand/find_links — not
+// sidecar files.
 //
 // SearchContext is the retrieval session surface: host namespace + active ResultSet
 // for continue (replaced on each search, find_exact, find_objects, or large expand).
@@ -47,22 +51,22 @@
 // (edges preserved). SoftDelete removes the graph node first, then soft-deletes the
 // store row. Revive via Put recreates the graph node.
 //
-// # Postgres vs Helix (complementary)
+// # Store vs graph (complementary)
 //
-// Postgres is the source of truth and document corpus:
+// The Store is the source of truth and document corpus:
 // full rows, parts/chunks, BM25 + dense hybrid search, property filters, soft-delete,
 // containment (parent_id). Tools: search, find_exact, read; expand children.
 // search may pass ScopeIDs to limit hits to a parent neighborhood.
 //
-// Helix holds first-class entity nodes and cross-object edges only (not chunks).
+// The graph holds first-class entity nodes and cross-object edges only (not chunks).
 // Helix owns: native text/vector indexes, $distance ranking, graph topology, edge
 // props, BothE neighbor walks, optional tenant indexes on namespace.
 // Tacklr does not reimplement BM25/HNSW or in-process neighbor indexes for Helix.
 // We dual-write searchable props (EntityIndexText + embedding), Link edges, fuse
-// Helix text+vector channels with RRF (Helix has no single hybrid op), then hydrate
-// full rows from Postgres under Scope.
+// graph text+vector channels with RRF, then hydrate full rows from the Store
+// under Scope.
 //
-// Tools: find_objects (after Bootstrap), expand with relation_types, link.
+// Tools: find_objects (after graph Bootstrap), expand with relation_types, link.
 // Optional: helixgraph.EnsureEdgeTextIndex(rel) + SearchEdgesText for note search
 // on a known relation label.
 //
@@ -71,16 +75,16 @@
 //	find_objects (entity land; filters via schema filterable_fields)
 //	  or search/find_exact (corpus) → LandingIDs (parent promote)
 //	→ expand / ExpandMany (max_hops, direction, WantContainment)
-//	  or ExpandByRecipe (host-named ExpandRequest template) → hydrate Postgres
+//	  or ExpandByRecipe (host-named ExpandRequest template) → hydrate Store
 //	→ optional find_links (edge text) for relationship-first land
 //	→ search(scope_ids=…) for neighborhood corpus
 //	→ optional host Reranker after hydrate; SortRichObjects for peer ordering
 //
-// Graph-first then Postgres drill-down:
+// Graph-first then store drill-down:
 //
-//	find_objects / expand(graph) → Helix ids → hydrate from Postgres
-//	expand() containment → Postgres ListChildren (chunks)
-//	read / search → Postgres
+//	find_objects / expand(graph) → graph ids → hydrate from Store
+//	expand() containment → Store.ListChildren (chunks)
+//	read / search → Store
 //
 // schema() returns filter_usage.tools listing search, find_exact, and find_objects
 // so agents know filterable_fields apply to entity find as well as corpus search.
@@ -93,7 +97,7 @@
 //
 // # Boot sketch
 //
-//	store, err := brain.NewPostgresStore(pool)
+//	store, err := postgres.New(pool)
 //	store.EmbeddingDim = 1536 // optional; default 1536
 //	if err := store.Setup(ctx, specs...); err != nil { return err }
 //	g, err := helixgraph.New(helixURL)
@@ -102,6 +106,6 @@
 //	if err := eng.LoadKindsFromStore(ctx); err != nil { return err }
 //
 // Integration tests (skipped under -short / without Docker):
-//   - PostgresStore: Testcontainers + brain/testdata/Dockerfile.postgres
+//   - postgres.Store: Testcontainers + brain/testdata/Dockerfile.postgres
 //   - helixgraph: Testcontainers + ghcr.io/helixdb/enterprise-dev (in-memory)
 package brain

--- a/brain/engine.go
+++ b/brain/engine.go
@@ -111,7 +111,7 @@ func WithConfig(cfg EngineConfig) EngineOption {
 	return func(eng *Engine) { eng.cfg = cfg }
 }
 
-// WithGraph sets the optional non-containment graph backend (Helix or MemoryGraph).
+// WithGraph sets the optional non-containment graph backend (helixgraph or MemoryGraph).
 // Writer and object-search capabilities are resolved once here (not re-asserted per call).
 func WithGraph(g GraphReader) EngineOption {
 	return func(eng *Engine) {

--- a/brain/filter_plan.go
+++ b/brain/filter_plan.go
@@ -6,7 +6,8 @@ import (
 	"time"
 )
 
-// filterPlan is the single compiled form of Filter used by Memory and Postgres.
+// filterPlan is the single compiled form of Filter used by MemoryStore and
+// relational stores (via FilterSQL).
 type filterPlan struct {
 	preds []filterPred
 }
@@ -212,7 +213,19 @@ func objectMatchesFilters(obj Object, f Filter) bool {
 	return plan.match(obj)
 }
 
-func filterSQL(scope Scope, filters Filter, startArg int) (string, []any, error) {
+func sanitizeJSONKey(k string) string {
+	return strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
+			return r
+		}
+		return -1
+	}, k)
+}
+
+// FilterSQL compiles filters into a WHERE fragment and bound args for a
+// relational store. startArg is the first $N placeholder (usually 2 when $1
+// is the query). The fragment begins with AND when non-empty.
+func FilterSQL(scope Scope, filters Filter, startArg int) (string, []any, error) {
 	plan, err := compileFilters(filters)
 	if err != nil {
 		return "", nil, err

--- a/brain/filter_plan_test.go
+++ b/brain/filter_plan_test.go
@@ -24,7 +24,7 @@ func TestFilterPlan_listAndSQLParity(t *testing.T) {
 	if !plan.match(obj) {
 		t.Fatal("memory match list")
 	}
-	sql, args, err := plan.sql(Scope{Namespace: ns}, 1)
+	sql, args, err := FilterSQL(Scope{Namespace: ns}, f, 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/brain/graph.go
+++ b/brain/graph.go
@@ -13,7 +13,7 @@ import (
 )
 
 // EdgeMeta is optional metadata on a non-containment relationship (why/how/when linked).
-// Kept short and relational — full bodies stay on objects in Postgres.
+// Kept short and relational — full bodies stay on objects in the Store.
 type EdgeMeta struct {
 	Note       string     `json:"note,omitempty"`
 	Status     string     `json:"status,omitempty"`     // e.g. active, resolved
@@ -50,7 +50,7 @@ type GraphWriter interface {
 	// EnsureObject upserts a graph node for obj.ID (searchable props when available).
 	// Must preserve incident edges (update in place, not drop+recreate).
 	EnsureObject(ctx context.Context, obj Object) error
-	// RemoveObject drops the node (and incident edges) after/with Postgres soft-delete.
+	// RemoveObject drops the node (and incident edges) after/with store soft-delete.
 	RemoveObject(ctx context.Context, id uuid.UUID) error
 	// AddEdge creates a directed edge from→to with optional relationship metadata.
 	AddEdge(ctx context.Context, from, to uuid.UUID, relationType string, meta EdgeMeta) error

--- a/brain/memory.go
+++ b/brain/memory.go
@@ -42,7 +42,7 @@ func NewMemoryStore() *MemoryStore {
 // Put implements ObjectWriter. Soft-deleted rows may be stored; Get hides them.
 // Clones maps/slices so callers cannot mutate the store through shared references.
 func (s *MemoryStore) Put(_ context.Context, obj Object) error {
-	if err := requireObjectIdentity(obj); err != nil {
+	if err := ValidateObjectIdentity(obj); err != nil {
 		return err
 	}
 	obj = cloneObject(obj)

--- a/brain/postgres/doc.go
+++ b/brain/postgres/doc.go
@@ -1,0 +1,9 @@
+// Package postgres is the optional Postgres implementation of brain.Store.
+//
+// Hosts construct a Store with New(pool) and inject it into brain.NewEngine.
+// Call Setup once per database to create extensions, tables, and indexes.
+// Query/Exec emit otelpgx spans under the caller context after telemetry.Init.
+//
+// Package brain does not import this package. MemoryStore stays in brain for
+// tests and offline hosts.
+package postgres

--- a/brain/postgres/otel.go
+++ b/brain/postgres/otel.go
@@ -1,4 +1,4 @@
-package brain
+package postgres
 
 import (
 	"context"

--- a/brain/postgres/otel_test.go
+++ b/brain/postgres/otel_test.go
@@ -1,4 +1,4 @@
-package brain_test
+package postgres_test
 
 import (
 	"context"
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/ryanaldo34/tacklr/brain"
+	"github.com/ryanaldo34/tacklr/brain/postgres"
 )
 
 type traceStubDB struct{}
@@ -44,9 +45,7 @@ func (emptyRows) Values() ([]any, error)                       { return nil, nil
 func (emptyRows) RawValues() [][]byte                          { return nil }
 func (emptyRows) Conn() *pgx.Conn                              { return nil }
 
-// TestPostgresStore_sqlSpansParentUnderCallerSpan: Query/Exec client spans
-// join the caller trace (tacklr.tool) rather than opening a new one.
-func TestPostgresStore_sqlSpansParentUnderCallerSpan(t *testing.T) {
+func TestStore_sqlSpansParentUnderCallerSpan(t *testing.T) {
 	sr := tracetest.NewSpanRecorder()
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
 	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
@@ -54,7 +53,7 @@ func TestPostgresStore_sqlSpansParentUnderCallerSpan(t *testing.T) {
 	otel.SetTracerProvider(tp)
 	t.Cleanup(func() { otel.SetTracerProvider(prev) })
 
-	store, err := brain.NewPostgresStore(traceStubDB{})
+	store, err := postgres.New(traceStubDB{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/brain/postgres/setup.go
+++ b/brain/postgres/setup.go
@@ -1,28 +1,30 @@
-package brain
+package postgres
 
 import (
 	"context"
 	"fmt"
 	"strconv"
+
+	"github.com/ryanaldo34/tacklr/brain"
 )
 
-// DefaultEmbeddingDim is the pgvector column size when PostgresStore.EmbeddingDim is 0.
+// DefaultEmbeddingDim is the pgvector column size when Store.EmbeddingDim is 0.
 const DefaultEmbeddingDim = 1536
 
 // Setup creates extensions, tables, and indexes (idempotent), then upserts kinds
 // into object_kinds. EmbeddingDim is the pgvector size and must match the embedder;
 // zero uses DefaultEmbeddingDim. This does not migrate an existing column to a new size.
-func (s *PostgresStore) Setup(ctx context.Context, kinds ...KindSpec) error {
+func (s *Store) Setup(ctx context.Context, kinds ...brain.KindSpec) error {
 	dim := s.EmbeddingDim
 	if dim <= 0 {
 		dim = DefaultEmbeddingDim
 	}
 	for _, q := range schemaStatements(dim) {
 		if _, err := s.db.Exec(ctx, q); err != nil {
-			return fmt.Errorf("brain: setup: %w", err)
+			return fmt.Errorf("postgres: setup: %w", err)
 		}
 	}
-	return PersistKinds(ctx, s, kinds...)
+	return brain.PersistKinds(ctx, s, kinds...)
 }
 
 func schemaStatements(dim int) []string {

--- a/brain/postgres/store.go
+++ b/brain/postgres/store.go
@@ -1,4 +1,4 @@
-package brain
+package postgres
 
 import (
 	"context"
@@ -12,6 +12,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/ryanaldo34/tacklr/brain"
 )
 
 // PgxDB is satisfied by *pgx.Conn and *pgxpool.Pool.
@@ -22,28 +24,28 @@ type PgxDB interface {
 }
 
 var (
-	_ Store        = (*PostgresStore)(nil)
-	_ ObjectWriter = (*PostgresStore)(nil)
-	_ ObjectLister = (*PostgresStore)(nil)
-	_ KindWriter   = (*PostgresStore)(nil)
-	_ PgxDB        = tracedDB{}
+	_ brain.Store        = (*Store)(nil)
+	_ brain.ObjectWriter = (*Store)(nil)
+	_ brain.ObjectLister = (*Store)(nil)
+	_ brain.KindWriter   = (*Store)(nil)
+	_ PgxDB              = tracedDB{}
 )
 
-// PostgresStore implements Store against the objects / object_kinds schema.
+// Store is the optional Postgres brain.Store. Hosts inject it into NewEngine.
 // Call Setup once per database. Setup does not migrate an existing vector column.
-type PostgresStore struct {
+type Store struct {
 	// EmbeddingDim is the pgvector size Setup uses. Zero means DefaultEmbeddingDim.
 	EmbeddingDim int
 	db           PgxDB
 }
 
-// NewPostgresStore wraps a pgx pool or connection. Query/Exec emit otelpgx
+// New wraps a pgx pool or connection. Query/Exec emit otelpgx
 // client spans as children of ctx (after telemetry.Init).
-func NewPostgresStore(db PgxDB) (*PostgresStore, error) {
+func New(db PgxDB) (*Store, error) {
 	if db == nil {
-		return nil, fmt.Errorf("brain: db is required")
+		return nil, fmt.Errorf("postgres: db is required")
 	}
-	return &PostgresStore{db: newTracedDB(db)}, nil
+	return &Store{db: newTracedDB(db)}, nil
 }
 
 const objectSelectCols = `
@@ -52,7 +54,7 @@ const objectSelectCols = `
 `
 
 // Get implements ObjectReader.
-func (s *PostgresStore) Get(ctx context.Context, scope Scope, id uuid.UUID) (Object, error) {
+func (s *Store) Get(ctx context.Context, scope brain.Scope, id uuid.UUID) (brain.Object, error) {
 	q := `SELECT ` + objectSelectCols + ` FROM objects WHERE id = $1 AND deleted_at IS NULL`
 	args := []any{id}
 	q, args = appendNamespaceSQL(q, args, scope)
@@ -60,7 +62,7 @@ func (s *PostgresStore) Get(ctx context.Context, scope Scope, id uuid.UUID) (Obj
 }
 
 // GetMany implements ObjectReader.
-func (s *PostgresStore) GetMany(ctx context.Context, scope Scope, ids []uuid.UUID) ([]Object, error) {
+func (s *Store) GetMany(ctx context.Context, scope brain.Scope, ids []uuid.UUID) ([]brain.Object, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
@@ -69,10 +71,10 @@ func (s *PostgresStore) GetMany(ctx context.Context, scope Scope, ids []uuid.UUI
 	q, args = appendNamespaceSQL(q, args, scope)
 	rows, err := s.db.Query(ctx, q, args...)
 	if err != nil {
-		return nil, fmt.Errorf("brain: get many: %w", err)
+		return nil, fmt.Errorf("postgres: get many: %w", err)
 	}
 	defer rows.Close()
-	byID := make(map[uuid.UUID]Object, len(ids))
+	byID := make(map[uuid.UUID]brain.Object, len(ids))
 	for rows.Next() {
 		obj, err := s.scanObject(rows)
 		if err != nil {
@@ -81,9 +83,9 @@ func (s *PostgresStore) GetMany(ctx context.Context, scope Scope, ids []uuid.UUI
 		byID[obj.ID] = obj
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("brain: get many: %w", err)
+		return nil, fmt.Errorf("postgres: get many: %w", err)
 	}
-	out := make([]Object, 0, len(byID))
+	out := make([]brain.Object, 0, len(byID))
 	for _, id := range ids {
 		if o, ok := byID[id]; ok {
 			out = append(out, o)
@@ -93,7 +95,7 @@ func (s *PostgresStore) GetMany(ctx context.Context, scope Scope, ids []uuid.UUI
 }
 
 // ListChildren implements ObjectReader.
-func (s *PostgresStore) ListChildren(ctx context.Context, scope Scope, parentID uuid.UUID) ([]Object, error) {
+func (s *Store) ListChildren(ctx context.Context, scope brain.Scope, parentID uuid.UUID) ([]brain.Object, error) {
 	q := `SELECT ` + objectSelectCols + `
 		FROM objects
 		WHERE parent_id = $1 AND deleted_at IS NULL`
@@ -103,11 +105,11 @@ func (s *PostgresStore) ListChildren(ctx context.Context, scope Scope, parentID 
 
 	rows, err := s.db.Query(ctx, q, args...)
 	if err != nil {
-		return nil, fmt.Errorf("brain: list children: %w", err)
+		return nil, fmt.Errorf("postgres: list children: %w", err)
 	}
 	defer rows.Close()
 
-	var out []Object
+	var out []brain.Object
 	for rows.Next() {
 		obj, err := s.scanObject(rows)
 		if err != nil {
@@ -116,14 +118,14 @@ func (s *PostgresStore) ListChildren(ctx context.Context, scope Scope, parentID 
 		out = append(out, obj)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("brain: list children: %w", err)
+		return nil, fmt.Errorf("postgres: list children: %w", err)
 	}
 	return out, nil
 }
 
 // Put implements ObjectWriter (full-column upsert; clears soft-delete on revive).
-func (s *PostgresStore) Put(ctx context.Context, obj Object) error {
-	if err := requireObjectIdentity(obj); err != nil {
+func (s *Store) Put(ctx context.Context, obj brain.Object) error {
+	if err := brain.ValidateObjectIdentity(obj); err != nil {
 		return err
 	}
 	if obj.Properties == nil {
@@ -131,7 +133,7 @@ func (s *PostgresStore) Put(ctx context.Context, obj Object) error {
 	}
 	propsJSON, err := json.Marshal(obj.Properties)
 	if err != nil {
-		return fmt.Errorf("brain: marshal properties: %w", err)
+		return fmt.Errorf("postgres: marshal properties: %w", err)
 	}
 	var emb any
 	if len(obj.Embedding) > 0 {
@@ -167,39 +169,39 @@ func (s *PostgresStore) Put(ctx context.Context, obj Object) error {
 			deleted_at = NULL`
 	nsJSON, err := obj.Namespace.Value()
 	if err != nil {
-		return fmt.Errorf("brain: marshal namespace: %w", err)
+		return fmt.Errorf("postgres: marshal namespace: %w", err)
 	}
 	if _, err := s.db.Exec(ctx, q,
 		obj.ID, obj.Kind, obj.Title, obj.Summary, propsJSON, obj.Content, obj.ContentType,
 		obj.ParentID, obj.Position, emb, nsJSON, obj.CreatedAt, obj.UpdatedAt,
 	); err != nil {
-		return fmt.Errorf("brain: put object: %w", err)
+		return fmt.Errorf("postgres: put object: %w", err)
 	}
 	return nil
 }
 
 // SoftDelete implements ObjectWriter.
-func (s *PostgresStore) SoftDelete(ctx context.Context, scope Scope, id uuid.UUID) error {
+func (s *Store) SoftDelete(ctx context.Context, scope brain.Scope, id uuid.UUID) error {
 	if id == uuid.Nil {
-		return fmt.Errorf("%w: object id is required", ErrInvalid)
+		return fmt.Errorf("%w: object id is required", brain.ErrInvalid)
 	}
 	q := `UPDATE objects SET deleted_at = $1, updated_at = $1 WHERE id = $2 AND deleted_at IS NULL`
 	args := []any{time.Now().UTC(), id}
 	q, args = appendNamespaceSQL(q, args, scope)
 	tag, err := s.db.Exec(ctx, q, args...)
 	if err != nil {
-		return fmt.Errorf("brain: soft delete: %w", err)
+		return fmt.Errorf("postgres: soft delete: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("%w: %s", ErrNotFound, id)
+		return fmt.Errorf("%w: %s", brain.ErrNotFound, id)
 	}
 	return nil
 }
 
 // PutKind implements KindWriter.
-func (s *PostgresStore) PutKind(ctx context.Context, k ObjectKind) error {
+func (s *Store) PutKind(ctx context.Context, k brain.ObjectKind) error {
 	if strings.TrimSpace(k.Kind) == "" {
-		return fmt.Errorf("brain: kind is required")
+		return fmt.Errorf("postgres: kind is required")
 	}
 	fields := k.FilterableFields
 	if len(fields) == 0 {
@@ -214,25 +216,25 @@ func (s *PostgresStore) PutKind(ctx context.Context, k ObjectKind) error {
 			is_parent = EXCLUDED.is_parent,
 			filterable_fields = EXCLUDED.filterable_fields`
 	if _, err := s.db.Exec(ctx, q, k.Kind, k.Description, k.IsPart, k.IsParent, []byte(fields)); err != nil {
-		return fmt.Errorf("brain: put kind: %w", err)
+		return fmt.Errorf("postgres: put kind: %w", err)
 	}
 	return nil
 }
 
 // GetKind implements KindReader.
-func (s *PostgresStore) GetKind(ctx context.Context, kind string) (ObjectKind, error) {
+func (s *Store) GetKind(ctx context.Context, kind string) (brain.ObjectKind, error) {
 	const q = `
 		SELECT kind, description, is_part, is_parent, filterable_fields
 		FROM object_kinds WHERE kind = $1`
-	var k ObjectKind
+	var k brain.ObjectKind
 	var desc *string
 	var fields []byte
 	err := s.db.QueryRow(ctx, q, kind).Scan(&k.Kind, &desc, &k.IsPart, &k.IsParent, &fields)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return ObjectKind{}, fmt.Errorf("%w: kind %q", ErrNotFound, kind)
+			return brain.ObjectKind{}, fmt.Errorf("%w: kind %q", brain.ErrNotFound, kind)
 		}
-		return ObjectKind{}, fmt.Errorf("brain: get kind: %w", err)
+		return brain.ObjectKind{}, fmt.Errorf("postgres: get kind: %w", err)
 	}
 	if desc != nil {
 		k.Description = *desc
@@ -246,23 +248,23 @@ func (s *PostgresStore) GetKind(ctx context.Context, kind string) (ObjectKind, e
 }
 
 // ListKinds implements KindReader.
-func (s *PostgresStore) ListKinds(ctx context.Context) ([]ObjectKind, error) {
+func (s *Store) ListKinds(ctx context.Context) ([]brain.ObjectKind, error) {
 	const q = `
 		SELECT kind, description, is_part, is_parent, filterable_fields
 		FROM object_kinds ORDER BY kind ASC`
 	rows, err := s.db.Query(ctx, q)
 	if err != nil {
-		return nil, fmt.Errorf("brain: list kinds: %w", err)
+		return nil, fmt.Errorf("postgres: list kinds: %w", err)
 	}
 	defer rows.Close()
 
-	var out []ObjectKind
+	var out []brain.ObjectKind
 	for rows.Next() {
-		var k ObjectKind
+		var k brain.ObjectKind
 		var desc *string
 		var fields []byte
 		if err := rows.Scan(&k.Kind, &desc, &k.IsPart, &k.IsParent, &fields); err != nil {
-			return nil, fmt.Errorf("brain: list kinds: %w", err)
+			return nil, fmt.Errorf("postgres: list kinds: %w", err)
 		}
 		if desc != nil {
 			k.Description = *desc
@@ -275,13 +277,13 @@ func (s *PostgresStore) ListKinds(ctx context.Context) ([]ObjectKind, error) {
 		out = append(out, k)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("brain: list kinds: %w", err)
+		return nil, fmt.Errorf("postgres: list kinds: %w", err)
 	}
 	return out, nil
 }
 
 // ListByKind implements ObjectLister (first-class objects only).
-func (s *PostgresStore) ListByKind(ctx context.Context, scope Scope, kind string, limit int) ([]Object, error) {
+func (s *Store) ListByKind(ctx context.Context, scope brain.Scope, kind string, limit int) ([]brain.Object, error) {
 	kind = strings.TrimSpace(kind)
 	if kind == "" || limit <= 0 {
 		return nil, nil
@@ -297,10 +299,10 @@ func (s *PostgresStore) ListByKind(ctx context.Context, scope Scope, kind string
 }
 
 // GetByProperty implements ObjectLister.
-func (s *PostgresStore) GetByProperty(ctx context.Context, scope Scope, key, value string) (Object, error) {
+func (s *Store) GetByProperty(ctx context.Context, scope brain.Scope, key, value string) (brain.Object, error) {
 	key = strings.TrimSpace(key)
 	if key == "" {
-		return Object{}, fmt.Errorf("brain: property key is required")
+		return brain.Object{}, fmt.Errorf("postgres: property key is required")
 	}
 	q := `SELECT ` + objectSelectCols + `
 		FROM objects
@@ -312,39 +314,39 @@ func (s *PostgresStore) GetByProperty(ctx context.Context, scope Scope, key, val
 }
 
 // KindsWithObjects implements ObjectLister.
-func (s *PostgresStore) KindsWithObjects(ctx context.Context, scope Scope) ([]string, error) {
+func (s *Store) KindsWithObjects(ctx context.Context, scope brain.Scope) ([]string, error) {
 	q := `SELECT DISTINCT kind FROM objects WHERE deleted_at IS NULL AND parent_id IS NULL`
 	var args []any
 	q, args = appendNamespaceSQL(q, args, scope)
 	q += ` ORDER BY kind ASC`
 	rows, err := s.db.Query(ctx, q, args...)
 	if err != nil {
-		return nil, fmt.Errorf("brain: kinds with objects: %w", err)
+		return nil, fmt.Errorf("postgres: kinds with objects: %w", err)
 	}
 	defer rows.Close()
 	var out []string
 	for rows.Next() {
 		var k string
 		if err := rows.Scan(&k); err != nil {
-			return nil, fmt.Errorf("brain: kinds with objects: %w", err)
+			return nil, fmt.Errorf("postgres: kinds with objects: %w", err)
 		}
 		if k != "" {
 			out = append(out, k)
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("brain: kinds with objects: %w", err)
+		return nil, fmt.Errorf("postgres: kinds with objects: %w", err)
 	}
 	return out, nil
 }
 
-func (s *PostgresStore) scanObjectRows(ctx context.Context, q string, args []any, label string, capHint int) ([]Object, error) {
+func (s *Store) scanObjectRows(ctx context.Context, q string, args []any, label string, capHint int) ([]brain.Object, error) {
 	rows, err := s.db.Query(ctx, q, args...)
 	if err != nil {
-		return nil, fmt.Errorf("brain: %s: %w", label, err)
+		return nil, fmt.Errorf("postgres: %s: %w", label, err)
 	}
 	defer rows.Close()
-	out := make([]Object, 0, capHint)
+	out := make([]brain.Object, 0, capHint)
 	for rows.Next() {
 		obj, err := s.scanObject(rows)
 		if err != nil {
@@ -353,7 +355,7 @@ func (s *PostgresStore) scanObjectRows(ctx context.Context, q string, args []any
 		out = append(out, obj)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("brain: %s: %w", label, err)
+		return nil, fmt.Errorf("postgres: %s: %w", label, err)
 	}
 	return out, nil
 }
@@ -362,9 +364,9 @@ type scannable interface {
 	Scan(dest ...any) error
 }
 
-func (s *PostgresStore) scanObject(row scannable) (Object, error) {
+func (s *Store) scanObject(row scannable) (brain.Object, error) {
 	var (
-		o           Object
+		o           brain.Object
 		title       *string
 		summary     *string
 		propsRaw    []byte
@@ -391,9 +393,9 @@ func (s *PostgresStore) scanObject(row scannable) (Object, error) {
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return Object{}, ErrNotFound
+			return brain.Object{}, brain.ErrNotFound
 		}
-		return Object{}, fmt.Errorf("brain: scan object: %w", err)
+		return brain.Object{}, fmt.Errorf("postgres: scan object: %w", err)
 	}
 	if title != nil {
 		o.Title = *title
@@ -416,18 +418,18 @@ func (s *PostgresStore) scanObject(row scannable) (Object, error) {
 	o.Properties = map[string]any{}
 	if len(propsRaw) > 0 {
 		if err := json.Unmarshal(propsRaw, &o.Properties); err != nil {
-			return Object{}, fmt.Errorf("brain: properties json: %w", err)
+			return brain.Object{}, fmt.Errorf("postgres: properties json: %w", err)
 		}
 	}
 	return o, nil
 }
 
 // SearchLexical implements PartSearcher using pg_textsearch BM25.
-func (s *PostgresStore) SearchLexical(ctx context.Context, scope Scope, query string, filters Filter, k int) ([]ScoredID, error) {
+func (s *Store) SearchLexical(ctx context.Context, scope brain.Scope, query string, filters brain.Filter, k int) ([]brain.ScoredID, error) {
 	if k <= 0 || strings.TrimSpace(query) == "" {
 		return nil, nil
 	}
-	where, fargs, err := filterSQL(scope, filters, 2)
+	where, fargs, err := brain.FilterSQL(scope, filters, 2)
 	if err != nil {
 		return nil, err
 	}
@@ -445,11 +447,11 @@ func (s *PostgresStore) SearchLexical(ctx context.Context, scope Scope, query st
 }
 
 // SearchVector implements PartSearcher using pgvector cosine distance.
-func (s *PostgresStore) SearchVector(ctx context.Context, scope Scope, embedding []float32, filters Filter, k int) ([]ScoredID, error) {
+func (s *Store) SearchVector(ctx context.Context, scope brain.Scope, embedding []float32, filters brain.Filter, k int) ([]brain.ScoredID, error) {
 	if k <= 0 || len(embedding) == 0 {
 		return nil, nil
 	}
-	where, fargs, err := filterSQL(scope, filters, 2)
+	where, fargs, err := brain.FilterSQL(scope, filters, 2)
 	if err != nil {
 		return nil, err
 	}
@@ -468,11 +470,11 @@ func (s *PostgresStore) SearchVector(ctx context.Context, scope Scope, embedding
 }
 
 // SearchTrigram implements PartSearcher using pg_trgm similarity.
-func (s *PostgresStore) SearchTrigram(ctx context.Context, scope Scope, query string, filters Filter, k int) ([]ScoredID, error) {
+func (s *Store) SearchTrigram(ctx context.Context, scope brain.Scope, query string, filters brain.Filter, k int) ([]brain.ScoredID, error) {
 	if k <= 0 || strings.TrimSpace(query) == "" {
 		return nil, nil
 	}
-	where, fargs, err := filterSQL(scope, filters, 2)
+	where, fargs, err := brain.FilterSQL(scope, filters, 2)
 	if err != nil {
 		return nil, err
 	}
@@ -493,13 +495,13 @@ func (s *PostgresStore) SearchTrigram(ctx context.Context, scope Scope, query st
 	return s.queryScored(ctx, q, args, false)
 }
 
-func (s *PostgresStore) queryScored(ctx context.Context, q string, args []any, invertBM25 bool) ([]ScoredID, error) {
+func (s *Store) queryScored(ctx context.Context, q string, args []any, invertBM25 bool) ([]brain.ScoredID, error) {
 	rows, err := s.db.Query(ctx, q, args...)
 	if err != nil {
-		return nil, fmt.Errorf("brain: search query: %w", err)
+		return nil, fmt.Errorf("postgres: search query: %w", err)
 	}
 	defer rows.Close()
-	var out []ScoredID
+	var out []brain.ScoredID
 	for rows.Next() {
 		var (
 			id       uuid.UUID
@@ -511,12 +513,12 @@ func (s *PostgresStore) queryScored(ctx context.Context, q string, args []any, i
 			score    float64
 		)
 		if err := rows.Scan(&id, &title, &content, &parentID, &position, &updated, &score); err != nil {
-			return nil, fmt.Errorf("brain: search scan: %w", err)
+			return nil, fmt.Errorf("postgres: search scan: %w", err)
 		}
 		if invertBM25 {
 			score = -score
 		}
-		item := ScoredID{ID: id, Score: score, UpdatedAt: updated, ParentID: parentID}
+		item := brain.ScoredID{ID: id, Score: score, UpdatedAt: updated, ParentID: parentID}
 		if title != nil {
 			item.Title = *title
 		}
@@ -530,21 +532,12 @@ func (s *PostgresStore) queryScored(ctx context.Context, q string, args []any, i
 		out = append(out, item)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("brain: search rows: %w", err)
+		return nil, fmt.Errorf("postgres: search rows: %w", err)
 	}
 	return out, nil
 }
 
-func sanitizeJSONKey(k string) string {
-	return strings.Map(func(r rune) rune {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
-			return r
-		}
-		return -1
-	}, k)
-}
-
-func appendNamespaceSQL(q string, args []any, scope Scope) (string, []any) {
+func appendNamespaceSQL(q string, args []any, scope brain.Scope) (string, []any) {
 	if scope.Namespace.Empty() {
 		return q, args
 	}

--- a/brain/postgres/store_integration_test.go
+++ b/brain/postgres/store_integration_test.go
@@ -1,4 +1,4 @@
-package brain_test
+package postgres_test
 
 import (
 	"context"
@@ -10,9 +10,10 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
 
 	"github.com/ryanaldo34/tacklr/brain"
+	"github.com/ryanaldo34/tacklr/brain/postgres"
 )
 
 // Pre-built via Makefile/CI: docker build -f brain/testdata/Dockerfile.postgres -t tacklr-pg-brain:test
@@ -35,7 +36,7 @@ func TestPostgresStore_liveRetrievalChannels(t *testing.T) {
 	ctx := context.Background()
 	pool := sharedPostgresPool(t)
 	mustExec(t, pool, `TRUNCATE objects, object_kinds CASCADE`)
-	store, err := brain.NewPostgresStore(pool)
+	store, err := postgres.New(pool)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -246,7 +247,7 @@ func TestPostgresStore_liveEmptyChannels(t *testing.T) {
 	}
 	ctx := context.Background()
 	pool := sharedPostgresPool(t)
-	store, err := brain.NewPostgresStore(pool)
+	store, err := postgres.New(pool)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -272,12 +273,12 @@ func sharedPostgresPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	ctx := context.Background()
 	pgOnce.Do(func() {
-		ctr, err := postgres.Run(ctx, brainPgImage,
-			postgres.WithDatabase("brain"),
-			postgres.WithUsername("brain"),
-			postgres.WithPassword("brain"),
-			postgres.BasicWaitStrategies(),
-			postgres.WithSQLDriver("pgx"),
+		ctr, err := tcpostgres.Run(ctx, brainPgImage,
+			tcpostgres.WithDatabase("brain"),
+			tcpostgres.WithUsername("brain"),
+			tcpostgres.WithPassword("brain"),
+			tcpostgres.BasicWaitStrategies(),
+			tcpostgres.WithSQLDriver("pgx"),
 		)
 		if err != nil {
 			pgSkip = err.Error() + " (build image: make brain-pg-image)"
@@ -296,7 +297,7 @@ func sharedPostgresPool(t *testing.T) *pgxpool.Pool {
 			_ = ctr.Terminate(ctx)
 			return
 		}
-		store, err := brain.NewPostgresStore(pool)
+		store, err := postgres.New(pool)
 		if err != nil {
 			pgStart = err
 			pool.Close()
@@ -339,6 +340,24 @@ func sharedPostgresPool(t *testing.T) *pgxpool.Pool {
 	return pgPool
 }
 
+func mustNS(t testing.TB, nv ...string) brain.Namespace {
+	t.Helper()
+	ns, err := brain.ParseNamespace(nv...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ns
+}
+
+func mustFilter(t testing.TB, m map[string]any) brain.Filter {
+	t.Helper()
+	f, err := brain.DecodeFilter(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
 func mustExec(t *testing.T, pool *pgxpool.Pool, sql string, args ...any) {
 	t.Helper()
 	if _, err := pool.Exec(context.Background(), sql, args...); err != nil {
@@ -355,7 +374,7 @@ func TestPut_livePostgresUpsertAndSoftDelete(t *testing.T) {
 	pool := sharedPostgresPool(t)
 	mustExec(t, pool, `TRUNCATE objects, object_kinds CASCADE`)
 
-	store, err := brain.NewPostgresStore(pool)
+	store, err := postgres.New(pool)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -433,7 +452,7 @@ func TestEngine_livePostgresMultiTurnWriteSearch(t *testing.T) {
 	pool := sharedPostgresPool(t)
 	mustExec(t, pool, `TRUNCATE objects, object_kinds CASCADE`)
 
-	store, err := brain.NewPostgresStore(pool)
+	store, err := postgres.New(pool)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -621,11 +640,11 @@ func TestApplyKinds_livePostgresMigration(t *testing.T) {
 	pool := sharedPostgresPool(t)
 	mustExec(t, pool, `TRUNCATE objects, object_kinds CASCADE`)
 
-	store, err := brain.NewPostgresStore(pool)
+	store, err := postgres.New(pool)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Compile-time / runtime: PostgresStore is a KindRegistry.
+	// Compile-time / runtime: postgres.Store is a KindRegistry.
 	var _ brain.KindRegistry = store
 
 	eng, err := brain.NewEngine(store)
@@ -701,7 +720,7 @@ func TestPostgresStore_setupRegistersKinds(t *testing.T) {
 	pool := sharedPostgresPool(t)
 	mustExec(t, pool, `TRUNCATE objects, object_kinds CASCADE`)
 
-	store, err := brain.NewPostgresStore(pool)
+	store, err := postgres.New(pool)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/brain/postgres/store_test.go
+++ b/brain/postgres/store_test.go
@@ -1,4 +1,4 @@
-package brain_test
+package postgres_test
 
 import (
 	"context"
@@ -8,11 +8,11 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 
-	"github.com/ryanaldo34/tacklr/brain"
+	"github.com/ryanaldo34/tacklr/brain/postgres"
 )
 
-func TestNewPostgresStore_requiresDB(t *testing.T) {
-	if _, err := brain.NewPostgresStore(nil); err == nil {
+func TestNew_requiresDB(t *testing.T) {
+	if _, err := postgres.New(nil); err == nil {
 		t.Fatal("want error")
 	}
 }
@@ -31,8 +31,8 @@ type execErrRow struct{}
 
 func (execErrRow) Scan(...any) error { return pgx.ErrNoRows }
 
-func TestPostgresStore_setupReportsExecError(t *testing.T) {
-	store, err := brain.NewPostgresStore(execErrDB{})
+func TestStore_setupReportsExecError(t *testing.T) {
+	store, err := postgres.New(execErrDB{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/brain/store.go
+++ b/brain/store.go
@@ -29,8 +29,8 @@ type KindWriter interface {
 }
 
 // ObjectWriter persists knowledge objects (Engine.Put / SoftDelete).
-// PostgresStore and MemoryStore implement it. Custom backends implement for
-// non-Postgres deployments. Not required for read-only engines.
+// MemoryStore and postgres.Store implement it. Custom backends implement
+// ObjectWriter for other deployments. Not required for read-only engines.
 type ObjectWriter interface {
 	Put(ctx context.Context, obj Object) error
 	SoftDelete(ctx context.Context, scope Scope, id uuid.UUID) error

--- a/brain/write.go
+++ b/brain/write.go
@@ -360,7 +360,8 @@ func isReservedStoreProp(name string) bool {
 	}
 }
 
-func requireObjectIdentity(obj Object) error {
+// ValidateObjectIdentity checks id, kind, and namespace before a store Put.
+func ValidateObjectIdentity(obj Object) error {
 	if obj.ID == uuid.Nil {
 		return fmt.Errorf("%w: object id is required", ErrInvalid)
 	}

--- a/docs/durable.md
+++ b/docs/durable.md
@@ -177,7 +177,7 @@ The wait loop (in-process goroutine or `SessionWorkflow`) starts `tacklr.turn`. 
 | In-process | wait loop calls `telemetry.StartTurnSpan` |
 | Temporal | `temporalotel.Tracer` inside `SessionWorkflow` |
 
-Host setup: `telemetry.Init` installs the process-wide ReplaySafe tracer (and OTLP exporters when an endpoint is set). `Dial` prepends Temporal’s official OpenTelemetry v2 plugin onto that global provider. Postgres Query/Exec spans join that same trace because `PostgresStore` / `PostgresWireStore` run otelpgx against the caller context.
+Host setup: `telemetry.Init` installs the process-wide ReplaySafe tracer (and OTLP exporters when an endpoint is set). `Dial` prepends Temporal’s official OpenTelemetry v2 plugin onto that global provider. Postgres Query/Exec spans join that same trace because `postgres.Store` / `PostgresWireStore` run otelpgx against the caller context.
 
 ```go
 shutdown, err := telemetry.Init(ctx, telemetry.Config{

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -2,7 +2,8 @@
 
 This is the canonical guide to Tacklr’s knowledge base: how objects are stored, how
 they appear as files, how search and the graph work, and how an agent is supposed
-to use them.
+to use them. The engine is generic: inject a `brain.Store` and optional graph.
+`brain/postgres` and `brain/helixgraph` are optional backends.
 
 You do not need to have read the rest of the Tacklr codebase first. Terms are
 defined as they appear, and again in the [glossary](#glossary).
@@ -22,7 +23,7 @@ defined as they appear, and again in the [glossary](#glossary).
 
 | Reader | What you should take away |
 |--------|---------------------------|
-| **Host / product engineer** | How to register kinds, wire Postgres (and optional Helix), mount `/engram`, and decide index policy |
+| **Host / product engineer** | How to register kinds, inject `postgres.Store` and optional `helixgraph.Graph`, mount `/engram`, and decide index policy |
 | **Agent author / tool designer** | Which tool to call for which question; why `ls` never shows relationships |
 | **Contributor** | Which package owns which job; what must not import what |
 
@@ -642,12 +643,13 @@ eng, err := brain.NewEngine(store, brain.WithKinds(
 // The harness closes `eng` into those tool handlers (same pattern as host tools).
 ```
 
-Production-shaped. `PostgresStore.Setup` creates extensions, tables, and
+Production-shaped. `postgres.Store.Setup` creates extensions, tables, and
 indexes, then upserts the kinds you pass. Set `EmbeddingDim` to match the
 embedder (zero means 1536). Setup does not change an existing vector column.
+Helix is an optional graph. Inject both; `brain` does not import either package.
 
 ```go
-store, err := brain.NewPostgresStore(pool)
+store, err := postgres.New(pool)
 store.EmbeddingDim = 1536
 kinds := append([]brain.KindSpec{dealSpec, personSpec}, vfsindex.MountIndexKinds()...)
 if err := store.Setup(ctx, kinds...); err != nil { /* ... */ }
@@ -720,7 +722,7 @@ Tests call `store.Setup` (embedding dim 3) instead of loading SQL files.
 | Engram Markdown codec | `brain/engramfile.go` |
 | VFS Provider | `brain/provider.go` |
 | Store ports | `brain/store.go` |
-| Postgres schema + kinds | `PostgresStore.Setup` (`brain/postgres_setup.go`) |
+| Postgres store | `brain/postgres` (`postgres.New`, `Store.Setup`) |
 | Graph ports + MemoryGraph | `brain/graph.go` |
 | Helix adapter | `brain/helixgraph/` |
 | Artifact indexer | `vfsindex/indexer.go` |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`brain` is the generic engine: `Store`, graph interfaces, `MemoryStore`, and `MemoryGraph`. Durable backends are injected.

- **`brain/postgres`** owns `postgres.New(pool)` / `Store.Setup` (was `brain.NewPostgresStore`)
- **`brain/helixgraph`** stays the optional Helix adapter
- `brain` does not import either backend

Hosts write:

```go
store, err := postgres.New(pool)
g, err := helixgraph.New(helixURL)
eng, err := brain.NewEngine(store, brain.WithGraph(g), brain.WithEmbedder(emb))
```

## Docs

README host now:

- calls `telemetry.Init` (OTLP traces/metrics/logs, ReplaySafe tracer, `tacklr.turn`)
- builds the brain from Postgres + Helix, not `MemoryStore`

`docs/knowledge.md` and `brain/doc.go` match that split.

## Tests

Postgres unit and Testcontainers tests live with the new package. Short tests, `go vet`, and `golangci-lint` are clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04a65-fb13-7dd5-87d9-2994e5749602?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04a65-fb13-7dd5-87d9-2994e5749602&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

