### PR TITLE
fix: jail Linux run_command to the session mount

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,15 @@ jobs:
       - name: Build
         run: go build ./...
 
+      # Ubuntu 24.04 AppArmor lets unprivileged CLONE_NEWUSER succeed but
+      # blocks bind-mounts inside the namespace. The session jail needs both.
+      - name: Allow unprivileged user namespaces
+        run: |
+          sudo sysctl -w kernel.unprivileged_userns_clone=1 || true
+          if sudo sysctl -a 2>/dev/null | grep -q '^kernel.apparmor_restrict_unprivileged_userns'; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+
       # Integration tests use Testcontainers (no mocks for graph/DB):
       #   - Postgres (pgvector + pg_textsearch BM25)
       #   - Helix enterprise-dev (in-memory graph, dynamic /v1/query)

--- a/docs/fuse-vfs-run-command.md
+++ b/docs/fuse-vfs-run-command.md
@@ -195,8 +195,8 @@ Update `docs/vfs.md`, `docs/knowledge.md`, `README.md`, `vfs/doc.go` so they mat
 ## Decisions that still hold
 
 1. FUSE root is virtual `/`. Single-segment points only.
-2. Harness tools, `MountInfo`, `Specs`, and checkpoints never print `HostDir`. The child may `pwd` it.
-3. `run_command` is cwd-only `/bin/sh -c`. No chroot in this train. Residual escape risk is documented, not tested as a negative.
+2. Harness tools, `MountInfo`, `Specs`, and checkpoints never print `HostDir`. Linux child `pwd` is `/session`; macOS/Windows child `pwd` is HostDir.
+3. `run_command` is `/bin/sh -c` with cwd at the FUSE root. On Linux the child is jailed there (user+mount+pid namespace + chroot). Missing user namespaces panic when `run_command` is registered, not when the model first calls it. macOS/Windows stay cwd-only.
 4. Registry `run_command` is `PermissionRequired: true` by default.
 5. `list` / `stat` stay whenever a `MountSession` exists. Do not gate them on `FuseAvailable()`.
 6. `write` modes are counted by field presence. IR body field is `ir_text`.
@@ -209,10 +209,10 @@ Update `docs/vfs.md`, `docs/knowledge.md`, `README.md`, `vfs/doc.go` so they mat
 
 | Risk | Notes |
 |------|--------|
-| `run_command` is a full host shell as the process user | Permission gate is not a jail |
-| `ls /` and `echo x > /tmp/pwn` leave the tree | cwd-only; writable FUSE does not fix this |
-| Child `pwd` shows `HostDir` | Do not redact stdout |
-| Read-only FUSE does not stop writes **outside** the mount | Next jail plan |
+| `run_command` is a full host shell as the process user | Linux: jailed to this session’s HostDir. macOS/Windows: cwd-only |
+| Child `pwd` on Linux is `/session`, not HostDir | Do not redact stdout |
+| macOS/Windows `ls ..` can leave the tree | No user namespaces |
+| Linux without user namespaces panics on `run_command` | Fail closed. Ubuntu 24.04 AppArmor may block unprivileged user ns. |
 | Production without `/dev/fuse` has no VFS tools | Use `DirectProjection` in tests; embedders pass a session |
 
 ---

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -7,23 +7,27 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"sync"
 	"syscall"
 )
 
-const outputCap = 1 << 20
+const (
+	outputCap      = 1 << 20
+	jailSetupExit  = 125
+	jailFailMarker = "tacklr-jail-setup-failed"
+)
 
 // Run executes command in the projected VFS directory and returns a bounded,
 // structured stdout/stderr result. Non-zero process exits are successful
 // outcomes; startup and context failures are errors.
