### PR TITLE
fix: park on expired tool/VFS credentials

### DIFF
--- a/builtins/web.go
+++ b/builtins/web.go
@@ -128,6 +128,9 @@ func mapExaErr(name string, err error) error {
 		if st.QueryFixable() {
 			return tacklr.Correction(err, name+": the search provider rejected that request. Simplify filters (omit category or domain lists) and retry")
 		}
+		if st.Status == 401 {
+			return fmt.Errorf("%s: credentials expired: %w", name, errors.Join(tacklr.ErrAuthExpired, err))
+		}
 		return fmt.Errorf("%s: the search provider failed: %w", name, errors.Join(tacklr.ErrFailed, err))
 	}
 	if errors.Is(err, ErrService) {

--- a/builtins/web_test.go
+++ b/builtins/web_test.go
@@ -280,6 +280,9 @@ func TestMapExaErr_andStatusErrorEdges(t *testing.T) {
 	if err := mapExaErr("web_search", ErrService); err == nil || !errors.Is(err, tacklr.ErrFailed) {
 		t.Fatalf("service: %v", err)
 	}
+	if err := mapExaErr("web_search", &StatusError{Status: 401, Body: "no"}); err == nil || !errors.Is(err, tacklr.ErrAuthExpired) {
+		t.Fatalf("401: %v", err)
+	}
 	if err := mapExaErr("web_search", errors.New("plain")); err == nil || err.Error() != "plain" {
 		t.Fatalf("plain: %v", err)
 	}

--- a/durable/inprocess/runtime_test.go
+++ b/durable/inprocess/runtime_test.go
@@ -328,6 +328,134 @@ func TestAskUserChoiceYieldsThenResumeCompletes(t *testing.T) {
 	}
 }
 
+func TestPrompt_authExpiredYieldsThenResumeCompletes(t *testing.T) {
+	ctx := t.Context()
+	var calls atomic.Int32
+	cloud := tacklr.NewTool(tacklr.ToolConfig{
+		Name: "cloud_read",
+		Handler: func(context.Context) (string, error) {
+			if calls.Add(1) == 1 {
+				return "", fmt.Errorf("gdrive: %w", vfs.ErrAuthExpired)
+			}
+			return "from-cloud", nil
+		},
+	})
+	model := &testkit.ScriptedModel{
+		InvokeFn: func(ctx context.Context, msgs []*tacklr.Message, tools []*tacklr.Tool, ch chan<- tacklr.LLMResponseChunk) {
+			if last := lastMsg(msgs); last != nil && last.Role == tacklr.RoleTool {
+				ch <- tacklr.LLMResponseChunk{Type: tacklr.StreamEventMessage, Content: last.Content, IsComplete: true}
+				return
+			}
+			ch <- tacklr.LLMResponseChunk{
+				Type: tacklr.StreamEventFunctionCall,
+				ToolCalls: []tacklr.ToolCall{{
+					ID: "c1", CallID: "c1", Name: "cloud_read", Arguments: `{}`,
+				}},
+				IsComplete: true,
+			}
+		},
+	}
+	rt := New(Config{Catalog: newCatalog(t, model, durable.AgentSpec{
+		Options: tacklr.AgentOptions{Tools: []*tacklr.Tool{cloud}},
+	}), Snapshots: NewMemorySnapshot(), Projection: vfs.DirectProjection{}})
+	id, err := rt.CreateSession(ctx, durable.CreateSession{AgentID: "default"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Prompt(ctx, id, durable.Prompt{Text: "read cloud"}); err != nil {
+		t.Fatal(err)
+	}
+	sub, err := rt.Subscribe(ctx, id, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sub.Close() })
+	got := waitEvents(t, rt, id, sub, 8*time.Second)
+	var yielded bool
+	for _, ev := range got {
+		if ev.Type == tacklr.StreamEventInterrupt {
+			yielded = true
+		}
+		if ev.Type == tacklr.StreamEventToolResult {
+			t.Fatalf("auth park yielded a tool_result: %+v", summarize(got))
+		}
+	}
+	if !yielded {
+		t.Fatalf("want yield, got %+v", summarize(got))
+	}
+	if err := rt.Resume(ctx, id, durable.Resume{
+		Responses: map[string][]byte{"c1": []byte(`{}`)},
+		Auth: durable.AuthContext{Bindings: []vfs.Binding{{
+			Provider: "gdrive", Auth: vfs.Credential{Token: "tok-2"},
+		}}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got = waitEvents(t, rt, id, sub, 8*time.Second)
+	var saw bool
+	for _, ev := range got {
+		if ev.Type == tacklr.StreamEventMessage && strings.Contains(ev.Content, "from-cloud") {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Fatalf("want retried read, got %+v", summarize(got))
+	}
+}
+
+func TestPrompt_permissionDeniedCorrects(t *testing.T) {
+	ctx := t.Context()
+	denied := tacklr.NewTool(tacklr.ToolConfig{
+		Name: "cloud_read",
+		Handler: func(context.Context) (string, error) {
+			return "", fmt.Errorf("share: %w", vfs.ErrPermission)
+		},
+	})
+	model := &testkit.ScriptedModel{
+		InvokeFn: func(ctx context.Context, msgs []*tacklr.Message, tools []*tacklr.Tool, ch chan<- tacklr.LLMResponseChunk) {
+			if last := lastMsg(msgs); last != nil && last.Role == tacklr.RoleTool {
+				ch <- tacklr.LLMResponseChunk{Type: tacklr.StreamEventMessage, Content: "ok", IsComplete: true}
+				return
+			}
+			ch <- tacklr.LLMResponseChunk{
+				Type: tacklr.StreamEventFunctionCall,
+				ToolCalls: []tacklr.ToolCall{{
+					ID: "c1", CallID: "c1", Name: "cloud_read", Arguments: `{}`,
+				}},
+				IsComplete: true,
+			}
+		},
+	}
+	rt := New(Config{Catalog: newCatalog(t, model, durable.AgentSpec{
+		Options: tacklr.AgentOptions{Tools: []*tacklr.Tool{denied}},
+	}), Snapshots: NewMemorySnapshot(), Projection: vfs.DirectProjection{}})
+	id, err := rt.CreateSession(ctx, durable.CreateSession{AgentID: "default"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.Prompt(ctx, id, durable.Prompt{Text: "read"}); err != nil {
+		t.Fatal(err)
+	}
+	sub, err := rt.Subscribe(ctx, id, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = sub.Close() })
+	got := waitEvents(t, rt, id, sub, 8*time.Second)
+	var sawCorrection bool
+	for _, ev := range got {
+		if ev.Type == tacklr.StreamEventInterrupt {
+			t.Fatalf("permission parked: %+v", summarize(got))
+		}
+		if ev.Type == tacklr.StreamEventToolResult && strings.Contains(ev.Content, "permission denied") {
+			sawCorrection = true
+		}
+	}
+	if !sawCorrection {
+		t.Fatalf("want permission correction, got %+v", summarize(got))
+	}
+}
+
 // TestPrompt_parallelBatchHitlRunsRemainder: durable driver used to abort the
 // rest of a model tool batch when one call parked. Next inference then sent a
 // function_call without function_call_output (Azure 400). Resume must still

--- a/durable/temporal/workflow_test.go
+++ b/durable/temporal/workflow_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -213,6 +214,76 @@ func TestSessionWorkflow_activityRetryThenCompletes(t *testing.T) {
 	}
 	if st := querySession(t, env); st.State != durable.SessionComplete {
 		t.Fatalf("Status after retry: %+v", st)
+	}
+}
+
+func TestSessionWorkflow_authExpiredYieldThenResume(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	env.SetWorkerOptions(worker.Options{EnableSessionWorker: true})
+	var calls atomic.Int32
+	cloud := tacklr.NewTool(tacklr.ToolConfig{
+		Name: "cloud_read",
+		Handler: func(context.Context) (string, error) {
+			if calls.Add(1) == 1 {
+				return "", fmt.Errorf("gdrive: %w", vfs.ErrAuthExpired)
+			}
+			return "from-cloud", nil
+		},
+	})
+	cat := durable.NewCatalog("default")
+	model := &testkit.ScriptedModel{
+		InvokeFn: func(ctx context.Context, msgs []*tacklr.Message, tools []*tacklr.Tool, ch chan<- tacklr.LLMResponseChunk) {
+			if last := lastMsg(msgs); last != nil && last.Role == tacklr.RoleTool {
+				ch <- tacklr.LLMResponseChunk{Type: tacklr.StreamEventMessage, Content: last.Content, IsComplete: true}
+				return
+			}
+			ch <- tacklr.LLMResponseChunk{
+				Type: tacklr.StreamEventFunctionCall,
+				ToolCalls: []tacklr.ToolCall{{
+					ID: "c1", CallID: "c1", Name: "cloud_read", Arguments: `{}`,
+				}},
+				IsComplete: true,
+			}
+		},
+	}
+	cat.Register("default", durable.AgentSpec{
+		Options: tacklr.AgentOptions{Model: model, Config: tacklr.Config{MaxWindowSize: 8192}, Tools: []*tacklr.Tool{cloud}},
+	})
+	fallback := inprocess.NewMemoryEventLog()
+	env.RegisterWorkflow(SessionWorkflow)
+	env.RegisterActivity(newActs(cat, fallback, true))
+
+	id := durable.SessionID("sess-auth")
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(signalPrompt, promptSignal{Text: "read"})
+	}, time.Millisecond)
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(signalResume, resumeSignal{Responses: map[string][]byte{"c1": []byte(`{}`)}})
+	}, 20*time.Millisecond)
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(signalClose, nil)
+	}, 80*time.Millisecond)
+
+	env.ExecuteWorkflow(SessionWorkflow, workflowInput{SessionID: id, AgentID: "default"})
+	if err := env.GetWorkflowError(); err != nil {
+		t.Fatal(err)
+	}
+	got := drainLog(t, fallback, id)
+	var yielded, saw bool
+	for _, ev := range got {
+		if ev.Type == tacklr.StreamEventInterrupt {
+			yielded = true
+		}
+		if ev.Type == tacklr.StreamEventMessage && strings.Contains(ev.Content, "from-cloud") {
+			saw = true
+		}
+	}
+	if !yielded || !saw {
+		t.Fatalf("want yield + retried read, got %+v", got)
+	}
+	if st := querySession(t, env); st.State != durable.SessionComplete {
+		t.Fatalf("Status after auth resume: %+v", st)
 	}
 }
 

