### PR TITLE
feat: Brain retrieval contract, embedder choice, and kind-spec honesty

### DIFF
--- a/brain/contract_test.go
+++ b/brain/contract_test.go
@@ -1,0 +1,76 @@
+package brain_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/ryanaldo34/tacklr/brain"
+)
+
+// TestSearch_parentWithoutPartsIsFoundByFindObjects: search looks at chunks;
+// find_objects looks at parent records. An Engram with no parts is missing from
+// search and present in find_objects.
+func TestSearch_parentWithoutPartsIsFoundByFindObjects(t *testing.T) {
+	ctx := context.Background()
+	store := brain.NewMemoryStore()
+	g := brain.NewMemoryGraph()
+	eng, err := brain.NewEngine(store, brain.WithGraph(g), brain.WithKinds(
+		brain.KindSpec{Kind: "Deal", IsParent: true, Fields: []brain.FieldSpec{
+			{Name: "stage", Type: brain.FieldTypeString},
+		}},
+		brain.KindSpec{Kind: "Chunk", IsPart: true},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ns := mustNS(t, "id", uuid.NewString())
+	scope := brain.Scope{Namespace: ns}
+	sc := brain.NewSearchContext()
+
+	deal, err := eng.Put(ctx, scope, brain.Object{
+		Kind: "Deal", Title: "Acme renewal", Summary: "enterprise opportunity",
+		Content:    "pricing memo",
+		Properties: map[string]any{"stage": "negotiation"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	page, err := eng.Search(ctx, scope, brain.SearchRequest{Query: "Acme renewal"}, sc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Objects) != 0 {
+		t.Fatalf("search must miss parent-only object: %+v", page.Objects)
+	}
+
+	found, err := eng.FindObjects(ctx, scope, brain.FindObjectsRequest{Query: "Acme renewal"}, sc)
+	if err != nil || len(found.Objects) != 1 || found.Objects[0].ID != deal.ID {
+		t.Fatalf("find_objects title: %+v err=%v", found.Objects, err)
+	}
+	byStage, err := eng.FindObjects(ctx, scope, brain.FindObjectsRequest{
+		Query:   "Acme",
+		Filters: mustFilter(t, map[string]any{"kind": "Deal", "stage": "negotiation"}),
+	}, sc)
+	if err != nil || len(byStage.Objects) != 1 || byStage.Objects[0].ID != deal.ID {
+		t.Fatalf("find_objects stage filter: %+v err=%v", byStage.Objects, err)
+	}
+
+	pos := 1
+	if _, err := eng.Put(ctx, scope, brain.Object{
+		Kind: "Chunk", Title: "thread", Content: "pkce flow on the renewal",
+		ParentID: &deal.ID, Position: &pos,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	corpus, err := eng.Search(ctx, scope, brain.SearchRequest{Query: "pkce"}, sc)
+	if err != nil || len(corpus.Objects) != 1 || corpus.Objects[0].ID != deal.ID {
+		t.Fatalf("search after chunk: %+v err=%v", corpus.Objects, err)
+	}
+	if len(corpus.Objects[0].Evidence) == 0 {
+		t.Fatal("search must attach part evidence")
+	}
+}

--- a/brain/contract_test.go
+++ b/brain/contract_test.go
@@ -16,7 +16,7 @@ func TestSearch_parentWithoutPartsIsFoundByFindObjects(t *testing.T) {
 	ctx := context.Background()
 	store := brain.NewMemoryStore()
 	g := brain.NewMemoryGraph()
-	eng, err := brain.NewEngine(store, brain.WithGraph(g), brain.WithKinds(
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(g), brain.WithKinds(
 		brain.KindSpec{Kind: "Deal", IsParent: true, Fields: []brain.FieldSpec{
 			{Name: "stage", Type: brain.FieldTypeString},
 		}},

--- a/brain/doc.go
+++ b/brain/doc.go
@@ -97,6 +97,7 @@
 //
 // Embeddings: NewEngine requires WithEmbedder or WithLexicalOnly. Parents embed
 // EntityIndexText; parts embed IndexText with parent title prefix (corpus only).
+// WithIndexText rewrites that document at Put without changing the stored object.
 // One embedding dimension per process.
 // Helix hosts must call helixgraph.Graph.Bootstrap (or EnsureSearchIndexes) so
 // HasObjectSearch is true; MemoryGraph is always ready when attached.

--- a/brain/doc.go
+++ b/brain/doc.go
@@ -51,24 +51,30 @@
 // (edges preserved). SoftDelete removes the graph node first, then soft-deletes the
 // store row. Revive via Put recreates the graph node.
 //
-// # Store vs graph (complementary)
+// # Store vs graph
 //
-// The Store is the source of truth and document corpus:
-// full rows, parts/chunks, BM25 + dense hybrid search, property filters, soft-delete,
-// containment (parent_id). Tools: search, find_exact, read; expand children.
-// search may pass ScopeIDs to limit hits to a parent neighborhood.
+// The Store is the source of truth and the document corpus: full rows,
+// parts/chunks, BM25 + dense hybrid search, property filters, soft-delete,
+// containment (parent_id). Search and FindExact query parts (title, summary,
+// content) and promote hits to the parent. Tools: search, find_exact, read;
+// expand children. search may pass ScopeIDs to limit hits to a neighborhood.
 //
-// The graph holds first-class entity nodes and cross-object edges only (not chunks).
-// Helix owns: native text/vector indexes, $distance ranking, graph topology, edge
-// props, BothE neighbor walks, optional tenant indexes on namespace.
+// The graph holds first-class parent nodes and cross-object edges only (not
+// chunks). FindObjects queries that entity index (title, summary, indexed
+// properties, body). Tools: find_objects (after graph Bootstrap), expand with
+// relation_types, link. Optional: helixgraph.EnsureEdgeTextIndex(rel) +
+// SearchEdgesText for note search on a known relation label.
+//
+// Helix owns native text/vector indexes, $distance ranking, graph topology,
+// edge props, BothE neighbor walks, optional tenant indexes on namespace.
 // Tacklr does not reimplement BM25/HNSW or in-process neighbor indexes for Helix.
-// We dual-write searchable props (EntityIndexText + embedding), Link edges, fuse
+// Dual-write searchable props (EntityIndexText + embedding), Link edges, fuse
 // graph text+vector channels with RRF, then hydrate full rows from the Store
 // under Scope.
 //
-// Tools: find_objects (after graph Bootstrap), expand with relation_types, link.
-// Optional: helixgraph.EnsureEdgeTextIndex(rel) + SearchEdgesText for note search
-// on a known relation label.
+// Query strings are free text. Structured fields go in Filters. The same
+// filter keys work on search and find_objects; search applies them to the
+// part row, find_objects to the parent.
 //
 // GraphRAG-style composition (host-agnostic):
 //

--- a/brain/doc.go
+++ b/brain/doc.go
@@ -41,8 +41,10 @@
 //
 // # Explicit writes (no handoff side effects)
 //
-// Durable objects are written only via Engine.Put / SoftDelete (host SDK) or
-// kind-scoped agent tools. Context handoff never writes the knowledge base.
+// Durable objects are written only via Engine.Put / SoftDelete / ReplaceParts
+// (host SDK) or kind-scoped agent tools. Context handoff never writes the
+// knowledge base. ReplaceParts is how a host attaches corpus chunks under a
+// parent; Engram files stay parent-only.
 //
 // Hosts map save_* tools via AgentOptions.BrainWriteKinds. Write for retrieval:
 // fill title and summary (and useful properties) so search and find_objects work.

--- a/brain/doc.go
+++ b/brain/doc.go
@@ -95,8 +95,9 @@
 // schema() returns filter_usage.tools listing search, find_exact, and find_objects
 // so agents know filterable_fields apply to entity find as well as corpus search.
 //
-// Embeddings: WithEmbedder on NewEngine. Parents embed EntityIndexText; parts embed
-// IndexText with parent title prefix (corpus only). One embedding dimension per process.
+// Embeddings: NewEngine requires WithEmbedder or WithLexicalOnly. Parents embed
+// EntityIndexText; parts embed IndexText with parent title prefix (corpus only).
+// One embedding dimension per process.
 // Helix hosts must call helixgraph.Graph.Bootstrap (or EnsureSearchIndexes) so
 // HasObjectSearch is true; MemoryGraph is always ready when attached.
 // Bootstrap(true) enables Helix tenant filtering when the image supports it.

--- a/brain/engine.go
+++ b/brain/engine.go
@@ -112,6 +112,19 @@ func WithLexicalOnly() EngineOption {
 	return func(eng *Engine) { eng.lexicalOnly = true }
 }
 
+// IndexTextFunc returns the document to embed and to write as graph search_text.
+// defaultText is Engine's index text for this object (SkipIndex already applied).
+// Return defaultText to keep it, or any rewrite that should occupy the vector
+// space (prefix, replace, drop the body, join related titles, …). Empty means
+// do not embed. Title, Summary, Content, and Properties on the stored object
+// are not modified.
+type IndexTextFunc func(obj Object, defaultText string) string
+
+// WithIndexText sets how Put builds embedding / graph search text.
+func WithIndexText(fn IndexTextFunc) EngineOption {
+	return func(eng *Engine) { eng.indexTextFn = fn }
+}
+
 // WithConfig sets ranking configuration (normalized by NewEngine).
 func WithConfig(cfg EngineConfig) EngineOption {
 	return func(eng *Engine) { eng.cfg = cfg }
@@ -172,6 +185,7 @@ type Engine struct {
 	catalog     *KindCatalog // always non-nil; empty ⇒ open mode
 	bootErr     error        // set by WithKinds when registration fails
 	lexicalOnly bool
+	indexTextFn IndexTextFunc
 }
 
 // NewEngine builds an Engine over a Store. store must be non-nil.

--- a/brain/engine.go
+++ b/brain/engine.go
@@ -11,7 +11,7 @@ import (
 )
 
 // QueryEmbedder embeds a query string for the dense search channel.
-// When nil on the Engine, search runs lexical-only.
+// NewEngine requires WithEmbedder or WithLexicalOnly.
 type QueryEmbedder interface {
 	Embed(ctx context.Context, text string) ([]float32, error)
 }
@@ -101,9 +101,15 @@ func (c EngineConfig) lambdaValue() float64 {
 // EngineOption configures NewEngine.
 type EngineOption func(*Engine)
 
-// WithEmbedder sets the optional query embedder for hybrid search.
+// WithEmbedder sets the query embedder for hybrid search and Put embeddings.
 func WithEmbedder(e QueryEmbedder) EngineOption {
 	return func(eng *Engine) { eng.embedder = e }
+}
+
+// WithLexicalOnly opts out of embeddings: Search is lexical-only and Put stores
+// no vector. Required when the host does not pass WithEmbedder.
+func WithLexicalOnly() EngineOption {
+	return func(eng *Engine) { eng.lexicalOnly = true }
 }
 
 // WithConfig sets ranking configuration (normalized by NewEngine).
@@ -153,18 +159,19 @@ func WithKinds(specs ...KindSpec) EngineOption {
 
 // Engine is the retrieval facade over a Store.
 type Engine struct {
-	store    Store
-	embedder QueryEmbedder
-	graph    GraphReader         // optional expand Neighbors
-	graphW   GraphWriter         // optional dual-write / Link (resolved in WithGraph)
-	graphS   GraphObjectSearcher // optional find_objects (resolved in WithGraph)
-	graphE   GraphEdgeSearcher   // optional edge text search (resolved in WithGraph)
-	reranker Reranker
-	recipeMu sync.RWMutex
-	recipes  map[string]ExpandRecipe // guarded by recipeMu
-	cfg      EngineConfig
-	catalog  *KindCatalog // always non-nil; empty ⇒ open mode
-	bootErr  error        // set by WithKinds when registration fails
+	store       Store
+	embedder    QueryEmbedder
+	graph       GraphReader         // optional expand Neighbors
+	graphW      GraphWriter         // optional dual-write / Link (resolved in WithGraph)
+	graphS      GraphObjectSearcher // optional find_objects (resolved in WithGraph)
+	graphE      GraphEdgeSearcher   // optional edge text search (resolved in WithGraph)
+	reranker    Reranker
+	recipeMu    sync.RWMutex
+	recipes     map[string]ExpandRecipe // guarded by recipeMu
+	cfg         EngineConfig
+	catalog     *KindCatalog // always non-nil; empty ⇒ open mode
+	bootErr     error        // set by WithKinds when registration fails
+	lexicalOnly bool
 }
 
 // NewEngine builds an Engine over a Store. store must be non-nil.
@@ -184,6 +191,12 @@ func NewEngine(store Store, opts ...EngineOption) (*Engine, error) {
 	}
 	if e.bootErr != nil {
 		return nil, e.bootErr
+	}
+	if e.embedder != nil && e.lexicalOnly {
+		return nil, fmt.Errorf("%w: WithEmbedder and WithLexicalOnly are mutually exclusive", ErrInvalid)
+	}
+	if e.embedder == nil && !e.lexicalOnly {
+		return nil, fmt.Errorf("%w: WithEmbedder is required (or WithLexicalOnly to opt out)", ErrInvalid)
 	}
 	e.cfg = e.cfg.withDefaults()
 	return e, nil

--- a/brain/engine.go
+++ b/brain/engine.go
@@ -254,7 +254,7 @@ func schemaFromStore(ctx context.Context, store KindReader, kind string) (Schema
 		if err != nil {
 			return SchemaResult{}, err
 		}
-		return SchemaResult{Kinds: []ObjectKindInfo{ObjectKindInfo(k)}, FilterUsage: fu}, nil
+		return SchemaResult{Kinds: []ObjectKindInfo{kindInfoFromObjectKind(k)}, FilterUsage: fu}, nil
 	}
 	kinds, err := store.ListKinds(ctx)
 	if err != nil {
@@ -262,7 +262,7 @@ func schemaFromStore(ctx context.Context, store KindReader, kind string) (Schema
 	}
 	out := make([]ObjectKindInfo, len(kinds))
 	for i, k := range kinds {
-		out[i] = ObjectKindInfo(k)
+		out[i] = kindInfoFromObjectKind(k)
 	}
 	return SchemaResult{Kinds: out, FilterUsage: fu}, nil
 }

--- a/brain/engine_options_test.go
+++ b/brain/engine_options_test.go
@@ -3,6 +3,7 @@ package brain_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,14 +18,44 @@ func (nopRerank) Rerank(context.Context, []brain.RichObject) ([]brain.RichObject
 	return nil, nil
 }
 
+func TestNewEngine_embedderOrLexicalOnly(t *testing.T) {
+	store := brain.NewMemoryStore()
+	_, err := brain.NewEngine(store)
+	if err == nil || !errors.Is(err, brain.ErrInvalid) || !strings.Contains(err.Error(), "WithEmbedder") || !strings.Contains(err.Error(), "WithLexicalOnly") {
+		t.Fatalf("neither option: %v", err)
+	}
+	_, err = brain.NewEngine(store, brain.WithEmbedder(nopEmbed{}), brain.WithLexicalOnly())
+	if err == nil || !errors.Is(err, brain.ErrInvalid) || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("both options: %v", err)
+	}
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ns := mustNS(t, "id", uuid.NewString())
+	got, err := eng.Put(context.Background(), brain.Scope{Namespace: ns}, brain.Object{
+		Kind: "Note", Title: "hello", Content: "body",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Embedding) != 0 {
+		t.Fatalf("lexical-only put must not embed: %+v", got.Embedding)
+	}
+}
+
+type nopEmbed struct{}
+
+func (nopEmbed) Embed(context.Context, string) ([]float32, error) { return []float32{1}, nil }
+
 // TestNewEngine_options: WithReranker/ExpandRecipes/Kinds construct path.
 func TestNewEngine_options(t *testing.T) {
 	ctx := context.Background()
 	store := brain.NewMemoryStore()
-	if _, err := brain.NewEngine(store, brain.WithExpandRecipes(brain.ExpandRecipe{Name: ""})); err == nil || !errors.Is(err, brain.ErrInvalid) {
+	if _, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithExpandRecipes(brain.ExpandRecipe{Name: ""})); err == nil || !errors.Is(err, brain.ErrInvalid) {
 		t.Fatalf("empty expand recipe name must fail construct: %v", err)
 	}
-	eng, err := brain.NewEngine(store,
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(),
 		brain.WithReranker(nopRerank{}),
 		brain.WithExpandRecipes(
 			brain.ExpandRecipe{Name: "kids", MaxHops: 1, WantContainment: true},

--- a/brain/engine_test.go
+++ b/brain/engine_test.go
@@ -24,7 +24,7 @@ func TestEngine_ReadRichObjectInScope(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func TestEngine_ReadRejectsOutsideScope(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +151,7 @@ func TestEngine_SchemaAndOrderedChildren(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,7 +191,7 @@ func TestEngine_SchemaAndOrderedChildren(t *testing.T) {
 }
 
 func TestEngine_SchemaUnknownKind(t *testing.T) {
-	eng, err := brain.NewEngine(brain.NewMemoryStore())
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +215,7 @@ func TestEngine_ListChildrenRequiresVisibleParent(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/brain/engramfile_test.go
+++ b/brain/engramfile_test.go
@@ -112,7 +112,7 @@ func TestValidateObject_engramReservedAndOpenCatalog(t *testing.T) {
 
 func mustCatalog(t *testing.T, specs ...brain.KindSpec) *brain.KindCatalog {
 	t.Helper()
-	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithKinds(specs...))
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly(), brain.WithKinds(specs...))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/brain/eval_test.go
+++ b/brain/eval_test.go
@@ -38,7 +38,7 @@ func TestEval_goldenSearchQueries(t *testing.T) {
 		})
 	}
 
-	eng, err := brain.NewEngine(store, brain.WithConfig(brain.EngineConfig{
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithConfig(brain.EngineConfig{
 		Now: func() time.Time { return now },
 	}))
 	if err != nil {
@@ -80,7 +80,7 @@ func TestEval_graphRAGComposition(t *testing.T) {
 	ctx := context.Background()
 	store := brain.NewMemoryStore()
 	g := brain.NewMemoryGraph()
-	eng, err := brain.NewEngine(store, brain.WithGraph(g), brain.WithKinds(
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(g), brain.WithKinds(
 		brain.KindSpec{Kind: "Deal", IsParent: true, Fields: []brain.FieldSpec{
 			{Name: "stage", Type: brain.FieldTypeString},
 		}},
@@ -341,7 +341,7 @@ func TestEval_graphRAGScopeSafeMultiHop(t *testing.T) {
 	_ = g.AddEdge(ctx, a, mid, "references", brain.EdgeMeta{})
 	_ = g.AddEdge(ctx, mid, leaf, "references", brain.EdgeMeta{})
 
-	eng, err := brain.NewEngine(store, brain.WithGraph(g))
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(g))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -415,7 +415,7 @@ func TestEval_degradeGraphKeepsContainment(t *testing.T) {
 		ID: child, Kind: "Chunk", Content: "c", ParentID: &parent, Position: &pos,
 		Namespace: ns, UpdatedAt: now,
 	})
-	eng, err := brain.NewEngine(store, brain.WithGraph(failGraph{}))
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(failGraph{}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -450,7 +450,7 @@ func TestConcurrent_searchAndExpand(t *testing.T) {
 			ParentID: &parent, Position: &pos, Namespace: ns, UpdatedAt: now,
 		})
 	}
-	eng, err := brain.NewEngine(store, brain.WithConfig(brain.EngineConfig{
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithConfig(brain.EngineConfig{
 		Now: func() time.Time { return now },
 	}))
 	if err != nil {

--- a/brain/expand_test.go
+++ b/brain/expand_test.go
@@ -14,7 +14,7 @@ import (
 
 // TestExpand_cancelledContextFailsClosed before store work.
 func TestExpand_cancelledContextFailsClosed(t *testing.T) {
-	eng, err := brain.NewEngine(brain.NewMemoryStore())
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,7 +38,7 @@ func TestExpand_parentChildrenOrdered(t *testing.T) {
 	_ = store.Put(context.Background(), brain.Object{ID: c2, Kind: "Chunk", Title: "second", Content: "body2", ParentID: &parent, Position: &pos2, Namespace: ns, UpdatedAt: now})
 	_ = store.Put(context.Background(), brain.Object{ID: c1, Kind: "Chunk", Title: "first", Content: "body1", ParentID: &parent, Position: &pos1, Namespace: ns, UpdatedAt: now})
 
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +77,7 @@ func TestExpand_partNeighborhoodWindow(t *testing.T) {
 			ParentID: &parent, Position: &pos, Namespace: ns, UpdatedAt: now,
 		})
 	}
-	eng, err := brain.NewEngine(store, brain.WithConfig(brain.EngineConfig{SiblingRadius: 1}))
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithConfig(brain.EngineConfig{SiblingRadius: 1}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +118,7 @@ func TestExpand_highCardinalityResultSetAndContinue(t *testing.T) {
 			Namespace: ns, UpdatedAt: now,
 		})
 	}
-	eng, err := brain.NewEngine(store, brain.WithConfig(brain.EngineConfig{
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithConfig(brain.EngineConfig{
 		ExpandInlineMax: 5, MaxResultSetSize: 10, DefaultLimit: 3, MaxLimit: 50,
 		Now: func() time.Time { return now },
 	}))
@@ -162,7 +162,7 @@ func TestExpand_directionFiltersEdges(t *testing.T) {
 	}
 	_ = g.AddEdge(ctx, a, b, "references", brain.EdgeMeta{})
 	_ = g.AddEdge(ctx, b, c, "references", brain.EdgeMeta{})
-	eng, err := brain.NewEngine(store, brain.WithGraph(g))
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(g))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -195,7 +195,7 @@ func TestExpand_graphContinuePreservesRelation(t *testing.T) {
 		_ = store.Put(ctx, brain.Object{ID: id, Kind: "Document", Title: id.String()[:8], Namespace: ns, UpdatedAt: now})
 		_ = g.AddEdge(ctx, root, id, "references", brain.EdgeMeta{Note: "hop-" + id.String()[:4]})
 	}
-	eng, err := brain.NewEngine(store, brain.WithGraph(g), brain.WithConfig(brain.EngineConfig{
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(g), brain.WithConfig(brain.EngineConfig{
 		ExpandInlineMax: 2, DefaultLimit: 2, MaxLimit: 50, GraphNeighborK: 50,
 		Now: func() time.Time { return now },
 	}))
@@ -252,7 +252,7 @@ func TestExpandMany_landingsAndBudget(t *testing.T) {
 		}
 	}
 	_ = g.AddEdge(ctx, p1, n1, "references", brain.EdgeMeta{Note: "edge"})
-	eng, err := brain.NewEngine(store, brain.WithGraph(g), brain.WithConfig(brain.EngineConfig{
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(g), brain.WithConfig(brain.EngineConfig{
 		MaxResultSetSize: 2, Now: func() time.Time { return now },
 	}))
 	if err != nil {
@@ -264,7 +264,7 @@ func TestExpandMany_landingsAndBudget(t *testing.T) {
 		t.Fatalf("empty: %+v err=%v", empty, err)
 	}
 	// graph required without graph engine
-	engNoG, err := brain.NewEngine(store)
+	engNoG, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -319,7 +319,7 @@ func TestSearch_withReranker(t *testing.T) {
 		ID: part, Kind: "Chunk", Title: "chunk", Content: "unique rerank phrase alpha",
 		ParentID: &parent, Position: &pos, Namespace: ns, UpdatedAt: now,
 	})
-	eng, err := brain.NewEngine(store,
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(),
 		brain.WithReranker(reverseRerank{}),
 		brain.WithConfig(brain.EngineConfig{Now: func() time.Time { return now }}),
 	)
@@ -363,7 +363,7 @@ func TestExpand_graphNeighborsMemoryGraph(t *testing.T) {
 	_ = g.AddEdge(context.Background(), c, a, "references", brain.EdgeMeta{})
 	_ = g.AddEdge(context.Background(), a, hidden, "references", brain.EdgeMeta{})
 
-	eng, err := brain.NewEngine(store, brain.WithGraph(g))
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(g))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -407,7 +407,7 @@ func TestExpand_partMixedContainmentAndGraph(t *testing.T) {
 	g := brain.NewMemoryGraph()
 	_ = g.AddEdge(context.Background(), part, linked, "references", brain.EdgeMeta{})
 
-	eng, err := brain.NewEngine(store, brain.WithGraph(g), brain.WithConfig(brain.EngineConfig{SiblingRadius: 1}))
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(g), brain.WithConfig(brain.EngineConfig{SiblingRadius: 1}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -444,7 +444,7 @@ func TestExpand_graphStoreErrorSurfaces(t *testing.T) {
 	g := brain.NewMemoryGraph()
 	_ = g.AddEdge(context.Background(), root, store.failID, "references", brain.EdgeMeta{})
 
-	eng, err := brain.NewEngine(store, brain.WithGraph(g))
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(g))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -505,7 +505,7 @@ func TestExpand_graphRequiresBackend(t *testing.T) {
 	ns := mustNS(t, "id", uuid.NewString())
 	id := uuid.New()
 	_ = store.Put(context.Background(), brain.Object{ID: id, Kind: "Document", Namespace: ns})
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -518,7 +518,7 @@ func TestExpand_graphRequiresBackend(t *testing.T) {
 }
 
 func TestExpand_missingObject(t *testing.T) {
-	eng, err := brain.NewEngine(brain.NewMemoryStore())
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/brain/find_objects.go
+++ b/brain/find_objects.go
@@ -8,18 +8,21 @@ import (
 	"github.com/google/uuid"
 )
 
-// FindObjectsRequest is the engine input for entity/object find (graph node search).
+// FindObjectsRequest is entity retrieval (graph parent nodes).
+// Query matches entity index text (title, summary, indexed properties, body).
+// Filters apply to the hydrated parent row (same keys as schema filterable_fields).
+// Corpus retrieval is SearchRequest (store parts).
 type FindObjectsRequest struct {
 	Query   string
 	Kinds   []string // optional host kind names; empty = all kinds
-	Filters Filter   // same property keys as search; see schema filterable_fields
+	Filters Filter
 	Limit   int
 }
 
-// FindObjects ranks knowledge objects as entities via GraphObjectSearcher
-// (Helix text/vector or MemoryGraph), then hydrates under Scope from the store.
-// Filters use the same catalog rules as search/find_exact (schema filterable_fields).
-// Not a substitute for corpus Search: no part promotion evidence path.
+// FindObjects ranks first-class objects via GraphObjectSearcher (Helix or
+// MemoryGraph), then hydrates under Scope from the store and applies Filters
+// on parent rows. Requires a graph. Not corpus Search: no part evidence path.
+// A parent with no parts is visible here and invisible to Search.
 func (e *Engine) FindObjects(ctx context.Context, scope Scope, req FindObjectsRequest, results ResultSetStore) (page SearchPage, err error) {
 	if e.graphS == nil {
 		return page, fmt.Errorf("%w: graph object search is not available", ErrUnsupported)

--- a/brain/find_objects_test.go
+++ b/brain/find_objects_test.go
@@ -188,7 +188,7 @@ func TestFindObjects_multiTurnMemoryGraph(t *testing.T) {
 		t.Fatalf("org scope should see workspace graph node: %+v", pageOrg.Objects)
 	}
 	// Without object searcher.
-	engNo, err := brain.NewEngine(store)
+	engNo, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/brain/graph.go
+++ b/brain/graph.go
@@ -47,7 +47,8 @@ type GraphReader interface {
 // Embeds GraphReader so a single WithGraph value can satisfy both read and write.
 type GraphWriter interface {
 	GraphReader
-	// EnsureObject upserts a graph node for obj.ID (searchable props when available).
+	// EnsureObject upserts a graph node for a first-class object (parents only).
+	// Node text and vector are what FindObjects searches.
 	// Must preserve incident edges (update in place, not drop+recreate).
 	EnsureObject(ctx context.Context, obj Object) error
 	// RemoveObject drops the node (and incident edges) after/with store soft-delete.
@@ -58,10 +59,10 @@ type GraphWriter interface {
 	RemoveEdge(ctx context.Context, from, to uuid.UUID, relationType string) error
 }
 
-// GraphObjectSearcher finds entity nodes by text and/or vector (Helix native indexes
-// or MemoryGraph in-process). Results are ranked best-first; Engine hydrates under Scope.
-// Namespace is applied by MemoryGraph via Covers; Helix returns unscoped candidates
-// and Engine hydrates under Scope.
+// GraphObjectSearcher is entity retrieval over parent nodes (find_objects).
+// It does not search chunks. Corpus retrieval is PartSearcher on the store.
+// Results are ranked best-first; Engine hydrates under Scope.
+// Namespace: MemoryGraph uses Covers; Helix returns unscoped candidates.
 type GraphObjectSearcher interface {
 	SearchText(ctx context.Context, query string, limit int, namespace Namespace) ([]ScoredID, error)
 	SearchVector(ctx context.Context, embedding []float32, limit int, namespace Namespace) ([]ScoredID, error)

--- a/brain/graph.go
+++ b/brain/graph.go
@@ -48,9 +48,9 @@ type GraphReader interface {
 type GraphWriter interface {
 	GraphReader
 	// EnsureObject upserts a graph node for a first-class object (parents only).
-	// Node text and vector are what FindObjects searches.
+	// searchText is the entity document Engine computed (FindObjects text/vector).
 	// Must preserve incident edges (update in place, not drop+recreate).
-	EnsureObject(ctx context.Context, obj Object) error
+	EnsureObject(ctx context.Context, obj Object, searchText string) error
 	// RemoveObject drops the node (and incident edges) after/with store soft-delete.
 	RemoveObject(ctx context.Context, id uuid.UUID) error
 	// AddEdge creates a directed edge from→to with optional relationship metadata.
@@ -123,7 +123,7 @@ func NewMemoryGraph() *MemoryGraph {
 
 // EnsureObject implements GraphWriter and stores searchable props for FindObjects.
 // Replaces any prior node for the same id (live update; edges are independent).
-func (g *MemoryGraph) EnsureObject(ctx context.Context, obj Object) error {
+func (g *MemoryGraph) EnsureObject(ctx context.Context, obj Object, searchText string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -136,7 +136,7 @@ func (g *MemoryGraph) EnsureObject(ctx context.Context, obj Object) error {
 		kind:       obj.Kind,
 		title:      obj.Title,
 		summary:    obj.Summary,
-		searchText: EntityIndexText(obj),
+		searchText: searchText,
 		namespace:  obj.Namespace.Clone(),
 		updatedAt:  obj.UpdatedAt,
 	}

--- a/brain/graph_extra_test.go
+++ b/brain/graph_extra_test.go
@@ -91,7 +91,7 @@ func TestMemoryGraph_cancelledContextFailsClosed(t *testing.T) {
 	if err := g.AddEdge(ctx, a, uuid.New(), "about", EdgeMeta{}); !errors.Is(err, context.Canceled) {
 		t.Fatalf("AddEdge: %v", err)
 	}
-	if err := g.EnsureObject(ctx, Object{ID: a, Kind: "Document"}); !errors.Is(err, context.Canceled) {
+	if err := g.EnsureObject(ctx, Object{ID: a, Kind: "Document"}, ""); !errors.Is(err, context.Canceled) {
 		t.Fatalf("EnsureObject: %v", err)
 	}
 	if err := g.RemoveObject(ctx, a); !errors.Is(err, context.Canceled) {
@@ -145,5 +145,27 @@ func TestEdgeMeta_IsZero(t *testing.T) {
 func TestMemoryGraph_removeObjectNilID(t *testing.T) {
 	if err := NewMemoryGraph().RemoveObject(context.Background(), uuid.Nil); err == nil {
 		t.Fatal("want error")
+	}
+}
+
+// TestMemoryGraph_searchUsesEnsureObjectText: FindObjects text is the string
+// passed to EnsureObject, not a recompute from the object.
+func TestMemoryGraph_searchUsesEnsureObjectText(t *testing.T) {
+	ctx := context.Background()
+	g := NewMemoryGraph()
+	id := uuid.New()
+	if err := g.EnsureObject(ctx, Object{ID: id, Title: "Acme renewal", Kind: "Deal"}, "custom retrieval document"); err != nil {
+		t.Fatal(err)
+	}
+	hit, err := g.SearchText(ctx, "custom retrieval", 5, nil)
+	if err != nil || len(hit) != 1 || hit[0].ID != id {
+		t.Fatalf("searchText: %+v err=%v", hit, err)
+	}
+	miss, err := g.SearchText(ctx, "Acme renewal", 5, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(miss) != 0 {
+		t.Fatalf("title must not be indexed unless it was in searchText: %+v", miss)
 	}
 }

--- a/brain/helixgraph/graph.go
+++ b/brain/helixgraph/graph.go
@@ -403,7 +403,7 @@ func (g *Graph) resolveNodeObjectIDs(ctx context.Context, internal []uint64) (ma
 
 // EnsureObject implements brain.GraphWriter: insert if missing, else update props in place.
 // Incident edges are preserved (never drop+recreate the node identity).
-func (g *Graph) EnsureObject(ctx context.Context, obj brain.Object) error {
+func (g *Graph) EnsureObject(ctx context.Context, obj brain.Object, searchText string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -415,9 +415,9 @@ func (g *Graph) EnsureObject(ctx context.Context, obj brain.Object) error {
 		return err
 	}
 	if exists {
-		return g.updateObjectProps(ctx, obj)
+		return g.updateObjectProps(ctx, obj, searchText)
 	}
-	return g.insertObject(ctx, obj)
+	return g.insertObject(ctx, obj, searchText)
 }
 
 func (g *Graph) objectExists(ctx context.Context, id uuid.UUID) (bool, error) {
@@ -439,10 +439,10 @@ func (g *Graph) objectExists(ctx context.Context, id uuid.UUID) (bool, error) {
 	return raw.N.Count > 0, nil
 }
 
-func (g *Graph) insertObject(ctx context.Context, obj brain.Object) error {
+func (g *Graph) insertObject(ctx context.Context, obj brain.Object, searchText string) error {
 	q := helix.WriteQuery("brain_insert_object")
 	oid := q.ParamString("object_id", obj.ID.String())
-	props := objectProps(oid, obj)
+	props := objectProps(oid, obj, searchText)
 	req := q.
 		VarAs("n", helix.G().AddN(nodeLabel, props)).
 		Returning("n")
@@ -452,10 +452,10 @@ func (g *Graph) insertObject(ctx context.Context, obj brain.Object) error {
 	return nil
 }
 
-func (g *Graph) updateObjectProps(ctx context.Context, obj brain.Object) error {
+func (g *Graph) updateObjectProps(ctx context.Context, obj brain.Object, searchText string) error {
 	q := helix.WriteQuery("brain_update_object")
 	oid := q.ParamString("object_id", obj.ID.String())
-	pairs := objectPropPairs(obj)
+	pairs := objectPropPairs(obj, searchText)
 	if len(pairs) == 0 {
 		return nil
 	}
@@ -476,7 +476,7 @@ type namedProp struct {
 }
 
 // objectPropPairs returns updatable node properties (excludes object_id identity).
-func objectPropPairs(obj brain.Object) []namedProp {
+func objectPropPairs(obj brain.Object, searchText string) []namedProp {
 	var props []namedProp
 	if obj.Kind != "" {
 		props = append(props, namedProp{propKind, obj.Kind})
@@ -487,7 +487,7 @@ func objectPropPairs(obj brain.Object) []namedProp {
 	if obj.Summary != "" {
 		props = append(props, namedProp{propSummary, obj.Summary})
 	}
-	if st := brain.EntityIndexText(obj); st != "" {
+	if st := strings.TrimSpace(searchText); st != "" {
 		props = append(props, namedProp{propSearchText, st})
 	}
 	if !obj.Namespace.Empty() {
@@ -541,8 +541,8 @@ func scalarPropValue(v any) (any, bool) {
 	}
 }
 
-func objectProps(oid helix.ParamRef, obj brain.Object) helix.Props {
-	pairs := objectPropPairs(obj)
+func objectProps(oid helix.ParamRef, obj brain.Object, searchText string) helix.Props {
+	pairs := objectPropPairs(obj, searchText)
 	props := make(helix.Props, 0, len(pairs)+1)
 	props = append(props, helix.Prop(propObjectID, oid))
 	for _, p := range pairs {

--- a/brain/helixgraph/graph_write_test.go
+++ b/brain/helixgraph/graph_write_test.go
@@ -69,7 +69,7 @@ func TestGraph_ensureObjectAndAddEdgeRequestShape(t *testing.T) {
 		UpdatedAt: now,
 		Embedding: []float32{0.1, 0.2},
 	}
-	if err := g.EnsureObject(ctx, obj); err != nil {
+	if err := g.EnsureObject(ctx, obj, brain.EntityIndexText(obj)); err != nil {
 		t.Fatal(err)
 	}
 	// First EnsureObject: exists-check then insert (AddN, no node Drop).
@@ -98,7 +98,7 @@ func TestGraph_ensureObjectAndAddEdgeRequestShape(t *testing.T) {
 	// Second EnsureObject updates in place (SetProperty), no AddN / node Drop.
 	nBeforeUpdate := len(bodies)
 	obj.Title = "memo-v2"
-	if err := g.EnsureObject(ctx, obj); err != nil {
+	if err := g.EnsureObject(ctx, obj, brain.EntityIndexText(obj)); err != nil {
 		t.Fatal(err)
 	}
 	updateBodies := bodies[nBeforeUpdate:]
@@ -174,7 +174,7 @@ func TestGraph_writeValidation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := g.EnsureObject(ctx, brain.Object{}); err == nil {
+	if err := g.EnsureObject(ctx, brain.Object{}, ""); err == nil {
 		t.Fatal("nil object id")
 	}
 	if err := g.AddEdge(ctx, uuid.New(), uuid.Nil, "r", brain.EdgeMeta{}); err == nil {
@@ -197,7 +197,7 @@ func TestGraph_writeValidation(t *testing.T) {
 	if err := g.RemoveObject(cctx, uuid.New()); !errors.Is(err, context.Canceled) {
 		t.Fatalf("cancelled RemoveObject: %v", err)
 	}
-	if err := g.EnsureObject(cctx, brain.Object{ID: uuid.New()}); !errors.Is(err, context.Canceled) {
+	if err := g.EnsureObject(cctx, brain.Object{ID: uuid.New()}, ""); !errors.Is(err, context.Canceled) {
 		t.Fatalf("cancelled EnsureObject: %v", err)
 	}
 	if err := g.Bootstrap(cctx, false); !errors.Is(err, context.Canceled) {

--- a/brain/helixgraph/integration_test.go
+++ b/brain/helixgraph/integration_test.go
@@ -37,7 +37,7 @@ func TestGraph_liveNeighborsBoth(t *testing.T) {
 
 	a, b, c := uuid.New(), uuid.New(), uuid.New()
 	for _, id := range []uuid.UUID{a, b, c} {
-		if err := g.EnsureObject(ctx, brain.Object{ID: id}); err != nil {
+		if err := g.EnsureObject(ctx, brain.Object{ID: id}, ""); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -115,17 +115,17 @@ func TestGraph_liveEnsureObjectIdempotent(t *testing.T) {
 	g := liveGraph(t)
 	id := uuid.New()
 	other := uuid.New()
-	if err := g.EnsureObject(ctx, brain.Object{ID: id, Title: "a"}); err != nil {
+	if err := g.EnsureObject(ctx, brain.Object{ID: id, Title: "a"}, "a"); err != nil {
 		t.Fatal(err)
 	}
-	if err := g.EnsureObject(ctx, brain.Object{ID: other, Title: "b"}); err != nil {
+	if err := g.EnsureObject(ctx, brain.Object{ID: other, Title: "b"}, "b"); err != nil {
 		t.Fatal(err)
 	}
 	if err := g.AddEdge(ctx, id, other, "references", brain.EdgeMeta{Note: "keep"}); err != nil {
 		t.Fatal(err)
 	}
 	// Re-ensure without re-link: edges must survive.
-	if err := g.EnsureObject(ctx, brain.Object{ID: id, Title: "a-v2"}); err != nil {
+	if err := g.EnsureObject(ctx, brain.Object{ID: id, Title: "a-v2"}, "a-v2"); err != nil {
 		t.Fatal(err)
 	}
 	ns, err := g.Neighbors(ctx, id, []string{"references"}, 5)
@@ -337,10 +337,10 @@ func TestGraph_liveEnsureObjectRichProps(t *testing.T) {
 		CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
 		Embedding: []float32{0, 1},
 	}
-	if err := g.EnsureObject(ctx, a); err != nil {
+	if err := g.EnsureObject(ctx, a, brain.EntityIndexText(a)); err != nil {
 		t.Fatal(err)
 	}
-	if err := g.EnsureObject(ctx, b); err != nil {
+	if err := g.EnsureObject(ctx, b, brain.EntityIndexText(b)); err != nil {
 		t.Fatal(err)
 	}
 	if err := g.AddEdge(ctx, a.ID, b.ID, "references", brain.EdgeMeta{}); err != nil {
@@ -350,7 +350,7 @@ func TestGraph_liveEnsureObjectRichProps(t *testing.T) {
 	// Turn 2: re-ensure A with new title (in-place); edge to B must remain without re-link.
 	a.Title = "Alpha-v2"
 	a.Content = "updated alpha"
-	if err := g.EnsureObject(ctx, a); err != nil {
+	if err := g.EnsureObject(ctx, a, brain.EntityIndexText(a)); err != nil {
 		t.Fatal(err)
 	}
 	ns, err := g.Neighbors(ctx, a.ID, []string{"references"}, 10)
@@ -436,10 +436,10 @@ func TestGraph_liveSearchEdgesTextVectorAndProps(t *testing.T) {
 		CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
 		Embedding: []float32{0, 1},
 	}
-	if err := g.EnsureObject(ctx, a); err != nil {
+	if err := g.EnsureObject(ctx, a, brain.EntityIndexText(a)); err != nil {
 		t.Fatal(err)
 	}
-	if err := g.EnsureObject(ctx, b); err != nil {
+	if err := g.EnsureObject(ctx, b, brain.EntityIndexText(b)); err != nil {
 		t.Fatal(err)
 	}
 	// Full edge meta for AddEdge prop dual-write.

--- a/brain/helixgraph/integration_test.go
+++ b/brain/helixgraph/integration_test.go
@@ -149,7 +149,7 @@ func TestEngine_liveFindObjectsTextSearch(t *testing.T) {
 		t.Fatalf("Bootstrap: %v", err)
 	}
 	store := brain.NewMemoryStore()
-	eng, err := brain.NewEngine(store, brain.WithGraph(g), brain.WithKinds(
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(g), brain.WithKinds(
 		brain.KindSpec{Kind: "Fact", IsParent: true},
 		brain.KindSpec{Kind: "Deal", IsParent: true},
 	))
@@ -567,7 +567,7 @@ func TestEngine_liveFindLinksSearchEdges(t *testing.T) {
 		t.Skipf("edge text index: %v", err)
 	}
 	store := brain.NewMemoryStore()
-	eng, err := brain.NewEngine(store, brain.WithGraph(g), brain.WithKinds(
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(g), brain.WithKinds(
 		brain.KindSpec{Kind: "Document", IsParent: true},
 		brain.KindSpec{Kind: "Fact", IsParent: true},
 	))

--- a/brain/kind.go
+++ b/brain/kind.go
@@ -174,6 +174,9 @@ func NormalizeKindSpec(spec KindSpec) (KindSpec, error) {
 		if f.Name == "" {
 			return KindSpec{}, fmt.Errorf("brain: kind %q field: name is required", spec.Kind)
 		}
+		if isObjectColumn(f.Name) {
+			return KindSpec{}, fmt.Errorf("brain: kind %q field: %q collides with an object column", spec.Kind, f.Name)
+		}
 		if isCoreFilterKey(f.Name) {
 			return KindSpec{}, fmt.Errorf("brain: kind %q field: %q collides with a core filter key", spec.Kind, f.Name)
 		}
@@ -201,6 +204,15 @@ func NormalizeKindSpec(spec KindSpec) (KindSpec, error) {
 	}
 	spec.Fields = fields
 	return spec, nil
+}
+
+func isObjectColumn(k string) bool {
+	switch k {
+	case "title", "summary", "content":
+		return true
+	default:
+		return false
+	}
 }
 
 func isCoreFilterKey(k string) bool {
@@ -248,7 +260,18 @@ func KindSpecFromObjectKind(k ObjectKind) (KindSpec, error) {
 
 // KindInfoFromSpec builds the agent-facing schema payload for one kind.
 func KindInfoFromSpec(spec KindSpec) ObjectKindInfo {
-	return ObjectKindInfo(objectKindFromNormalized(spec))
+	return kindInfoFromObjectKind(objectKindFromNormalized(spec))
+}
+
+func kindInfoFromObjectKind(k ObjectKind) ObjectKindInfo {
+	return ObjectKindInfo{
+		Kind:             k.Kind,
+		Description:      k.Description,
+		IsPart:           k.IsPart,
+		IsParent:         k.IsParent,
+		Columns:          CoreColumns(),
+		FilterableFields: k.FilterableFields,
+	}
 }
 
 // KindRegistry is KindReader + KindWriter for durable kind schemas.

--- a/brain/kind.go
+++ b/brain/kind.go
@@ -26,8 +26,10 @@ type FieldSpec struct {
 	Type        FieldType `json:"type"`
 	Description string    `json:"description,omitempty"`
 	Required    bool      `json:"required,omitempty"`
-	Operators   []string  `json:"operators,omitempty"` // always eq, or eq+in (see NormalizeKindSpec)
-	Examples    []string  `json:"examples,omitempty"`
+	Operators   []string  `json:"operators,omitempty"`  // always eq, or eq+in (see NormalizeKindSpec)
+	Examples    []string  `json:"examples,omitempty"`   // documentation only; not enforced
+	Enum        []string  `json:"enum,omitempty"`       // closed set for string fields; enforced on Put
+	SkipIndex   bool      `json:"skip_index,omitempty"` // omit from entity index text; still stored and filterable
 }
 
 // KindSpec is the host-facing definition of a knowledge object kind.
@@ -194,6 +196,11 @@ func NormalizeKindSpec(spec KindSpec) (KindSpec, error) {
 			return KindSpec{}, fmt.Errorf("brain: kind %q: duplicate field %q", spec.Kind, f.Name)
 		}
 		seen[f.Name] = struct{}{}
+		enum, err := normalizeFieldEnum(spec.Kind, f)
+		if err != nil {
+			return KindSpec{}, err
+		}
+		f.Enum = enum
 		// Operators are documentation for schema(); always the closed set we implement.
 		if f.Type == FieldTypeBoolean {
 			f.Operators = []string{"eq"}
@@ -204,6 +211,29 @@ func NormalizeKindSpec(spec KindSpec) (KindSpec, error) {
 	}
 	spec.Fields = fields
 	return spec, nil
+}
+
+func normalizeFieldEnum(kind string, f FieldSpec) ([]string, error) {
+	if len(f.Enum) == 0 {
+		return nil, nil
+	}
+	if f.Type != FieldTypeString {
+		return nil, fmt.Errorf("brain: kind %q field %q: enum is only valid on string fields", kind, f.Name)
+	}
+	out := make([]string, 0, len(f.Enum))
+	seen := make(map[string]struct{}, len(f.Enum))
+	for _, v := range f.Enum {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			return nil, fmt.Errorf("brain: kind %q field %q: enum value is required", kind, f.Name)
+		}
+		if _, dup := seen[v]; dup {
+			return nil, fmt.Errorf("brain: kind %q field %q: duplicate enum value %q", kind, f.Name, v)
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out, nil
 }
 
 func isObjectColumn(k string) bool {

--- a/brain/kind_test.go
+++ b/brain/kind_test.go
@@ -30,6 +30,14 @@ func TestNormalizeKindSpec_rejectsInvalidFields(t *testing.T) {
 			Kind:   "Document",
 			Fields: []brain.FieldSpec{{Name: "content", Type: brain.FieldTypeString}},
 		}, "object column"},
+		{"enum on number", brain.KindSpec{
+			Kind:   "Document",
+			Fields: []brain.FieldSpec{{Name: "stage", Type: brain.FieldTypeNumber, Enum: []string{"1"}}},
+		}, "enum is only valid on string"},
+		{"empty enum value", brain.KindSpec{
+			Kind:   "Document",
+			Fields: []brain.FieldSpec{{Name: "stage", Type: brain.FieldTypeString, Enum: []string{"open", " "}}},
+		}, "enum value is required"},
 		{"duplicate field", brain.KindSpec{
 			Kind: "Document",
 			Fields: []brain.FieldSpec{
@@ -172,6 +180,9 @@ func TestSchema_prefersCatalog(t *testing.T) {
 	}
 	if got := one.Kinds[0].Columns; len(got) != 3 || got[0].Name != "title" || !got[0].Filter || got[1].Name != "summary" || got[2].Name != "content" {
 		t.Fatalf("columns: %+v", got)
+	}
+	if !strings.Contains(one.FilterUsage.Note, "enum") {
+		t.Fatalf("filter_usage.note should mention enum: %s", one.FilterUsage.Note)
 	}
 	var fields []brain.FieldSpec
 	if err := json.Unmarshal(one.Kinds[0].FilterableFields, &fields); err != nil {

--- a/brain/kind_test.go
+++ b/brain/kind_test.go
@@ -26,6 +26,10 @@ func TestNormalizeKindSpec_rejectsInvalidFields(t *testing.T) {
 			Kind:   "Document",
 			Fields: []brain.FieldSpec{{Name: "created_after", Type: brain.FieldTypeString}},
 		}, "core filter"},
+		{"object column collision", brain.KindSpec{
+			Kind:   "Document",
+			Fields: []brain.FieldSpec{{Name: "content", Type: brain.FieldTypeString}},
+		}, "object column"},
 		{"duplicate field", brain.KindSpec{
 			Kind: "Document",
 			Fields: []brain.FieldSpec{
@@ -163,8 +167,11 @@ func TestSchema_prefersCatalog(t *testing.T) {
 	if len(one.FilterUsage.Tools) < 3 || !strings.Contains(strings.Join(one.FilterUsage.Tools, ","), "find_objects") {
 		t.Fatalf("filter_usage.tools: %+v", one.FilterUsage)
 	}
-	if !strings.Contains(one.FilterUsage.Note, "filterable_fields") {
+	if !strings.Contains(one.FilterUsage.Note, "filterable_fields") || !strings.Contains(one.FilterUsage.Note, "columns") {
 		t.Fatalf("filter_usage.note: %s", one.FilterUsage.Note)
+	}
+	if got := one.Kinds[0].Columns; len(got) != 3 || got[0].Name != "title" || !got[0].Filter || got[1].Name != "summary" || got[2].Name != "content" {
+		t.Fatalf("columns: %+v", got)
 	}
 	var fields []brain.FieldSpec
 	if err := json.Unmarshal(one.Kinds[0].FilterableFields, &fields); err != nil {

--- a/brain/kind_test.go
+++ b/brain/kind_test.go
@@ -66,7 +66,7 @@ func TestNormalizeKindSpec_rejectsInvalidFields(t *testing.T) {
 
 func TestValidateFiltersAgainst_catalogRules(t *testing.T) {
 	store := brain.NewMemoryStore()
-	eng, err := brain.NewEngine(store, brain.WithKinds(
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithKinds(
 		brain.KindSpec{
 			Kind: "Document", IsParent: true,
 			Fields: []brain.FieldSpec{
@@ -125,7 +125,7 @@ func TestEmptyCatalog_openFiltersAndStoreSchema(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -146,7 +146,7 @@ func TestSchema_prefersCatalog(t *testing.T) {
 	store := brain.NewMemoryStore()
 	// Store has different description; catalog wins when non-empty.
 	_ = store.PutKind(ctx, brain.ObjectKind{Kind: "Document", Description: "store copy", IsParent: true})
-	eng, err := brain.NewEngine(store, brain.WithKinds(
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithKinds(
 		brain.KindSpec{
 			Kind: "Document", Description: "catalog copy", IsParent: true,
 			Fields: []brain.FieldSpec{{Name: "stage", Type: brain.FieldTypeString}},
@@ -228,7 +228,7 @@ func TestSearch_catalogRestrictsKindsAndAllowsFilteredHit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	eng, err := brain.NewEngine(store, brain.WithKinds(
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithKinds(
 		brain.KindSpec{Kind: "Document", IsParent: true},
 		brain.KindSpec{Kind: "Chunk", IsPart: true},
 	))
@@ -266,7 +266,7 @@ func TestSearch_catalogRestrictsKindsAndAllowsFilteredHit(t *testing.T) {
 func TestApplyKinds_migrationAddAndModify(t *testing.T) {
 	ctx := context.Background()
 	store := brain.NewMemoryStore()
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -322,7 +322,7 @@ func TestApplyKinds_migrationAddAndModify(t *testing.T) {
 	}
 
 	// New process adopts durable state via LoadKindsFromStore.
-	eng2, err := brain.NewEngine(store)
+	eng2, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -346,7 +346,7 @@ func TestApplyKinds_migrationAddAndModify(t *testing.T) {
 
 	// SyncKindsToStore flushes WithKinds catalog to a durable writer.
 	mem := brain.NewMemoryStore()
-	engSync, err := brain.NewEngine(mem, brain.WithKinds(
+	engSync, err := brain.NewEngine(mem, brain.WithLexicalOnly(), brain.WithKinds(
 		brain.KindSpec{Kind: "Synced", IsParent: true, Description: "via sync"},
 	))
 	if err != nil {
@@ -372,7 +372,7 @@ func TestApplyKinds_migrationAddAndModify(t *testing.T) {
 func TestApplyKinds_invalidBatchFailsClosed(t *testing.T) {
 	ctx := context.Background()
 	store := brain.NewMemoryStore()
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -392,7 +392,7 @@ func TestApplyKinds_invalidBatchFailsClosed(t *testing.T) {
 }
 
 func TestWithKinds_invalidFailsNewEngine(t *testing.T) {
-	_, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithKinds(brain.KindSpec{}))
+	_, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly(), brain.WithKinds(brain.KindSpec{}))
 	if err == nil {
 		t.Fatal("want error")
 	}

--- a/brain/memory.go
+++ b/brain/memory.go
@@ -280,7 +280,7 @@ func (s *MemoryStore) ListKinds(_ context.Context) ([]ObjectKind, error) {
 }
 
 // SearchLexical implements PartSearcher with a deterministic TF×IDF-style score.
-// Only content-bearing parts (parent_id set) are candidates.
+// Only parts (parent_id set) are candidates.
 func (s *MemoryStore) SearchLexical(_ context.Context, scope Scope, query string, filters Filter, k int) ([]ScoredID, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -336,7 +336,7 @@ func (s *MemoryStore) SearchLexical(_ context.Context, scope Scope, query string
 	return topKScored(scored, k), nil
 }
 
-// SearchVector implements PartSearcher via cosine similarity on Object.Embedding.
+// SearchVector implements PartSearcher over part embeddings only.
 func (s *MemoryStore) SearchVector(_ context.Context, scope Scope, embedding []float32, filters Filter, k int) ([]ScoredID, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -394,7 +394,8 @@ func (s *MemoryStore) SearchTrigram(_ context.Context, scope Scope, query string
 	return topKScored(scored, k), nil
 }
 
-// candidateParts returns live store values under the caller's lock; do not retain across unlock.
+// candidateParts returns live parts (parent_id set) under the caller's lock.
+// Do not retain the slice across unlock.
 func (s *MemoryStore) candidateParts(scope Scope, filters Filter) ([]Object, error) {
 	plan, err := compileFilters(filters)
 	if err != nil {

--- a/brain/postgres/store.go
+++ b/brain/postgres/store.go
@@ -424,7 +424,8 @@ func (s *Store) scanObject(row scannable) (brain.Object, error) {
 	return o, nil
 }
 
-// SearchLexical implements PartSearcher using pg_textsearch BM25.
+// SearchLexical implements PartSearcher using pg_textsearch BM25 over parts
+// (parent_id set). search_text is title, summary, and content.
 func (s *Store) SearchLexical(ctx context.Context, scope brain.Scope, query string, filters brain.Filter, k int) ([]brain.ScoredID, error) {
 	if k <= 0 || strings.TrimSpace(query) == "" {
 		return nil, nil
@@ -446,7 +447,7 @@ func (s *Store) SearchLexical(ctx context.Context, scope brain.Scope, query stri
 	return s.queryScored(ctx, q, args, true)
 }
 
-// SearchVector implements PartSearcher using pgvector cosine distance.
+// SearchVector implements PartSearcher using pgvector cosine distance over parts.
 func (s *Store) SearchVector(ctx context.Context, scope brain.Scope, embedding []float32, filters brain.Filter, k int) ([]brain.ScoredID, error) {
 	if k <= 0 || len(embedding) == 0 {
 		return nil, nil
@@ -469,7 +470,7 @@ func (s *Store) SearchVector(ctx context.Context, scope brain.Scope, embedding [
 	return s.queryScored(ctx, q, args, false)
 }
 
-// SearchTrigram implements PartSearcher using pg_trgm similarity.
+// SearchTrigram implements PartSearcher using pg_trgm similarity over parts.
 func (s *Store) SearchTrigram(ctx context.Context, scope brain.Scope, query string, filters brain.Filter, k int) ([]brain.ScoredID, error) {
 	if k <= 0 || strings.TrimSpace(query) == "" {
 		return nil, nil

--- a/brain/postgres/store_integration_test.go
+++ b/brain/postgres/store_integration_test.go
@@ -380,7 +380,7 @@ func TestPut_livePostgresUpsertAndSoftDelete(t *testing.T) {
 	}
 	var _ brain.ObjectWriter = store
 
-	eng, err := brain.NewEngine(store, brain.WithKinds(
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithKinds(
 		brain.KindSpec{
 			Kind: "Document", IsParent: true,
 			Fields: []brain.FieldSpec{{Name: "stage", Type: brain.FieldTypeString}},
@@ -647,7 +647,7 @@ func TestApplyKinds_livePostgresMigration(t *testing.T) {
 	// Compile-time / runtime: postgres.Store is a KindRegistry.
 	var _ brain.KindRegistry = store
 
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -687,7 +687,7 @@ func TestApplyKinds_livePostgresMigration(t *testing.T) {
 	}
 
 	// Fresh process: load durable kinds (no hard-coded WithKinds).
-	eng2, err := brain.NewEngine(store)
+	eng2, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/brain/provider_test.go
+++ b/brain/provider_test.go
@@ -43,7 +43,7 @@ func withParams(open vfs.Open, point string, params map[string]string) vfs.Open 
 func TestBrainProvider_prefixWriteReadDirRemoveAndIR(t *testing.T) {
 	ctx := context.Background()
 	ns := mustNS(t, "id", uuid.NewString())
-	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithKinds(
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly(), brain.WithKinds(
 		brain.KindSpec{
 			Kind: "Deal", IsParent: true,
 			Fields: []brain.FieldSpec{
@@ -265,7 +265,7 @@ func (b bareDoc) MediaType() string { return "text/markdown" }
 func TestBrainProvider_rootsLayout(t *testing.T) {
 	ctx := context.Background()
 	ns := mustNS(t, "id", uuid.NewString())
-	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithKinds(
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly(), brain.WithKinds(
 		brain.KindSpec{Kind: "Person", IsParent: true},
 	))
 	if err != nil {
@@ -306,7 +306,7 @@ func TestBrainProvider_rootsLayout(t *testing.T) {
 func TestBrainProvider_openCatalogListsKindsInUseAndMkdir(t *testing.T) {
 	ctx := context.Background()
 	ns := mustNS(t, "id", uuid.NewString())
-	eng, err := brain.NewEngine(brain.NewMemoryStore())
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -337,7 +337,7 @@ func TestBrainProvider_openCatalogListsKindsInUseAndMkdir(t *testing.T) {
 func TestBrainOpen_rejectsInvalidConfig(t *testing.T) {
 	ctx := context.Background()
 	ns := mustNS(t, "id", uuid.NewString())
-	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithKinds(
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly(), brain.WithKinds(
 		brain.KindSpec{Kind: "Note", IsParent: true},
 		brain.KindSpec{Kind: "Deal", IsParent: true},
 	))

--- a/brain/search.go
+++ b/brain/search.go
@@ -9,8 +9,12 @@ import (
 	"github.com/google/uuid"
 )
 
-// Search runs hybrid retrieval (BM25 + optional vector), RRF, temporal decay,
-// parent promotion, and materializes a ResultSet into results.
+// Search is corpus retrieval: hybrid BM25 + optional vector over store parts,
+// RRF, temporal decay, parent promotion, then a ResultSet page.
+// Query text matches part title, summary, and content. Structured fields on
+// the parent belong in FindObjects filters (or here only if the part row
+// carries them). A parent with no parts does not appear. Entity search is
+// FindObjects.
 func (e *Engine) Search(ctx context.Context, scope Scope, req SearchRequest, results ResultSetStore) (SearchPage, error) {
 	ranked, err := e.hybridCandidates(ctx, scope, req)
 	if err != nil {
@@ -20,8 +24,9 @@ func (e *Engine) Search(ctx context.Context, scope Scope, req SearchRequest, res
 	return e.materialize(ctx, scope, ranked, req.Limit, results)
 }
 
-// FindExact runs equality-first exact retrieval (no dense channel), then
+// FindExact is corpus retrieval without the dense channel: UUID Get, else
 // lexical + trigram fusion, promotion, and ResultSet materialization.
+// Same part-only candidate rule as Search. UUID lookup may return a parent.
 func (e *Engine) FindExact(ctx context.Context, scope Scope, req SearchRequest, results ResultSetStore) (SearchPage, error) {
 	ranked, err := e.exactCandidates(ctx, scope, req)
 	if err != nil {

--- a/brain/search_test.go
+++ b/brain/search_test.go
@@ -48,7 +48,7 @@ func TestSearch_promotesParentWithEvidenceAndNamespace(t *testing.T) {
 	}, now)
 	seedDocWithParts(t, store, nsB, "Other ns", []string{"OAuth PKCE elsewhere"}, now)
 
-	eng, err := brain.NewEngine(store, brain.WithConfig(fixedNow(now)))
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithConfig(fixedNow(now)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +128,7 @@ func TestSearch_filtersProperty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	eng, err := brain.NewEngine(store, brain.WithConfig(fixedNow(now)))
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithConfig(fixedNow(now)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +219,7 @@ func TestSearch_scopeIDsRestrictsHits(t *testing.T) {
 		ID: c2, Kind: "Chunk", Title: "oauth other", Content: "oauth risk material shared",
 		ParentID: &p2, Position: &pos, Namespace: ns, UpdatedAt: now,
 	})
-	eng, err := brain.NewEngine(store, brain.WithConfig(brain.EngineConfig{Now: func() time.Time { return now }}))
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithConfig(brain.EngineConfig{Now: func() time.Time { return now }}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +255,7 @@ func TestFindExact_uuidParentAndPart(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	eng, err := brain.NewEngine(store, brain.WithConfig(fixedNow(now)))
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithConfig(fixedNow(now)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -304,7 +304,7 @@ func TestFindExact_titleMatch(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	eng, err := brain.NewEngine(store, brain.WithConfig(fixedNow(now)))
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithConfig(fixedNow(now)))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -329,7 +329,7 @@ func TestContinue_andReplaceResultSet(t *testing.T) {
 			"shared retrieval content alpha beta gamma " + string(rune('a'+i)),
 		}, now)
 	}
-	eng, err := brain.NewEngine(store, brain.WithConfig(brain.EngineConfig{
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithConfig(brain.EngineConfig{
 		DefaultLimit: 2, MaxLimit: 50,
 		Now: func() time.Time { return now },
 	}))
@@ -395,7 +395,7 @@ func TestContinue_andReplaceResultSet(t *testing.T) {
 }
 
 func TestSearch_rejectsBadFiltersAndEmptyQuery(t *testing.T) {
-	eng, err := brain.NewEngine(brain.NewMemoryStore())
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -441,7 +441,7 @@ func TestFindExact_trigramFuzzy(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	eng, err := brain.NewEngine(store, brain.WithConfig(fixedNow(now)))
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithConfig(fixedNow(now)))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/brain/store.go
+++ b/brain/store.go
@@ -44,7 +44,10 @@ type ObjectLister interface {
 	KindsWithObjects(ctx context.Context, scope Scope) ([]string, error)
 }
 
-// PartSearcher is the candidate retrieval port for hybrid / exact search.
+// PartSearcher is corpus retrieval over the store: parts only (parent_id set).
+// Query text matches part title, summary, and content. Filters apply to the
+// part row. Engine.Search promotes hits to the parent. Entity search over
+// parent records is GraphObjectSearcher (FindObjects), not this port.
 type PartSearcher interface {
 	SearchLexical(ctx context.Context, scope Scope, query string, filters Filter, k int) ([]ScoredID, error)
 	SearchVector(ctx context.Context, scope Scope, embedding []float32, filters Filter, k int) ([]ScoredID, error)

--- a/brain/types.go
+++ b/brain/types.go
@@ -153,11 +153,28 @@ type FilterUsage struct {
 func DefaultFilterUsage() FilterUsage {
 	return FilterUsage{
 		Tools: []string{"search", "find_exact", "find_objects"},
-		Note: "Each kind's filterable_fields lists property keys, types, and operators allowed in filters. " +
-			"Use those keys on search, find_exact, and find_objects (not invented names). " +
-			"When kinds are registered, property filters require a kind filter (or find_objects.kinds). " +
-			"Core keys: kind, title, created_after, created_before, updated_after, updated_before. " +
-			"Call schema with a kind before filtering.",
+		Note: "Each kind lists columns (title, summary, content) and filterable_fields (host properties). " +
+			"search and find_exact take a free-text query over chunk title, summary, and content; " +
+			"put structured fields in filters. find_objects searches parent records; the same " +
+			"filterable_fields apply to the parent. When kinds are registered, property filters " +
+			"require a kind filter (or find_objects.kinds). Core filter keys: kind, title, " +
+			"created_after, created_before, updated_after, updated_before. Field examples are " +
+			"illustrations, not a closed set. Call schema with a kind before filtering.",
+	}
+}
+
+// CoreColumn is a built-in object field shown next to filterable_fields in schema().
+type CoreColumn struct {
+	Name   string `json:"name"`
+	Filter bool   `json:"filter,omitempty"`
+}
+
+// CoreColumns is title, summary, and content — always present on every object.
+func CoreColumns() []CoreColumn {
+	return []CoreColumn{
+		{Name: "title", Filter: true},
+		{Name: "summary"},
+		{Name: "content"},
 	}
 }
 
@@ -167,6 +184,7 @@ type ObjectKindInfo struct {
 	Description      string          `json:"description,omitempty"`
 	IsPart           bool            `json:"is_part"`
 	IsParent         bool            `json:"is_parent"`
+	Columns          []CoreColumn    `json:"columns"`
 	FilterableFields json.RawMessage `json:"filterable_fields,omitempty"`
 }
 

--- a/brain/types.go
+++ b/brain/types.go
@@ -159,7 +159,8 @@ func DefaultFilterUsage() FilterUsage {
 			"filterable_fields apply to the parent. When kinds are registered, property filters " +
 			"require a kind filter (or find_objects.kinds). Core filter keys: kind, title, " +
 			"created_after, created_before, updated_after, updated_before. Field examples are " +
-			"illustrations, not a closed set. Call schema with a kind before filtering.",
+			"illustrations, not a closed set; enum on a string field is enforced on write. " +
+			"Call schema with a kind before filtering.",
 	}
 }
 

--- a/brain/types.go
+++ b/brain/types.go
@@ -41,7 +41,8 @@ type Object struct {
 	ContentType string
 	ParentID    *uuid.UUID
 	Position    *int
-	// Embedding is optional dense vector for hybrid search fixtures / stores.
+	// Embedding is the dense vector stored on the row. Store search reads it
+	// on parts. Parent embeddings are copied to the graph for FindObjects.
 	Embedding []float32
 	// Namespace is the ordered named isolation attrs stored on the row.
 	Namespace Namespace
@@ -202,6 +203,10 @@ func (f Filter) empty() bool {
 }
 
 // SearchRequest is the engine input for search and find_exact.
+// SearchRequest is corpus retrieval over store parts (Search / FindExact).
+// Query is free text against part title, summary, and content. Structured
+// fields belong in Filters on the part row, or in FindObjectsRequest when
+// they live on the parent.
 type SearchRequest struct {
 	Query   string
 	Filters Filter

--- a/brain/write.go
+++ b/brain/write.go
@@ -56,6 +56,48 @@ func (e *Engine) Put(ctx context.Context, scope Scope, obj Object) (Object, erro
 	return obj, nil
 }
 
+// ReplaceParts replaces all children of a first-class parent.
+// Existing parts are soft-deleted, then each item is Put with ParentID set
+// (Position defaults to the slice index). Search looks at these parts; the
+// parent Engram body is not a corpus document. vfsindex remains the path for
+// workspace files.
+func (e *Engine) ReplaceParts(ctx context.Context, scope Scope, parentID uuid.UUID, parts []Object) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if parentID == uuid.Nil {
+		return fmt.Errorf("%w: parent id is required", ErrInvalid)
+	}
+	parent, err := e.store.Get(ctx, scope, parentID)
+	if err != nil {
+		return err
+	}
+	if parent.ParentID != nil {
+		return fmt.Errorf("%w: parent must be a first-class object", ErrInvalid)
+	}
+	old, err := e.store.ListChildren(ctx, scope, parentID)
+	if err != nil {
+		return err
+	}
+	for _, c := range old {
+		if err := e.SoftDelete(ctx, scope, c.ID); err != nil {
+			return err
+		}
+	}
+	for i, p := range parts {
+		pid := parentID
+		p.ParentID = &pid
+		if p.Position == nil {
+			pos := i
+			p.Position = &pos
+		}
+		if _, err := e.Put(ctx, scope, p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // SoftDelete removes the graph node first (when present), then marks the store row deleted.
 // Graph-first keeps store intact if graph removal fails. If store SoftDelete fails after a
 // successful graph remove, re-Put re-creates the graph node.

--- a/brain/write.go
+++ b/brain/write.go
@@ -292,18 +292,25 @@ func capRunes(s string, maxRunes int) string {
 
 // indexTextForEmbed: parents use entity index text; parts use parent-prefixed corpus IndexText.
 func (e *Engine) indexTextForEmbed(ctx context.Context, scope Scope, obj Object) string {
+	var text string
 	if obj.ParentID == nil {
 		spec, ok := KindSpec{}, false
 		if e.catalog != nil {
 			spec, ok = e.catalog.Get(obj.Kind)
 		}
-		return entityIndexText(obj, spec, ok)
+		text = entityIndexText(obj, spec, ok)
+	} else {
+		parent, err := e.store.Get(ctx, scope, *obj.ParentID)
+		if err != nil {
+			text = IndexText(obj)
+		} else {
+			text = IndexTextWithParent(obj, parent.Title)
+		}
 	}
-	parent, err := e.store.Get(ctx, scope, *obj.ParentID)
-	if err != nil {
-		return IndexText(obj)
+	if e.indexTextFn != nil {
+		text = strings.TrimSpace(e.indexTextFn(obj, text))
 	}
-	return IndexTextWithParent(obj, parent.Title)
+	return text
 }
 
 // ValidateObject checks an object against the kind catalog when non-empty.

--- a/brain/write.go
+++ b/brain/write.go
@@ -49,7 +49,7 @@ func (e *Engine) Put(ctx context.Context, scope Scope, obj Object) (Object, erro
 	}
 	// Dual-write first-class objects only (no parent_id). Each Put refreshes node props.
 	if obj.ParentID == nil && e.graphW != nil {
-		if err := e.graphW.EnsureObject(ctx, obj); err != nil {
+		if err := e.graphW.EnsureObject(ctx, obj, indexText); err != nil {
 			return Object{}, fmt.Errorf("%w: %w", ErrGraphEnsure, err)
 		}
 	}

--- a/brain/write.go
+++ b/brain/write.go
@@ -177,7 +177,13 @@ func IndexText(obj Object) string {
 
 // EntityIndexText builds text for first-class graph nodes and parent embeddings:
 // title, summary, scalar properties (sorted keys), and full content.
+// Reserved store props (slug, vfs_path) are omitted. Callers with a kind catalog
+// should prefer Engine.Put, which also honors FieldSpec.SkipIndex.
 func EntityIndexText(obj Object) string {
+	return entityIndexText(obj, KindSpec{}, false)
+}
+
+func entityIndexText(obj Object, spec KindSpec, haveSpec bool) string {
 	parts := make([]string, 0, 8)
 	if t := strings.TrimSpace(obj.Title); t != "" {
 		parts = append(parts, t)
@@ -188,6 +194,9 @@ func EntityIndexText(obj Object) string {
 	if len(obj.Properties) > 0 {
 		keys := slices.Sorted(maps.Keys(obj.Properties))
 		for _, k := range keys {
+			if skipIndexProperty(k, spec, haveSpec) {
+				continue
+			}
 			line := formatPropertyLine(k, obj.Properties[k])
 			if line != "" {
 				parts = append(parts, line)
@@ -198,6 +207,17 @@ func EntityIndexText(obj Object) string {
 		parts = append(parts, c)
 	}
 	return strings.Join(parts, "\n")
+}
+
+func skipIndexProperty(name string, spec KindSpec, haveSpec bool) bool {
+	if isReservedStoreProp(name) {
+		return true
+	}
+	if !haveSpec {
+		return false
+	}
+	f, ok := spec.Field(name)
+	return ok && f.SkipIndex
 }
 
 func formatPropertyLine(key string, v any) string {
@@ -270,10 +290,14 @@ func capRunes(s string, maxRunes int) string {
 	return s
 }
 
-// indexTextForEmbed: parents use EntityIndexText; parts use parent-prefixed corpus IndexText.
+// indexTextForEmbed: parents use entity index text; parts use parent-prefixed corpus IndexText.
 func (e *Engine) indexTextForEmbed(ctx context.Context, scope Scope, obj Object) string {
 	if obj.ParentID == nil {
-		return EntityIndexText(obj)
+		spec, ok := KindSpec{}, false
+		if e.catalog != nil {
+			spec, ok = e.catalog.Get(obj.Kind)
+		}
+		return entityIndexText(obj, spec, ok)
 	}
 	parent, err := e.store.Get(ctx, scope, *obj.ParentID)
 	if err != nil {
@@ -335,8 +359,26 @@ func ValidateObject(obj Object, cat *KindCatalog) error {
 		if err := checkFieldValue(v, f.Type); err != nil {
 			return fmt.Errorf("brain: property %q: %w", name, err)
 		}
+		if err := checkFieldEnum(v, f); err != nil {
+			return fmt.Errorf("brain: property %q: %w", name, err)
+		}
 	}
 	return nil
+}
+
+func checkFieldEnum(v any, f FieldSpec) error {
+	if len(f.Enum) == 0 {
+		return nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return nil
+	}
+	s = strings.TrimSpace(s)
+	if slices.Contains(f.Enum, s) {
+		return nil
+	}
+	return fmt.Errorf("value %q is not in enum", s)
 }
 
 // Reserved store properties persisted on objects without a KindSpec field.

--- a/brain/write_test.go
+++ b/brain/write_test.go
@@ -282,6 +282,67 @@ func TestPut_enumRejectsUnknownString(t *testing.T) {
 	}
 }
 
+func TestPut_indexTextFuncShapesEmbedAndGraph(t *testing.T) {
+	ctx := context.Background()
+	var gotEmbed string
+	emb := captureEmbedder{fn: func(text string) []float32 {
+		gotEmbed = text
+		return []float32{1, 0, 0}
+	}}
+	store := brain.NewMemoryStore()
+	g := brain.NewMemoryGraph()
+	eng, err := brain.NewEngine(store, brain.WithEmbedder(emb), brain.WithGraph(g),
+		brain.WithIndexText(func(obj brain.Object, defaultText string) string {
+			return "related: neighbor record\n" + defaultText
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ns := mustNS(t, "id", uuid.NewString())
+	scope := brain.Scope{Namespace: ns}
+	obj, err := eng.Put(ctx, scope, brain.Object{
+		Kind: "Note", Title: "invoice", Content: "amount due Friday",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if obj.Content != "amount due Friday" {
+		t.Fatalf("content must stay on the object: %q", obj.Content)
+	}
+	if !strings.Contains(gotEmbed, "related: neighbor record") || !strings.Contains(gotEmbed, "invoice") {
+		t.Fatalf("embed text: %q", gotEmbed)
+	}
+	hit, err := g.SearchText(ctx, "neighbor record", 5, ns)
+	if err != nil || len(hit) != 1 || hit[0].ID != obj.ID {
+		t.Fatalf("graph search extra text: %+v err=%v", hit, err)
+	}
+}
+
+func TestPut_indexTextFuncEmptySkipsEmbed(t *testing.T) {
+	ctx := context.Background()
+	emb := captureEmbedder{fn: func(string) []float32 {
+		t.Fatal("embedder must not run on empty index text")
+		return nil
+	}}
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithEmbedder(emb),
+		brain.WithIndexText(func(brain.Object, string) string { return "  " }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ns := mustNS(t, "id", uuid.NewString())
+	got, err := eng.Put(ctx, brain.Scope{Namespace: ns}, brain.Object{
+		Kind: "Note", Title: "x", Content: "body",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Embedding) != 0 {
+		t.Fatalf("empty index text must not embed: %+v", got.Embedding)
+	}
+}
+
 func TestApplyKinds_roundTripSkipIndexAndEnum(t *testing.T) {
 	ctx := context.Background()
 	store := brain.NewMemoryStore()

--- a/brain/write_test.go
+++ b/brain/write_test.go
@@ -191,6 +191,132 @@ func TestEntityIndexText_includesSummaryAndProperties(t *testing.T) {
 			t.Fatalf("missing %q in %q", want, got)
 		}
 	}
+	withSlug := brain.EntityIndexText(brain.Object{
+		Title: "Acme", Properties: map[string]any{brain.PropSlug: "acme", "stage": "open"},
+	})
+	if strings.Contains(withSlug, "slug:") || !strings.Contains(withSlug, "stage: open") {
+		t.Fatalf("slug must be omitted: %q", withSlug)
+	}
+}
+
+// TestPut_skipIndexKeepsPropertyOffEntityText: SkipIndex fields stay on the
+// object and remain filterable, but they are not in embed or find_objects text.
+func TestPut_skipIndexKeepsPropertyOffEntityText(t *testing.T) {
+	ctx := context.Background()
+	var gotEmbed string
+	emb := captureEmbedder{fn: func(text string) []float32 {
+		gotEmbed = text
+		return []float32{1, 0, 0}
+	}}
+	store := brain.NewMemoryStore()
+	g := brain.NewMemoryGraph()
+	eng, err := brain.NewEngine(store, brain.WithEmbedder(emb), brain.WithGraph(g), brain.WithKinds(
+		brain.KindSpec{Kind: "Deal", IsParent: true, Fields: []brain.FieldSpec{
+			{Name: "stage", Type: brain.FieldTypeString},
+			{Name: "message_id", Type: brain.FieldTypeString, SkipIndex: true},
+		}},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ns := mustNS(t, "id", uuid.NewString())
+	scope := brain.Scope{Namespace: ns}
+	const msgID = "msg-skip-index-token"
+	deal, err := eng.Put(ctx, scope, brain.Object{
+		Kind: "Deal", Title: "Acme renewal",
+		Properties: map[string]any{"stage": "open", "message_id": msgID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(gotEmbed, msgID) {
+		t.Fatalf("skip-index field in embed text: %q", gotEmbed)
+	}
+	if !strings.Contains(gotEmbed, "stage: open") {
+		t.Fatalf("indexed field missing from embed: %q", gotEmbed)
+	}
+	got, err := eng.GetByProperty(ctx, scope, "message_id", msgID)
+	if err != nil || got.ID != deal.ID {
+		t.Fatalf("GetByProperty: %+v err=%v", got, err)
+	}
+	rich, err := eng.Read(ctx, scope, deal.ID)
+	if err != nil || rich.Properties["message_id"] != msgID {
+		t.Fatalf("read still has property: %+v err=%v", rich, err)
+	}
+	miss, err := g.SearchText(ctx, msgID, 5, ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(miss) != 0 {
+		t.Fatalf("graph search text must not contain skip-index value: %+v", miss)
+	}
+	hit, err := g.SearchText(ctx, "Acme renewal", 5, ns)
+	if err != nil || len(hit) != 1 || hit[0].ID != deal.ID {
+		t.Fatalf("graph search title: %+v err=%v", hit, err)
+	}
+}
+
+func TestPut_enumRejectsUnknownString(t *testing.T) {
+	ctx := context.Background()
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithKinds(
+		brain.KindSpec{Kind: "Deal", IsParent: true, Fields: []brain.FieldSpec{
+			{Name: "stage", Type: brain.FieldTypeString, Enum: []string{"open", "closed"}},
+			{Name: "note", Type: brain.FieldTypeString, Examples: []string{"hello"}},
+		}},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ns := mustNS(t, "id", uuid.NewString())
+	scope := brain.Scope{Namespace: ns}
+	_, err = eng.Put(ctx, scope, brain.Object{
+		Kind: "Deal", Title: "x", Properties: map[string]any{"stage": "Yellowish"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "enum") {
+		t.Fatalf("want enum error, got %v", err)
+	}
+	if _, err := eng.Put(ctx, scope, brain.Object{
+		Kind: "Deal", Title: "x", Properties: map[string]any{"stage": "open", "note": "Yellowish"},
+	}); err != nil {
+		t.Fatalf("examples are not closed: %v", err)
+	}
+}
+
+func TestApplyKinds_roundTripSkipIndexAndEnum(t *testing.T) {
+	ctx := context.Background()
+	store := brain.NewMemoryStore()
+	eng, err := brain.NewEngine(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := eng.ApplyKinds(ctx, brain.KindSpec{
+		Kind: "Deal", IsParent: true,
+		Fields: []brain.FieldSpec{
+			{Name: "stage", Type: brain.FieldTypeString, Enum: []string{"open", "closed"}},
+			{Name: "message_id", Type: brain.FieldTypeString, SkipIndex: true},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	eng2, err := brain.NewEngine(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := eng2.LoadKindsFromStore(ctx); err != nil {
+		t.Fatal(err)
+	}
+	spec, ok := eng2.Catalog().Get("Deal")
+	if !ok {
+		t.Fatal("missing Deal")
+	}
+	stage, _ := spec.Field("stage")
+	if len(stage.Enum) != 2 || stage.Enum[0] != "open" {
+		t.Fatalf("enum: %+v", stage)
+	}
+	mid, _ := spec.Field("message_id")
+	if !mid.SkipIndex {
+		t.Fatalf("skip_index: %+v", mid)
+	}
 }
 
 // TestPut_partEmbedIncludesParentTitle: part embeddings / graph index text get parent context.

--- a/brain/write_test.go
+++ b/brain/write_test.go
@@ -15,7 +15,7 @@ import (
 // TestPut_roundTripAndSoftDelete: open-catalog Put is readable, soft-delete hides the object.
 func TestPut_roundTripAndSoftDelete(t *testing.T) {
 	ctx := context.Background()
-	eng, err := brain.NewEngine(brain.NewMemoryStore())
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func TestPut_roundTripAndSoftDelete(t *testing.T) {
 // TestPut_catalogEnforced: each case is a distinct ValidateObject return path; success path writes parent+part.
 func TestPut_catalogEnforced(t *testing.T) {
 	ctx := context.Background()
-	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithKinds(
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly(), brain.WithKinds(
 		brain.KindSpec{
 			Kind: "Document", IsParent: true,
 			Fields: []brain.FieldSpec{
@@ -258,7 +258,7 @@ func TestPut_skipIndexKeepsPropertyOffEntityText(t *testing.T) {
 
 func TestPut_enumRejectsUnknownString(t *testing.T) {
 	ctx := context.Background()
-	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithKinds(
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly(), brain.WithKinds(
 		brain.KindSpec{Kind: "Deal", IsParent: true, Fields: []brain.FieldSpec{
 			{Name: "stage", Type: brain.FieldTypeString, Enum: []string{"open", "closed"}},
 			{Name: "note", Type: brain.FieldTypeString, Examples: []string{"hello"}},
@@ -285,7 +285,7 @@ func TestPut_enumRejectsUnknownString(t *testing.T) {
 func TestApplyKinds_roundTripSkipIndexAndEnum(t *testing.T) {
 	ctx := context.Background()
 	store := brain.NewMemoryStore()
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -298,7 +298,7 @@ func TestApplyKinds_roundTripSkipIndexAndEnum(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	eng2, err := brain.NewEngine(store)
+	eng2, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -365,7 +365,7 @@ func TestPut_multiTurnMemoryGraph(t *testing.T) {
 	ctx := context.Background()
 	store := brain.NewMemoryStore()
 	g := brain.NewMemoryGraph()
-	eng, err := brain.NewEngine(store, brain.WithGraph(g), brain.WithKinds(
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(g), brain.WithKinds(
 		brain.KindSpec{Kind: "Document", IsParent: true},
 		brain.KindSpec{Kind: "Chunk", IsPart: true},
 	))
@@ -461,7 +461,7 @@ func TestPut_multiTurnMemoryGraph(t *testing.T) {
 func TestLink_expandFindsNeighbor(t *testing.T) {
 	ctx := context.Background()
 	store := brain.NewMemoryStore()
-	eng, err := brain.NewEngine(store, brain.WithGraph(brain.NewMemoryGraph()))
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(brain.NewMemoryGraph()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -515,7 +515,7 @@ func TestLink_expandFindsNeighbor(t *testing.T) {
 	if err := eng.Link(ctx, scope, a.ID, b.ID, ""); !errors.Is(err, brain.ErrInvalid) {
 		t.Fatalf("want ErrInvalid for incomplete link: %v", err)
 	}
-	engNoGraph, err := brain.NewEngine(store)
+	engNoGraph, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -534,7 +534,7 @@ func TestLink_expandFindsNeighbor(t *testing.T) {
 func TestLinkWith_missingEndpointAndCancelled(t *testing.T) {
 	ctx := context.Background()
 	store := brain.NewMemoryStore()
-	eng, err := brain.NewEngine(store, brain.WithGraph(brain.NewMemoryGraph()))
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(brain.NewMemoryGraph()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -570,7 +570,7 @@ func TestSoftDelete_graphRemoveErrorSurfaces(t *testing.T) {
 	ctx := context.Background()
 	store := brain.NewMemoryStore()
 	g := &failRemoveGraph{MemoryGraph: brain.NewMemoryGraph()}
-	eng, err := brain.NewEngine(store, brain.WithGraph(g))
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(g))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -602,7 +602,7 @@ func TestLinkWith_expandAttachesMeta(t *testing.T) {
 	ctx := context.Background()
 	store := brain.NewMemoryStore()
 	g := brain.NewMemoryGraph()
-	eng, err := brain.NewEngine(store, brain.WithGraph(g))
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(g))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -681,7 +681,7 @@ func TestLink_crossObjectEmailDealBuyer(t *testing.T) {
 	ctx := context.Background()
 	store := brain.NewMemoryStore()
 	g := brain.NewMemoryGraph()
-	eng, err := brain.NewEngine(store, brain.WithGraph(g), brain.WithKinds(
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(g), brain.WithKinds(
 		brain.KindSpec{Kind: "Email", IsParent: true},
 		brain.KindSpec{Kind: "Deal", IsParent: true, Fields: []brain.FieldSpec{
 			{Name: "stage", Type: brain.FieldTypeString},

--- a/brain/write_test.go
+++ b/brain/write_test.go
@@ -815,3 +815,87 @@ func TestLink_crossObjectEmailDealBuyer(t *testing.T) {
 		t.Fatalf("containment expand: %+v err=%v", kids, err)
 	}
 }
+
+func TestReplaceParts_searchHitsNewChunks(t *testing.T) {
+	ctx := context.Background()
+	store := brain.NewMemoryStore()
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithKinds(
+		brain.KindSpec{Kind: "Document", IsParent: true},
+		brain.KindSpec{Kind: "Chunk", IsPart: true},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ns := mustNS(t, "id", uuid.NewString())
+	scope := brain.Scope{Namespace: ns}
+	parent, err := eng.Put(ctx, scope, brain.Object{Kind: "Document", Title: "Memo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := eng.ReplaceParts(ctx, scope, parent.ID, []brain.Object{
+		{Kind: "Chunk", Title: "a", Content: "pkceflow"},
+		{Kind: "Chunk", Title: "b", Content: "neighbor"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	kids, err := eng.ListChildren(ctx, scope, parent.ID)
+	if err != nil || len(kids) != 2 || kids[0].Title != "a" || kids[1].Title != "b" {
+		t.Fatalf("children: %+v err=%v", kids, err)
+	}
+	sc := brain.NewSearchContext()
+	page, err := eng.Search(ctx, scope, brain.SearchRequest{Query: "pkceflow"}, sc)
+	if err != nil || len(page.Objects) != 1 || page.Objects[0].ID != parent.ID {
+		t.Fatalf("search new chunk: %+v err=%v", page.Objects, err)
+	}
+	if err := eng.ReplaceParts(ctx, scope, parent.ID, []brain.Object{
+		{Kind: "Chunk", Title: "c", Content: "indemnityclause"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	kids, err = eng.ListChildren(ctx, scope, parent.ID)
+	if err != nil || len(kids) != 1 || kids[0].Title != "c" {
+		t.Fatalf("replaced children: %+v err=%v", kids, err)
+	}
+	miss, err := eng.Search(ctx, scope, brain.SearchRequest{Query: "pkceflow"}, sc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(miss.Objects) != 0 {
+		t.Fatalf("old chunk must be gone: %+v", miss.Objects)
+	}
+	hit, err := eng.Search(ctx, scope, brain.SearchRequest{Query: "indemnityclause"}, sc)
+	if err != nil || len(hit.Objects) != 1 || hit.Objects[0].ID != parent.ID {
+		t.Fatalf("search replacement: %+v err=%v", hit.Objects, err)
+	}
+}
+
+func TestReplaceParts_rejectsPartParent(t *testing.T) {
+	ctx := context.Background()
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly(), brain.WithKinds(
+		brain.KindSpec{Kind: "Document", IsParent: true},
+		brain.KindSpec{Kind: "Chunk", IsPart: true},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ns := mustNS(t, "id", uuid.NewString())
+	scope := brain.Scope{Namespace: ns}
+	parent, err := eng.Put(ctx, scope, brain.Object{Kind: "Document", Title: "Memo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pos := 0
+	part, err := eng.Put(ctx, scope, brain.Object{
+		Kind: "Chunk", Title: "c", ParentID: &parent.ID, Position: &pos,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = eng.ReplaceParts(ctx, scope, part.ID, nil)
+	if err == nil || !strings.Contains(err.Error(), "first-class") {
+		t.Fatalf("got %v", err)
+	}
+	if err := eng.ReplaceParts(ctx, scope, uuid.Nil, nil); err == nil {
+		t.Fatal("nil parent")
+	}
+}

--- a/brain/write_test.go
+++ b/brain/write_test.go
@@ -326,7 +326,7 @@ func TestPut_multiTurnMemoryGraph(t *testing.T) {
 	}
 
 	// Graph EnsureObject rejects nil id.
-	if err := g.EnsureObject(ctx, brain.Object{}); err == nil {
+	if err := g.EnsureObject(ctx, brain.Object{}, ""); err == nil {
 		t.Fatal("nil ensure")
 	}
 }

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -168,6 +168,10 @@ classDiagram
 | **Parent / Engram** | `parent_id` is empty | Yes — `{slug}.md` | Yes (dual-written on `Put`) |
 | **Part / Chunk** | `parent_id` is set | Never | Never |
 
+Parts are not files. `search` looks at parts (indexed workspace files, or
+chunks the host writes with `ReplaceParts`). The Engram Markdown body lives
+on the parent and is found with `find_objects` until parts exist.
+
 **Kinds** are defined by the **host**, not by Tacklr. `Deal` and `Person` in tests
 and examples are sample product types, not SDK types. You register them with
 `ApplyKinds` / `WithKinds`.

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -680,6 +680,7 @@ eng, err := brain.NewEngine(store,
     brain.WithEmbedder(emb),          // hybrid search + Put embeddings
     brain.WithGraph(g),               // link / find_objects / named expand
 )
+// Pass WithLexicalOnly() instead of WithEmbedder when you want keyword search only.
 if err := eng.LoadKindsFromStore(ctx); err != nil { /* ... */ }
 
 // AgentOptions:
@@ -717,6 +718,7 @@ Tests call `store.Setup` (embedding dim 3) instead of loading SQL files.
 |-----------|----------|
 | Wrong namespace | `Get` / search look like not found. Graph ids that fail hydrate are dropped. A coarser scope (fewer attrs) sees objects with extra attrs. |
 | Soft-deleted object | Hidden from Get and search. Graph node is already gone. |
+| No embedder at construct | `NewEngine` fails unless you pass `WithEmbedder` or `WithLexicalOnly`. |
 | Embedder down at **query** time | `search` / `find_objects` can run lexical-only (default). Set `FailOnEmbedderError` to surface the error. |
 | Embedder down at **Put** time | **Fail closed.** An unindexed parent is not persisted. |
 | Graph down at expand | Can degrade to containment if containment was requested. |

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -350,7 +350,9 @@ not `IndexPath`.
 
 ## Two backends: store and graph
 
-They are complementary. Do not treat Helix as a second document database.
+They are complementary. The store is the document corpus and the source of
+truth. The graph is tracked records and how they relate. Do not treat Helix as
+a second document database.
 
 ```mermaid
 flowchart TB
@@ -384,6 +386,19 @@ flowchart TB
 | **Holds** | Full rows, chunks, embeddings, filters | Parent nodes + edges |
 | **Answers** | `search`, `find_exact`, `read_object`, expand-children | `find_objects`, `link`, expand-relations, `find_links` |
 | **Required?** | Yes | Optional. Without it: no `link` / `find_objects` / named-relation expand |
+| **What the query matches** | Parts (chunks of notes and indexed files) | Parent records (a Deal, a Person, …) |
+
+`search` and `find_exact` look at **parts** (`parent_id` set): title, summary,
+and body. Hits promote to the parent with evidence. An Engram that has no
+parts does not appear there — use `find_objects`, or add chunks (host ingest).
+
+`find_objects` looks at **parent** nodes in the graph: the record’s title,
+summary, body, and indexed properties. Structured fields belong in **filters**,
+not in the query string. The same filter keys work on corpus search, but they
+apply to the part row, not the parent.
+
+Exact lookups (`Get`, `GetByProperty`, `ListByKind`, `find_exact` with a UUID)
+always go to the store.
 
 **Write rules**
 
@@ -404,7 +419,8 @@ flowchart TB
 | Part / Chunk | `IndexText` (title + summary + content), prefixed with the parent title |
 
 So `find_objects "open renewal"` can match a Deal whose `stage` property is
-`open`, not only the narrative body.
+`open`, not only the narrative body. Corpus `search` still matches chunk text,
+not those parent fields.
 
 A host that uses Helix must `Bootstrap` (or `EnsureSearchIndexes`) so object
 search is actually on. `MemoryGraph` is always ready and is what tests use.
@@ -438,6 +454,10 @@ Use for “what in the notes or indexed files supports this?”
 Hits are often **chunks**. The engine does **not** return those chunks as the
 primary result. It **promotes** them to their parent and attaches the best
 chunks as **evidence** (snippet, score, `start_line`, `block_id`).
+
+The query is free text against that chunk body. Structured fields on the parent
+record (stage, status, …) are filters on `find_objects`, not keywords for
+`search`.
 
 ```mermaid
 sequenceDiagram

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -415,8 +415,12 @@ always go to the store.
 
 | Object | Text that is embedded |
 |--------|------------------------|
-| Parent / Engram | `EntityIndexText`: title, summary, scalar properties (sorted keys), full body |
+| Parent / Engram | `EntityIndexText`: title, summary, indexed scalar properties, full body |
 | Part / Chunk | `IndexText` (title + summary + content), prefixed with the parent title |
+
+`WithIndexText` can rewrite that document at Put (prefix, replace, or drop
+fields) without changing the stored object. The same string is embedded and
+written as graph search text.
 
 So `find_objects "open renewal"` can match a Deal whose `stage` property is
 `open`, not only the narrative body. Corpus `search` still matches chunk text,

--- a/tools_brain.go
+++ b/tools_brain.go
@@ -91,9 +91,9 @@ func (b brainTools) newSchemaTool() *Tool {
 	return NewTool(ToolConfig{
 		Name:        "schema",
 		DisplayName: "Schema {kind}",
-		Description: `Discover structured filter fields and kind documentation for the knowledge base.
+		Description: `Discover kind documentation, object columns, and filterable fields.
 
-Call with a kind to see filterable_fields (name, type, operators) for that kind. Call with no kind to list registered kinds. filter_usage lists which tools accept those fields: search, find_exact, and find_objects share the same filter keys. Prefer schema() before inventing property names in filters. When kinds are registered, property filters require a kind key (or find_objects.kinds). Core keys: kind, title, created_after, created_before, updated_after, updated_before.`,
+Call with a kind to see columns (title, summary, content) and filterable_fields for that kind. Call with no kind to list registered kinds. Query text on search/find_exact matches chunk title/summary/content; structured fields go in filters. find_objects searches parent records with the same filter keys. Prefer schema() before inventing property names. When kinds are registered, property filters require a kind key (or find_objects.kinds). Core filter keys: kind, title, created_after, created_before, updated_after, updated_before.`,
 		Category: ToolCategoryRead,
 		Access:   ToolReadAccess,
 		Timeout:  30 * time.Second,
@@ -120,11 +120,12 @@ func (b brainTools) newSearchTool() *Tool {
 	return b.newQueryTool(ToolConfig{
 		Name:        "search",
 		DisplayName: "Search knowledge: {query}",
-		Description: `Search indexed knowledge (notes, Engrams, files you indexed). Returns ranked parents with evidence snippets.
+		Description: `Search notes and indexed files. Query is free text over chunk bodies. Returns ranked parents with evidence snippets.
 
+Structured fields on a record (stage, status, …) belong in filters — see schema() — or use find_objects for the record itself.
 Hit has vfs_path → open the live file with read (path + start_line / block_id from evidence).
 No vfs_path → read_object with the id.
-Live grep is run_command → rg (not this tool). Relationships: expand, not search. More pages: continue. Prefer schema() before inventing filter keys.`,
+Live grep is run_command → rg (not this tool). Relationships: expand, not search. More pages: continue.`,
 		Category: ToolCategorySearch,
 		Access:   ToolReadAccess,
 		Timeout:  30 * time.Second,

--- a/tools_brain_test.go
+++ b/tools_brain_test.go
@@ -19,7 +19,7 @@ func TestBrainTools_saveDiscoveryAndLink(t *testing.T) {
 	ctx := context.Background()
 	store := brain.NewMemoryStore()
 	g := brain.NewMemoryGraph()
-	eng, err := brain.NewEngine(store, brain.WithGraph(g), brain.WithKinds(
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(g), brain.WithKinds(
 		brain.KindSpec{Kind: "Discovery", IsParent: true},
 		brain.KindSpec{Kind: "Fact", IsParent: true},
 	))
@@ -162,7 +162,7 @@ func TestBrainTools_hostNamespaceScopedRead(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -254,7 +254,7 @@ func TestBrainTools_searchFindExactContinueAndCheckpoint(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	eng, err := brain.NewEngine(store, brain.WithConfig(brain.EngineConfig{
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithConfig(brain.EngineConfig{
 		DefaultLimit: 2, MaxLimit: 50, Now: func() time.Time { return now },
 	}))
 	if err != nil {
@@ -362,7 +362,7 @@ func TestBrainTools_expandChildren(t *testing.T) {
 		ID: child, Kind: "Chunk", Title: "C", Content: "secret",
 		ParentID: &parent, Position: &pos, Namespace: ns, UpdatedAt: now,
 	})
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -414,7 +414,7 @@ func TestBrainTools_expandMultiHopAndFindLinks(t *testing.T) {
 	if err := g.AddEdge(ctx, dealID, buyerID, "has_buyer", brain.EdgeMeta{Note: "economic buyer primary"}); err != nil {
 		t.Fatal(err)
 	}
-	eng, err := brain.NewEngine(store, brain.WithGraph(g))
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(g))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -479,7 +479,7 @@ func TestBrainTools_searchNamespaceIsolation(t *testing.T) {
 		ID: secretPart, Kind: "Chunk", Title: "chunk", Content: "namespace isolation secret token xyzzy",
 		ParentID: &secretParent, Position: &pos, Namespace: nsA, UpdatedAt: now,
 	})
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -552,7 +552,7 @@ func TestWorkerInheritsBrainAndNamespace(t *testing.T) {
 		ParentID: &parent, Position: &pos, Namespace: ns,
 	})
 
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -616,7 +616,7 @@ func TestWorkerInheritsBrainAndNamespace(t *testing.T) {
 func TestBrainTools_engramPathGraph(t *testing.T) {
 	ctx := context.Background()
 	g := brain.NewMemoryGraph()
-	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithGraph(g), brain.WithKinds(
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly(), brain.WithGraph(g), brain.WithKinds(
 		brain.KindSpec{Kind: "Deal", IsParent: true},
 		brain.KindSpec{Kind: "Person", IsParent: true},
 	))
@@ -718,7 +718,7 @@ func TestBrainTools_engramPathGraph(t *testing.T) {
 
 func TestBrainTools_expandAndUnlinkValidationErrors(t *testing.T) {
 	ctx := context.Background()
-	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithGraph(brain.NewMemoryGraph()))
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly(), brain.WithGraph(brain.NewMemoryGraph()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -769,7 +769,7 @@ func TestBrainTools_resolveFileRefPropagatesStoreFailure(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	eng, err := brain.NewEngine(failGetStore{MemoryStore: mem, err: errors.New("brain store down")})
+	eng, err := brain.NewEngine(failGetStore{MemoryStore: mem, err: errors.New("brain store down")}, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools_vfsindex_test.go
+++ b/tools_vfsindex_test.go
@@ -17,7 +17,7 @@ import (
 func vfsIndexHarness(t *testing.T, withNS bool) (*TurnManager, *vfs.MountSession, *brain.Engine, brain.Namespace) {
 	t.Helper()
 	store := brain.NewMemoryStore()
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -234,7 +234,7 @@ func TestVFSIndexTools_selectiveIndexSearchReadAndTrack(t *testing.T) {
 func TestVFSIndexTools_prefixAutoIndex(t *testing.T) {
 	ctx := context.Background()
 	ms := mustMountTree(t, "policy-prefix", vfs.At("work", vfs.Local(t.TempDir())).Indexed("  Prefix  "))
-	eng, err := brain.NewEngine(brain.NewMemoryStore())
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -260,7 +260,7 @@ func TestVFSIndexTools_prefixAutoIndex(t *testing.T) {
 func TestKnowledgeSaveSearchRead(t *testing.T) {
 	ctx := context.Background()
 	g := brain.NewMemoryGraph()
-	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithGraph(g), brain.WithKinds(
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly(), brain.WithGraph(g), brain.WithKinds(
 		brain.KindSpec{Kind: "Discovery", IsParent: true},
 		brain.KindSpec{Kind: "Fact", IsParent: true},
 	))
@@ -381,7 +381,7 @@ func TestKnowledgeSaveSearchRead(t *testing.T) {
 func TestKnowledgeSave_rootsMount(t *testing.T) {
 	ctx := context.Background()
 	g := brain.NewMemoryGraph()
-	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithGraph(g), brain.WithKinds(
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly(), brain.WithGraph(g), brain.WithKinds(
 		brain.KindSpec{Kind: "Discovery", IsParent: true},
 	))
 	if err != nil {
@@ -449,7 +449,7 @@ func TestKnowledgeSave_rootsMount(t *testing.T) {
 func TestRun_workspaceResearchTurn(t *testing.T) {
 	ctx := context.Background()
 	g := brain.NewMemoryGraph()
-	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithGraph(g), brain.WithKinds(
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly(), brain.WithGraph(g), brain.WithKinds(
 		brain.KindSpec{Kind: "Discovery", IsParent: true},
 	))
 	if err != nil {
@@ -610,7 +610,7 @@ func TestPathNativeGraphLinkExpand(t *testing.T) {
 	ms := mustMountTree(t, "path-graph", vfs.At("work", vfs.Local(t.TempDir())))
 	store := brain.NewMemoryStore()
 	g := brain.NewMemoryGraph()
-	eng, err := brain.NewEngine(store, brain.WithGraph(g))
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly(), brain.WithGraph(g))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vfsindex/indexer_test.go
+++ b/vfsindex/indexer_test.go
@@ -33,7 +33,7 @@ func TestMountIndexer_indexSearchAndNotify(t *testing.T) {
 	ms := treeLocal(t, vfs.At("work", builtins.Local(t.TempDir())))
 
 	store := brain.NewMemoryStore()
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +183,7 @@ func TestMountIndexer_markdownBlocksChunks(t *testing.T) {
 	ms := treeLocal(t, vfs.At("work", builtins.Local(t.TempDir())))
 
 	store := brain.NewMemoryStore()
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -300,7 +300,7 @@ func TestMountIndexer_emptyMarkdownLineChunks(t *testing.T) {
 	ms := treeLocal(t, vfs.At("work", builtins.Local(t.TempDir())))
 
 	store := brain.NewMemoryStore()
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -379,7 +379,7 @@ func TestMountIndexer_IndexFileResultAndDefaults(t *testing.T) {
 		vfs.At("off", builtins.Local(t.TempDir())).Indexed("none"),
 	)
 	store := brain.NewMemoryStore()
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -613,7 +613,7 @@ func TestMountIndexer_docsBlockText(t *testing.T) {
 	})
 	ms := treeLocal(t, vfs.At("docs", richFactory{doc: doc}.Open))
 	store := brain.NewMemoryStore()
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vfsindex/policy_test.go
+++ b/vfsindex/policy_test.go
@@ -35,7 +35,7 @@ func TestBridge_policyAndTrack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	eng, err := brain.NewEngine(brain.NewMemoryStore())
+	eng, err := brain.NewEngine(brain.NewMemoryStore(), brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vfsindex/scheduler_test.go
+++ b/vfsindex/scheduler_test.go
@@ -24,7 +24,7 @@ func TestAsyncScheduler_notifyCoalesceAndEventualIndex(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = ms.Close() })
 	store := brain.NewMemoryStore()
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestIndexPathResult_andUnindex(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = ms.Close() })
 	store := brain.NewMemoryStore()
-	eng, err := brain.NewEngine(store)
+	eng, err := brain.NewEngine(store, brain.WithLexicalOnly())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Changelog

- **Store vs graph:** `search` / `find_exact` query parts in the store and promote to the parent. `find_objects` queries parent nodes in the graph. Structured fields are filters, not query text.
- **schema():** every kind lists `title` / `summary` / `content` next to `filterable_fields`. Those names cannot be `FieldSpec` keys.
- **Embeddings:** `NewEngine` requires `WithEmbedder` or `WithLexicalOnly`.
- **SkipIndex / Enum:** a property can stay stored and filterable without going into entity index text. String fields can declare a closed `enum`; `examples` stay documentation.
- **WithIndexText:** hosts rewrite the document that is embedded and written as graph search text without changing the stored object. Engine passes that string into `EnsureObject`.
- **ReplaceParts:** host SDK to replace children under a parent. Engram files stay parent-only; corpus search looks at parts.

Fixes #126
Fixes #127
Fixes #128
Fixes #129
Fixes #130