+//
+// On Linux the shell is jailed to dir with a user+mount+pid namespace so it
+// cannot see sibling session mounts.
 func Run(ctx context.Context, dir, command string) (string, error) {
-	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", `cd "$1" && eval "$2"`, "run_command", dir, command)
-	cmd.Dir = os.TempDir()
+	cmd := jailCommand(ctx, dir, command)
 	cmd.Stdin = bytes.NewReader(nil)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {
 			return nil
@@ -45,8 +49,14 @@ func Run(ctx context.Context, dir, command string) (string, error) {
 	if err != nil {
 		var exitError *exec.ExitError
 		if errors.As(err, &exitError) {
+			if exitError.ExitCode() == jailSetupExit && strings.Contains(stderr.buf.String(), jailFailMarker) {
+				panic("run_command: session jail requires Linux user namespaces")
+			}
 			exit = exitError.ExitCode()
 		} else {
+			if jailRequired {
+				panic("run_command: session jail requires Linux user namespaces: " + err.Error())
+			}
 			return "", fmt.Errorf("run_command: %w", err)
 		}
 	}

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -41,7 +41,10 @@ func Run(ctx context.Context, dir, command string) (string, error) {
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 
-	err := cmd.Run()
+	err := startCmd(cmd)
+	if err == nil {
+		err = cmd.Wait()
+	}
 	if ctx.Err() != nil {
 		return "", ctx.Err()
 	}
@@ -50,7 +53,7 @@ func Run(ctx context.Context, dir, command string) (string, error) {
 		var exitError *exec.ExitError
 		if errors.As(err, &exitError) {
 			if exitError.ExitCode() == jailSetupExit && strings.Contains(stderr.buf.String(), jailFailMarker) {
-				panic("run_command: session jail requires Linux user namespaces")
+				panic("run_command: session jail requires Linux user namespaces: " + strings.TrimSpace(stderr.buf.String()))
 			}
 			exit = exitError.ExitCode()
 		} else {

--- a/internal/command/run.go
+++ b/internal/command/run.go
@@ -41,10 +41,7 @@ func Run(ctx context.Context, dir, command string) (string, error) {
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 
-	err := startCmd(cmd)
-	if err == nil {
-		err = cmd.Wait()
-	}
+	err := cmd.Run()
 	if ctx.Err() != nil {
 		return "", ctx.Err()
 	}

--- a/internal/command/run_linux.go
+++ b/internal/command/run_linux.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"runtime"
 	"sync"
 	"syscall"
 )
@@ -39,7 +40,12 @@ const jailRequired = true
 var jailOnce sync.Once
 
 func userNSAvailable() bool {
-	cmd := exec.Command("/bin/true")
+	dir, err := os.MkdirTemp("", "tacklr-jail-probe-")
+	if err != nil {
+		return false
+	}
+	defer os.RemoveAll(dir)
+	cmd := exec.Command("/bin/sh", "-c", `mount --make-rprivate / && mount --bind "$1" "$1"`, "probe", dir)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Cloneflags:                 syscall.CLONE_NEWUSER | syscall.CLONE_NEWNS | syscall.CLONE_NEWPID,
 		GidMappingsEnableSetgroups: false,
@@ -57,11 +63,18 @@ func RequireJail() {
 	})
 }
 
+func startCmd(cmd *exec.Cmd) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	return cmd.Start()
+}
+
 func jailCommand(ctx context.Context, dir, command string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", jailScript, "run_command", dir, command)
 	cmd.Dir = os.TempDir()
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid:                    true,
+		Pdeathsig:                  syscall.SIGKILL,
 		Cloneflags:                 syscall.CLONE_NEWUSER | syscall.CLONE_NEWNS | syscall.CLONE_NEWPID,
 		GidMappingsEnableSetgroups: false,
 		UidMappings: []syscall.SysProcIDMap{{

--- a/internal/command/run_linux.go
+++ b/internal/command/run_linux.go
@@ -1,0 +1,79 @@
+//go:build linux
+
+package command
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+)
+
+// Bootstrap runs in a fresh user+mount+pid namespace (SysProcAttr). Bind
+// HostDir at /session and host /bin /lib /usr /dev so /bin/sh still runs, then
+// exec chroot so pid 1 is inside the jail. Exit 125 with jailFailMarker if the
+// jail cannot be built. The agent command's exit status is preserved.
+const jailScript = `
+set -e
+die() { echo ` + jailFailMarker + ` >&2; exit 125; }
+host=$1
+cmd=$2
+mount --make-rprivate / || die
+jail=$(mktemp -d /tmp/tacklr-jail-XXXXXX) || die
+mkdir -p "$jail/session" "$jail/bin" "$jail/lib" "$jail/usr" "$jail/dev" "$jail/tmp" "$jail/etc" || die
+mount --bind "$host" "$jail/session" || die
+mount --bind /bin "$jail/bin" || die
+if [ -d /lib ]; then mount --bind /lib "$jail/lib" || die; fi
+if [ -d /lib64 ]; then mkdir -p "$jail/lib64" && mount --bind /lib64 "$jail/lib64" || die; fi
+if [ -d /usr ]; then mount --bind /usr "$jail/usr" || die; fi
+if [ -d /dev ]; then mount --rbind /dev "$jail/dev" || die; fi
+PATH=/bin:/usr/bin:/sbin:/usr/sbin
+chroot_bin=$(command -v chroot) || die
+export PATH=/bin:/usr/bin
+exec "$chroot_bin" "$jail" /bin/sh -c 'cd /session && eval "$1"' run_command "$cmd" || die
+`
+
+const jailRequired = true
+
+var jailOnce sync.Once
+
+func userNSAvailable() bool {
+	cmd := exec.Command("/bin/true")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Cloneflags:                 syscall.CLONE_NEWUSER | syscall.CLONE_NEWNS | syscall.CLONE_NEWPID,
+		GidMappingsEnableSetgroups: false,
+		UidMappings:                []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Getuid(), Size: 1}},
+		GidMappings:                []syscall.SysProcIDMap{{ContainerID: 0, HostID: os.Getgid(), Size: 1}},
+	}
+	return cmd.Run() == nil
+}
+
+func RequireJail() {
+	jailOnce.Do(func() {
+		if !userNSAvailable() {
+			panic("run_command: session jail requires Linux user namespaces")
+		}
+	})
+}
+
+func jailCommand(ctx context.Context, dir, command string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", jailScript, "run_command", dir, command)
+	cmd.Dir = os.TempDir()
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid:                    true,
+		Cloneflags:                 syscall.CLONE_NEWUSER | syscall.CLONE_NEWNS | syscall.CLONE_NEWPID,
+		GidMappingsEnableSetgroups: false,
+		UidMappings: []syscall.SysProcIDMap{{
+			ContainerID: 0,
+			HostID:      os.Getuid(),
+			Size:        1,
+		}},
+		GidMappings: []syscall.SysProcIDMap{{
+			ContainerID: 0,
+			HostID:      os.Getgid(),
+			Size:        1,
+		}},
+	}
+	return cmd
+}

--- a/internal/command/run_linux.go
+++ b/internal/command/run_linux.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"os"
 	"os/exec"
-	"runtime"
 	"sync"
 	"syscall"
 )
@@ -61,12 +60,6 @@ func RequireJail() {
 			panic("run_command: session jail requires Linux user namespaces")
 		}
 	})