--- a/durable_steps.go
+++ b/durable_steps.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ryanaldo34/tacklr/interrupt"
 	"github.com/ryanaldo34/tacklr/telemetry"
+	"github.com/ryanaldo34/tacklr/vfs"
 )
 
 func (a *TurnManager) absorbUser(ctx context.Context, user *Message, out chan StreamEvent) error {
@@ -168,6 +169,9 @@ func (a *TurnManager) runToolCall(ctx context.Context, tc ToolCall, out chan Str
 		Runtime:  runtimeCopy,
 	})
 	var parked interrupt.Interrupt
+	if err != nil && !errors.As(err, &parked) && (errors.Is(err, ErrAuthExpired) || errors.Is(err, vfs.ErrAuthExpired)) {
+		err = a.session.Park(tcKey, &interrupt.AuthExpired{Tool: tc.Name})
+	}
 	if errors.As(err, &parked) {
 		serialized, _ := parked.Serialize()
 		data, _ := json.Marshal(map[string]any{

--- a/interrupt/interrupt.go
+++ b/interrupt/interrupt.go
@@ -122,6 +122,33 @@ func (p *ChildWaiting) Error() string {
 	return "child session awaiting input"
 }
 
+// TypeAuthExpired parks a tool call until the host rebinds credentials on Resume.Auth.
+const TypeAuthExpired = "auth_expired"
+
+// AuthExpired is raised when a tool or VFS mount unwraps to expired credentials.
+// Return is a no-op; tokens travel on Resume.Auth, not the interrupt payload.
+type AuthExpired struct {
+	Tool     string `json:"tool,omitempty"`
+	Provider string `json:"provider,omitempty"`
+}
+
+func (p *AuthExpired) TypeName() string { return TypeAuthExpired }
+
+func (p *AuthExpired) Serialize() ([]byte, error) {
+	return json.Marshal(p)
+}
+
+func (p *AuthExpired) ValidatePayload([]byte) error { return nil }
+
+func (p *AuthExpired) Return([]byte) error { return nil }
+
+func (p *AuthExpired) Error() string {
+	if p != nil && p.Tool != "" {
+		return p.Tool + ": credentials expired"
+	}
+	return "credentials expired"
+}
+
 // ACP PermissionOptionKind values.
 const (
 	PermissionAllowOnce    = "allow_once"
@@ -267,6 +294,7 @@ func RegisterDefaults() {
 		Register(func() Interrupt { return &UserSelectionInterrupt{} })
 		Register(func() Interrupt { return &ToolPermissionInterrupt{} })
 		Register(func() Interrupt { return &ChildWaiting{Kind: TypeChildWaiting} })
+		Register(func() Interrupt { return &AuthExpired{} })
 	})
 }
 

--- a/interrupt/interrupt_test.go
+++ b/interrupt/interrupt_test.go
@@ -271,6 +271,30 @@ func TestChildWaiting_typeNameAndError(t *testing.T) {
 	}
 }
 
+func TestAuthExpired_typeNameAndResume(t *testing.T) {
+	empty := &interrupt.AuthExpired{}
+	if empty.TypeName() != interrupt.TypeAuthExpired {
+		t.Fatalf("type: %s", empty.TypeName())
+	}
+	if empty.Error() != "credentials expired" {
+		t.Fatalf("error: %s", empty.Error())
+	}
+	if err := empty.Return([]byte(`{}`)); err != nil {
+		t.Fatal(err)
+	}
+	named := &interrupt.AuthExpired{Tool: "read"}
+	if named.Error() != "read: credentials expired" {
+		t.Fatalf("named: %s", named.Error())
+	}
+	got, ok := interrupt.New(interrupt.TypeAuthExpired)
+	if !ok {
+		t.Fatal("auth_expired not registered")
+	}
+	if got.TypeName() != interrupt.TypeAuthExpired {
+		t.Fatalf("new: %s", got.TypeName())
+	}
+}
+
 // TestInterrupt_asError confirms errors.As works for tool return paths.
 func TestInterrupt_asError(t *testing.T) {
 	var err error = &interrupt.UserSelectionInterrupt{Options: []interrupt.UserChoice{{Title: "A"}}}

--- a/server/acp_protocol.go
+++ b/server/acp_protocol.go
@@ -410,6 +410,8 @@ func resolveInterruptViaACP(ctx context.Context, env ProtocolEnv, threadID strin
 			return nil, nil
 		}
 		return resolveSelectionViaElicitation(ctx, env, threadID, ev)
+	case tacklr.TypeAuthExpired:
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("unsupported interrupt type %q", kind)
 	}

--- a/server/permission_resolve_test.go
+++ b/server/permission_resolve_test.go
@@ -24,6 +24,16 @@ func TestResolveInterruptViaACP_dispatchOutcomes(t *testing.T) {
 		t.Fatalf("unsupported: %v", err)
 	}
 
+	authData, _ := json.Marshal(map[string]any{
+		"interruptId": "i-auth",
+		"type":        tacklr.TypeAuthExpired,
+		"data":        map[string]any{"tool": "read"},
+	})
+	park, parkErr := resolveInterruptViaACP(context.Background(), ProtocolEnv{Conn: &Conn{RPC: NewClientBridge(&recordingWriter{})}}, "s", &tacklr.StreamEvent{Data: authData})
+	if parkErr != nil || park != nil {
+		t.Fatalf("auth_expired park: ch=%v err=%v", park, parkErr)
+	}
+
 	// Bad envelope.
 	_, err = resolveInterruptViaACP(context.Background(), ProtocolEnv{Conn: &Conn{RPC: NewClientBridge(&recordingWriter{})}}, "s", &tacklr.StreamEvent{Data: []byte(`{`)})
 	if err == nil {

--- a/tools_error.go
+++ b/tools_error.go
@@ -53,16 +53,7 @@ func Correctionf(cause error, format string, args ...any) error {
 // already Correction, ErrFailed (service), else Correction(err, err.Error()).
 func presentToolError(name string, err error) error {
 	var intr interrupt.Interrupt
-	if errors.As(err, &intr) {
-		return err
-	}
-	if errors.Is(err, context.Canceled) {
-		return err
-	}
-	if errors.Is(err, ErrCorrection) {
-		return err
-	}
-	if errors.Is(err, ErrFailed) {
+	if errors.As(err, &intr) || errors.Is(err, context.Canceled) || errors.Is(err, ErrCorrection) || errors.Is(err, ErrFailed) {
 		return err
 	}
 	msg := strings.TrimPrefix(err.Error(), "vfs: ")

--- a/tools_vfs.go
+++ b/tools_vfs.go
@@ -495,7 +495,7 @@ func vfsToolErr(name, path string, err error) error {
 	case errors.Is(err, vfs.ErrNotDir):
 		return Correctionf(vfs.ErrNotDir, "%s: that path is a file, not a directory", name)
 	case errors.Is(err, vfs.ErrAuthExpired):
-		return fmt.Errorf("%s: cloud credentials expired: %w", name, errors.Join(ErrFailed, err))
+		return fmt.Errorf("%s: cloud credentials expired: %w", name, err)
 	case errors.Is(err, vfs.ErrPermission):
 		return Correctionf(vfs.ErrPermission, "%s: permission denied on that path. Use a path the session is allowed to access", name)
 	case errors.Is(err, vfs.ErrReadOnly):

--- a/types.go
+++ b/types.go
@@ -19,10 +19,11 @@ import (
 // should follow. Construct with Correction(cause, msg). Distinct from ErrFailed
 // (harness/runtime). errors.Is matches both ErrCorrection and cause.
 var (
-	ErrNotFound   = errors.New("not found")
-	ErrInvalid    = errors.New("invalid")
-	ErrFailed     = errors.New("failed")
-	ErrCorrection = errors.New("correction")
+	ErrNotFound    = errors.New("not found")
+	ErrInvalid     = errors.New("invalid")
+	ErrFailed      = errors.New("failed")
+	ErrCorrection  = errors.New("correction")
+	ErrAuthExpired = errors.New("auth expired")
 )
 
 var (
@@ -140,6 +141,7 @@ type (
 	UserSelectionInterrupt  = interrupt.UserSelectionInterrupt
 	ToolPermissionInterrupt = interrupt.ToolPermissionInterrupt
 	PermissionOption        = interrupt.PermissionOption
+	AuthExpired             = interrupt.AuthExpired
 )
 
 var (
@@ -153,6 +155,7 @@ const (
 	PermissionAllowAlways  = interrupt.PermissionAllowAlways
 	PermissionRejectOnce   = interrupt.PermissionRejectOnce
 	PermissionRejectAlways = interrupt.PermissionRejectAlways
+	TypeAuthExpired        = interrupt.TypeAuthExpired
 )
 
 // RegisterInterrupt registers a custom interrupt factory for session rehydrate.


### PR DESCRIPTION
## Changelog

Expired cloud credentials used to come back as a failed tool result and the turn kept going. They now park, same as other HITL.

`runToolCall` unwraps `vfs.ErrAuthExpired` / `tacklr.ErrAuthExpired` and yields `auth_expired`. Resume with that call id plus `Resume.Auth` retries the tool on the new tokens. Permission denied is still a correction. ACP does not try to finish OAuth inside the prompt.

Fixes #136