-}
-
-func startCmd(cmd *exec.Cmd) error {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-	return cmd.Start()
 }
 
 func jailCommand(ctx context.Context, dir, command string) *exec.Cmd {

--- a/internal/command/run_linux_test.go
+++ b/internal/command/run_linux_test.go
@@ -1,0 +1,57 @@
+//go:build linux
+
+package command
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func skipWithoutJail(t *testing.T) {
+	if !userNSAvailable() {
+		t.Skip("user namespaces not available")
+	}
+}
+
+func TestRun_sessionJailHidesSiblingDir(t *testing.T) {
+	skipWithoutJail(t)
+	a := t.TempDir()
+	b := t.TempDir()
+	if err := os.WriteFile(filepath.Join(a, "secret-a.txt"), []byte("alpha"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(b, "secret-b.txt"), []byte("beta"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := Run(context.Background(), a, "cat secret-a.txt && ls /")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "alpha") {
+		t.Fatalf("want session file, got %q", out)
+	}
+	if !strings.Contains(out, "session") {
+		t.Fatalf("want jail root, got %q", out)
+	}
+	out, err = Run(context.Background(), a, "cat "+filepath.Join(b, "secret-b.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "No such file") {
+		t.Fatalf("want sibling path missing in jail, got %q", out)
+	}
+}
+
+func TestRun_agentExit125IsCommandResult(t *testing.T) {
+	skipWithoutJail(t)
+	out, err := Run(context.Background(), t.TempDir(), "exit 125")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "exit=125") {
+		t.Fatalf("want command exit 125, got %q", out)
+	}
+}

--- a/internal/command/run_other.go
+++ b/internal/command/run_other.go
@@ -1,0 +1,21 @@
+//go:build !linux
+
+package command
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+const jailRequired = false
+
+func RequireJail() {}
+
+func jailCommand(ctx context.Context, dir, command string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", `cd "$1" && eval "$2"`, "run_command", dir, command)
+	cmd.Dir = os.TempDir()
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	return cmd
+}

--- a/internal/command/run_other.go
+++ b/internal/command/run_other.go
@@ -13,6 +13,10 @@ const jailRequired = false
 
 func RequireJail() {}
 
+func startCmd(cmd *exec.Cmd) error {
+	return cmd.Start()
+}
+
 func jailCommand(ctx context.Context, dir, command string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", `cd "$1" && eval "$2"`, "run_command", dir, command)
 	cmd.Dir = os.TempDir()

--- a/internal/command/run_other.go
+++ b/internal/command/run_other.go
@@ -13,10 +13,6 @@ const jailRequired = false
 
 func RequireJail() {}
 
-func startCmd(cmd *exec.Cmd) error {
-	return cmd.Start()
-}
-
 func jailCommand(ctx context.Context, dir, command string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", `cd "$1" && eval "$2"`, "run_command", dir, command)
 	cmd.Dir = os.TempDir()

--- a/internal/command/run_other_test.go
+++ b/internal/command/run_other_test.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package command
+
+import "testing"
+
+func skipWithoutJail(*testing.T) {}

--- a/internal/command/run_test.go
+++ b/internal/command/run_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestRun_truncatesOversizedOutput(t *testing.T) {
+	skipWithoutJail(t)
 	dir := t.TempDir()
 	big := bytes.Repeat([]byte("a"), outputCap+64)
 	if err := os.WriteFile(filepath.Join(dir, "big.txt"), big, 0o644); err != nil {

--- a/tools_command_test.go
+++ b/tools_command_test.go
@@ -39,12 +39,12 @@ func TestRunCommand_catDirtyAndFalseExit(t *testing.T) {
 	t.Cleanup(func() { _ = ms.Close() })
 
 	tool := newRunCommand(ms, false)
-	res, err := tool.invoke(ctx, `{"command":"pwd"}`, rt)
+	res, err := tool.invoke(ctx, `{"command":"ls"}`, rt)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(res.output, ms.HostDir()) {
-		t.Fatalf("pwd cwd: %s want %s", res.output, ms.HostDir())
+	if !strings.Contains(res.output, "workspace") {
+		t.Fatalf("ls cwd: %s", res.output)
 	}
 
 	res, err = tool.invoke(ctx, `{"command":"cat workspace/work/note.md"}`, rt)

--- a/tools_vfs.go
+++ b/tools_vfs.go
@@ -572,14 +572,15 @@ func growLineWindow(b *strings.Builder, extra int, lines []string) {
 const runCommandTimeout = 60 * time.Second
 
 type runCommandArgs struct {
-	Command string `json:"command" desc:"Host shell command. Runs as /bin/sh -c. cwd is the VFS root. Use relative paths (work/foo). Absolute /work is the host /work until a later jail."`
+	Command string `json:"command" desc:"Host shell command. Runs as /bin/sh -c. cwd is the VFS root. Use relative paths (workspace/work/foo). On Linux the shell is jailed to this mount."`
 }
 
 func newRunCommand(ms *vfs.MountSession, permissionRequired bool) *Tool {
+	command.RequireJail()
 	cfg := ToolConfig{
 		Name:        "run_command",
 		DisplayName: "Run {command}",
-		Description: `Run a host shell command as /bin/sh -c. cwd is the VFS root (FUSE mount). Use relative paths (work/foo, ./work/foo). Absolute /work is the host /work until a later jail. Non-zero exit is a successful tool result (exit=N).`,
+		Description: `Run a host shell command as /bin/sh -c. cwd is the VFS root (FUSE mount). Use relative paths (workspace/work/foo). On Linux the shell cannot see other session mounts. Non-zero exit is a successful tool result (exit=N).`,
 		Category:    ToolCategoryExecute,
 		Access:      ToolExecuteAccess,
 		Timeout:     runCommandTimeout,


### PR DESCRIPTION
## Changelog

`run_command` on a host with several sessions used to be a same-uid shell whose cwd was the FUSE root. `ls ..` could list sibling mounts.

On Linux the child now starts in a user+mount+pid namespace, bind-mounts this session at `/session`, and chroots there. Sibling HostDirs are not in that tree. If user namespaces are missing, Tacklr panics when `run_command` is registered, not mid-tool. macOS and Windows stay cwd-only.

No public API change.

Fixes #138